### PR TITLE
VID-87: Add createCashFlowWithHistory command

### DIFF
--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
@@ -20,6 +20,23 @@ public final class CashFlowDto {
         private BankAccount bankAccount;
     }
 
+    /**
+     * DTO for creating a CashFlow with historical data support.
+     * Creates a CashFlow in SETUP mode for historical data import.
+     */
+    @Data
+    @Builder
+    public static class CreateCashFlowWithHistoryJson {
+        private String userId;
+        private String name;
+        private String description;
+        private BankAccount bankAccount;
+        /** The first historical month (e.g., "2024-01" for importing from January 2024) */
+        private String startPeriod;
+        /** The balance at the start of startPeriod (opening balance) */
+        private Money initialBalance;
+    }
+
     @Data
     @Builder
     public static class AppendExpectedCashChangeJson {

--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
@@ -8,6 +8,7 @@ import com.multi.vidulum.cashflow.app.commands.budgeting.update.UpdateBudgetingC
 import com.multi.vidulum.cashflow.app.commands.comment.create.CreateCategoryCommand;
 import com.multi.vidulum.cashflow.app.commands.confirm.ConfirmCashChangeCommand;
 import com.multi.vidulum.cashflow.app.commands.create.CreateCashFlowCommand;
+import com.multi.vidulum.cashflow.app.commands.create.CreateCashFlowWithHistoryCommand;
 import com.multi.vidulum.cashflow.app.commands.edit.EditCashChangeCommand;
 import com.multi.vidulum.cashflow.app.commands.reject.RejectCashChangeCommand;
 import com.multi.vidulum.cashflow.app.queries.GetCashFlowQuery;
@@ -22,6 +23,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Clock;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -45,6 +47,26 @@ public class CashFlowRestController {
                         new Name(request.getName()),
                         new Description(request.getDescription()),
                         request.getBankAccount()
+                )
+        );
+
+        return snapshot.cashFlowId().id();
+    }
+
+    /**
+     * Create a CashFlow with historical data support.
+     * The CashFlow will be created in SETUP mode, allowing import of historical transactions.
+     */
+    @PostMapping("/with-history")
+    public String createCashFlowWithHistory(@RequestBody CashFlowDto.CreateCashFlowWithHistoryJson request) {
+        CashFlowSnapshot snapshot = commandGateway.send(
+                new CreateCashFlowWithHistoryCommand(
+                        new UserId(request.getUserId()),
+                        new Name(request.getName()),
+                        new Description(request.getDescription()),
+                        request.getBankAccount(),
+                        YearMonth.parse(request.getStartPeriod()),
+                        request.getInitialBalance()
                 )
         );
 

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowWithHistoryCommand.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowWithHistoryCommand.java
@@ -1,0 +1,31 @@
+package com.multi.vidulum.cashflow.app.commands.create;
+
+import com.multi.vidulum.cashflow.domain.BankAccount;
+import com.multi.vidulum.cashflow.domain.Description;
+import com.multi.vidulum.cashflow.domain.Name;
+import com.multi.vidulum.common.Money;
+import com.multi.vidulum.common.UserId;
+import com.multi.vidulum.shared.cqrs.commands.Command;
+
+import java.time.YearMonth;
+
+/**
+ * Command to create a CashFlow with historical data support.
+ * This creates a CashFlow in SETUP mode, allowing import of historical transactions.
+ *
+ * @param userId       the user who owns this cash flow
+ * @param name         name of the cash flow
+ * @param description  description of the cash flow
+ * @param bankAccount  bank account details with current balance
+ * @param startPeriod  the first historical month (e.g., 2024-01 for importing from January 2024)
+ * @param initialBalance the balance at the start of startPeriod (opening balance)
+ */
+public record CreateCashFlowWithHistoryCommand(
+        UserId userId,
+        Name name,
+        Description description,
+        BankAccount bankAccount,
+        YearMonth startPeriod,
+        Money initialBalance
+) implements Command {
+}

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowWithHistoryCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowWithHistoryCommandHandler.java
@@ -1,0 +1,62 @@
+package com.multi.vidulum.cashflow.app.commands.create;
+
+import com.multi.vidulum.cashflow.domain.*;
+import com.multi.vidulum.cashflow.domain.snapshots.CashFlowSnapshot;
+import com.multi.vidulum.common.JsonContent;
+import com.multi.vidulum.common.events.CashFlowUnifiedEvent;
+import com.multi.vidulum.shared.cqrs.commands.CommandHandler;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class CreateCashFlowWithHistoryCommandHandler implements CommandHandler<CreateCashFlowWithHistoryCommand, CashFlowSnapshot> {
+
+    private final DomainCashFlowRepository domainCashFlowRepository;
+    private final CashFlowEventEmitter cashFlowEventEmitter;
+    private final Clock clock;
+
+    @Override
+    public CashFlowSnapshot handle(CreateCashFlowWithHistoryCommand command) {
+        ZonedDateTime now = ZonedDateTime.now(clock);
+        YearMonth activePeriod = YearMonth.from(now);
+
+        // Validate: startPeriod must be before or equal to activePeriod
+        if (command.startPeriod().isAfter(activePeriod)) {
+            throw new StartPeriodInFutureException(command.startPeriod(), activePeriod);
+        }
+
+        CashFlow cashFlow = new CashFlow();
+        CashFlowEvent.CashFlowWithHistoryCreatedEvent event = new CashFlowEvent.CashFlowWithHistoryCreatedEvent(
+                CashFlowId.generate(),
+                command.userId(),
+                command.name(),
+                command.description(),
+                command.bankAccount(),
+                command.startPeriod(),
+                activePeriod,
+                command.initialBalance(),
+                now
+        );
+        cashFlow.apply(event);
+
+        CashFlow savedCashFlow = domainCashFlowRepository.save(cashFlow);
+        log.info("Cash flow with history [{}] has been created in SETUP mode!", savedCashFlow.getSnapshot());
+
+        cashFlowEventEmitter.emit(
+                CashFlowUnifiedEvent.builder()
+                        .metadata(Map.of("event", CashFlowEvent.CashFlowWithHistoryCreatedEvent.class.getSimpleName()))
+                        .content(JsonContent.asPrettyJson(event))
+                        .build()
+        );
+
+        return savedCashFlow.getSnapshot();
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlow.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlow.java
@@ -147,6 +147,42 @@ public class CashFlow implements Aggregate<CashFlowId, CashFlowSnapshot> {
         this.uncommittedEvents.add(event);
     }
 
+    /**
+     * Creates a CashFlow in SETUP mode for historical data import.
+     * The CashFlow will have status SETUP until activated.
+     */
+    public void apply(CashFlowEvent.CashFlowWithHistoryCreatedEvent event) {
+        LinkedList<Category> inflowCategories = new LinkedList<>();
+        inflowCategories.add(new Category(
+                new CategoryName("Uncategorized"),
+                null,
+                new LinkedList<>(),
+                false
+        ));
+        LinkedList<Category> outflowCategories = new LinkedList<>();
+        outflowCategories.add(new Category(
+                new CategoryName("Uncategorized"),
+                null,
+                new LinkedList<>(),
+                false
+        ));
+        this.cashFlowId = event.cashFlowId();
+        this.userId = event.userId();
+        this.name = event.name();
+        this.description = event.description();
+        this.bankAccount = event.bankAccount();
+        this.status = CashFlowStatus.SETUP;  // SETUP mode for historical import
+        this.cashChanges = new HashMap<>();
+        this.activePeriod = event.activePeriod();
+        this.created = event.created();
+        this.inflowCategories = inflowCategories;
+        this.outflowCategories = outflowCategories;
+        this.lastModification = null;
+        this.lastMessageChecksum = calculateChecksum(event);
+        this.uncommittedEvents = new LinkedList<>();
+        this.uncommittedEvents.add(event);
+    }
+
     public void apply(CashFlowEvent.ExpectedCashChangeAppendedEvent event) {
         CashChange cashChange = new CashChange(
                 event.cashChangeId(),

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateProjector.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateProjector.java
@@ -12,6 +12,7 @@ public class CashFlowAggregateProjector {
         events.forEach(processingEvent -> {
             switch (processingEvent) {
                 case CashFlowEvent.CashFlowCreatedEvent event -> cashFlow.apply(event);
+                case CashFlowEvent.CashFlowWithHistoryCreatedEvent event -> cashFlow.apply(event);
                 case CashFlowEvent.MonthAttestedEvent event -> cashFlow.apply(event);
                 case CashFlowEvent.ExpectedCashChangeAppendedEvent event -> cashFlow.apply(event);
                 case CashFlowEvent.PaidCashChangeAppendedEvent event -> cashFlow.apply(event);

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowEvent.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowEvent.java
@@ -11,6 +11,7 @@ import java.time.ZonedDateTime;
 public sealed interface CashFlowEvent extends DomainEvent
         permits
         CashFlowEvent.CashFlowCreatedEvent,
+        CashFlowEvent.CashFlowWithHistoryCreatedEvent,
         CashFlowEvent.MonthAttestedEvent,
         CashFlowEvent.ExpectedCashChangeAppendedEvent,
         CashFlowEvent.PaidCashChangeAppendedEvent,
@@ -29,6 +30,37 @@ public sealed interface CashFlowEvent extends DomainEvent
     record CashFlowCreatedEvent(CashFlowId cashFlowId, UserId userId, Name name, Description description,
                                 BankAccount bankAccount,
                                 ZonedDateTime created) implements CashFlowEvent {
+        @Override
+        public ZonedDateTime occurredAt() {
+            return created;
+        }
+    }
+
+    /**
+     * Event for creating a CashFlow with historical data support.
+     * Creates a CashFlow in SETUP mode with historical months marked as SETUP_PENDING.
+     *
+     * @param cashFlowId     unique identifier of the cash flow
+     * @param userId         the user who owns this cash flow
+     * @param name           name of the cash flow
+     * @param description    description of the cash flow
+     * @param bankAccount    bank account details with current balance
+     * @param startPeriod    the first historical month
+     * @param activePeriod   the current active month (derived from created timestamp)
+     * @param initialBalance the balance at the start of startPeriod
+     * @param created        timestamp when the cash flow was created
+     */
+    record CashFlowWithHistoryCreatedEvent(
+            CashFlowId cashFlowId,
+            UserId userId,
+            Name name,
+            Description description,
+            BankAccount bankAccount,
+            YearMonth startPeriod,
+            YearMonth activePeriod,
+            Money initialBalance,
+            ZonedDateTime created
+    ) implements CashFlowEvent {
         @Override
         public ZonedDateTime occurredAt() {
             return created;

--- a/src/main/java/com/multi/vidulum/cashflow/domain/StartPeriodInFutureException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/StartPeriodInFutureException.java
@@ -1,0 +1,24 @@
+package com.multi.vidulum.cashflow.domain;
+
+import java.time.YearMonth;
+
+public class StartPeriodInFutureException extends RuntimeException {
+
+    private final YearMonth startPeriod;
+    private final YearMonth activePeriod;
+
+    public StartPeriodInFutureException(YearMonth startPeriod, YearMonth activePeriod) {
+        super(String.format("Start period [%s] cannot be in the future. Current active period: [%s]",
+                startPeriod, activePeriod));
+        this.startPeriod = startPeriod;
+        this.activePeriod = activePeriod;
+    }
+
+    public YearMonth getStartPeriod() {
+        return startPeriod;
+    }
+
+    public YearMonth getActivePeriod() {
+        return activePeriod;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowEventListener.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowEventListener.java
@@ -31,6 +31,9 @@ public class CashFlowEventListener {
             case "CashFlowCreatedEvent" -> {
                 return event.getContent().to(CashFlowEvent.CashFlowCreatedEvent.class);
             }
+            case "CashFlowWithHistoryCreatedEvent" -> {
+                return event.getContent().to(CashFlowEvent.CashFlowWithHistoryCreatedEvent.class);
+            }
             case "MonthAttestedEvent" -> {
                 return event.getContent().to(CashFlowEvent.MonthAttestedEvent.class);
             }

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CashFlowForecastProcessor.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CashFlowForecastProcessor.java
@@ -17,6 +17,7 @@ public class CashFlowForecastProcessor {
 
     private final CashFlowForecastMongoRepository repository;
     private final CashFlowCreatedEventHandler cashFlowCreatedEventHandler;
+    private final CashFlowWithHistoryCreatedEventHandler cashFlowWithHistoryCreatedEventHandler;
     private final MonthAttestedEventHandler monthAttestedEventHandler;
     private final ExpectedCashChangeAppendedEventHandler expectedCashChangeAppendedEventHandler;
     private final PaidCashChangeAppendedEventHandler paidCashChangeAppendedEventHandler;
@@ -36,6 +37,7 @@ public class CashFlowForecastProcessor {
     private void processEvent(CashFlowEvent cashFlowEvent) {
         switch (cashFlowEvent) {
             case CashFlowEvent.CashFlowCreatedEvent event -> cashFlowCreatedEventHandler.handle(event);
+            case CashFlowEvent.CashFlowWithHistoryCreatedEvent event -> cashFlowWithHistoryCreatedEventHandler.handle(event);
             case CashFlowEvent.MonthAttestedEvent event -> monthAttestedEventHandler.handle(event);
             case CashFlowEvent.ExpectedCashChangeAppendedEvent event -> expectedCashChangeAppendedEventHandler.handle(event);
             case CashFlowEvent.PaidCashChangeAppendedEvent event -> paidCashChangeAppendedEventHandler.handle(event);

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CashFlowWithHistoryCreatedEventHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CashFlowWithHistoryCreatedEventHandler.java
@@ -1,0 +1,132 @@
+package com.multi.vidulum.cashflow_forecast_processor.app.processing;
+
+import com.multi.vidulum.cashflow.domain.CashFlowEvent;
+import com.multi.vidulum.cashflow.domain.CategoryName;
+import com.multi.vidulum.cashflow_forecast_processor.app.*;
+import com.multi.vidulum.common.Money;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Handler for CashFlowWithHistoryCreatedEvent.
+ * Creates monthly forecasts with:
+ * - SETUP_PENDING for historical months (from startPeriod to month before activePeriod)
+ * - ACTIVE for the current month (activePeriod)
+ * - FORECASTED for future months (11 months after activePeriod)
+ */
+@Component
+@AllArgsConstructor
+public class CashFlowWithHistoryCreatedEventHandler implements CashFlowEventHandler<CashFlowEvent.CashFlowWithHistoryCreatedEvent> {
+
+    @Autowired
+    private Clock clock;
+
+    @Autowired
+    private final CashFlowForecastStatementRepository statementRepository;
+
+    @Override
+    public void handle(CashFlowEvent.CashFlowWithHistoryCreatedEvent event) {
+        YearMonth startPeriod = event.startPeriod();
+        YearMonth activePeriod = event.activePeriod();
+        Money currency = event.bankAccount().balance();
+
+        // Create monthly forecasts for all periods
+        Map<YearMonth, CashFlowMonthlyForecast> monthlyForecasts = Stream.concat(
+                // Historical months (SETUP_PENDING): from startPeriod to month before activePeriod
+                generateMonths(startPeriod, activePeriod.minusMonths(1))
+                        .map(yearMonth -> createMonthlyForecast(yearMonth, currency, CashFlowMonthlyForecast.Status.SETUP_PENDING)),
+                // Current and future months: activePeriod + 11 months
+                generateMonths(activePeriod, activePeriod.plusMonths(11))
+                        .map(yearMonth -> {
+                            CashFlowMonthlyForecast.Status status = yearMonth.equals(activePeriod)
+                                    ? CashFlowMonthlyForecast.Status.ACTIVE
+                                    : CashFlowMonthlyForecast.Status.FORECASTED;
+                            return createMonthlyForecast(yearMonth, currency, status);
+                        })
+        ).collect(Collectors.toMap(
+                CashFlowMonthlyForecast::getPeriod,
+                Function.identity()
+        ));
+
+        // Create category structure
+        List<CategoryNode> inflowCategoryStructure = new LinkedList<>();
+        inflowCategoryStructure.add(new CategoryNode(null, new CategoryName("Uncategorized"), new LinkedList<>()));
+        List<CategoryNode> outflowCategoryStructure = new LinkedList<>();
+        outflowCategoryStructure.add(new CategoryNode(null, new CategoryName("Uncategorized"), new LinkedList<>()));
+        CurrentCategoryStructure currentCategoryStructure = new CurrentCategoryStructure(
+                inflowCategoryStructure,
+                outflowCategoryStructure,
+                ZonedDateTime.now(this.clock)
+        );
+
+        statementRepository.save(
+                new CashFlowForecastStatement(
+                        event.cashFlowId(),
+                        monthlyForecasts,
+                        event.bankAccount().bankAccountNumber(),
+                        currentCategoryStructure,
+                        event.created(),
+                        getChecksum(event)
+                ));
+    }
+
+    /**
+     * Generate a stream of YearMonths from start to end (inclusive).
+     */
+    private Stream<YearMonth> generateMonths(YearMonth start, YearMonth end) {
+        if (start.isAfter(end)) {
+            return Stream.empty();
+        }
+        List<YearMonth> months = new LinkedList<>();
+        YearMonth current = start;
+        while (!current.isAfter(end)) {
+            months.add(current);
+            current = current.plusMonths(1);
+        }
+        return months.stream();
+    }
+
+    private CashFlowMonthlyForecast createMonthlyForecast(YearMonth yearMonth, Money currency, CashFlowMonthlyForecast.Status status) {
+        List<CashCategory> categorizedInflows = new LinkedList<>();
+        categorizedInflows.add(
+                CashCategory.builder()
+                        .categoryName(new CategoryName("Uncategorized"))
+                        .category(new Category("Uncategorized"))
+                        .subCategories(List.of())
+                        .groupedTransactions(new GroupedTransactions())
+                        .totalPaidValue(Money.zero(currency.getCurrency()))
+                        .build()
+        );
+
+        List<CashCategory> categorizedOutflows = new LinkedList<>();
+        categorizedOutflows.add(
+                CashCategory.builder()
+                        .categoryName(new CategoryName("Uncategorized"))
+                        .category(new Category("Uncategorized"))
+                        .subCategories(List.of())
+                        .groupedTransactions(new GroupedTransactions())
+                        .totalPaidValue(Money.zero(currency.getCurrency()))
+                        .build()
+        );
+
+        return new CashFlowMonthlyForecast(
+                yearMonth,
+                CashFlowStats.justBalance(currency),
+                categorizedInflows,
+                categorizedOutflows,
+                status,
+                null
+        );
+    }
+}


### PR DESCRIPTION
- Add CreateCashFlowWithHistoryCommand and handler
- Add CashFlowWithHistoryCreatedEvent to sealed interface
- Add apply method in CashFlow aggregate setting SETUP status
- Add CashFlowWithHistoryCreatedEventHandler creating monthly forecasts:
  - SETUP_PENDING for historical months
  - ACTIVE for current month
  - FORECASTED for future months
- Add REST endpoint POST /cash-flow/with-history
- Add StartPeriodInFutureException validation
- Add Kafka event mapping in CashFlowEventListener
- Update SETUP mode validation tests to use createCashFlowWithHistory
- Add integration tests for new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)