### PR TITLE
VID-112: Add dedicated error handling for BalanceMismatchException

### DIFF
--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/attesthistoricalimport/AttestHistoricalImportCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/attesthistoricalimport/AttestHistoricalImportCommandHandler.java
@@ -49,6 +49,7 @@ public class AttestHistoricalImportCommandHandler implements CommandHandler<Atte
         if (!isZeroDifference && !command.forceAttestation() && !command.createAdjustment()) {
             throw new BalanceMismatchException(
                     command.cashFlowId(),
+                    snapshot.name(),
                     confirmedBalance,
                     calculatedBalance,
                     difference

--- a/src/main/java/com/multi/vidulum/cashflow/domain/BalanceMismatchException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/BalanceMismatchException.java
@@ -9,15 +9,17 @@ import com.multi.vidulum.common.Money;
 public class BalanceMismatchException extends RuntimeException {
 
     private final CashFlowId cashFlowId;
+    private final Name cashFlowName;
     private final Money confirmedBalance;
     private final Money calculatedBalance;
     private final Money difference;
 
-    public BalanceMismatchException(CashFlowId cashFlowId, Money confirmedBalance, Money calculatedBalance, Money difference) {
-        super(String.format("Balance mismatch for CashFlow [%s]. Confirmed: [%s], Calculated: [%s], Difference: [%s]. " +
-                        "Use forceActivation=true to activate anyway.",
-                cashFlowId.id(), confirmedBalance, calculatedBalance, difference));
+    public BalanceMismatchException(CashFlowId cashFlowId, Name cashFlowName, Money confirmedBalance, Money calculatedBalance, Money difference) {
+        super(String.format("Balance mismatch for CashFlow '%s' [%s]. Confirmed: [%s], Calculated: [%s], Difference: [%s]. " +
+                        "Use forceAttestation=true or createAdjustment=true to proceed.",
+                cashFlowName.name(), cashFlowId.id(), confirmedBalance, calculatedBalance, difference));
         this.cashFlowId = cashFlowId;
+        this.cashFlowName = cashFlowName;
         this.confirmedBalance = confirmedBalance;
         this.calculatedBalance = calculatedBalance;
         this.difference = difference;
@@ -25,6 +27,10 @@ public class BalanceMismatchException extends RuntimeException {
 
     public CashFlowId getCashFlowId() {
         return cashFlowId;
+    }
+
+    public Name getCashFlowName() {
+        return cashFlowName;
     }
 
     public Money getConfirmedBalance() {

--- a/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
+++ b/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     CASHFLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "CashFlow not found"),
     CASHFLOW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "Access to CashFlow denied"),
     CASHFLOW_INVALID_STATE(HttpStatus.BAD_REQUEST, "Operation not allowed in current state"),
+    CASHFLOW_BALANCE_MISMATCH(HttpStatus.CONFLICT, "Balance mismatch during attestation"),
 
     // Bank Data Ingestion
     INGESTION_STAGING_NOT_FOUND(HttpStatus.NOT_FOUND, "Staging session not found"),

--- a/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
+++ b/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.security.config;
 
+import com.multi.vidulum.cashflow.domain.BalanceMismatchException;
 import com.multi.vidulum.common.error.ApiError;
 import com.multi.vidulum.common.error.ErrorCode;
 import com.multi.vidulum.common.error.FieldError;
@@ -57,6 +58,13 @@ public class ErrorHttpHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiError> handleJsonParse(HttpMessageNotReadableException ex) {
         ApiError error = ApiError.of(ErrorCode.VALIDATION_INVALID_JSON);
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(BalanceMismatchException.class)
+    public ResponseEntity<ApiError> handleBalanceMismatch(BalanceMismatchException ex) {
+        log.warn("Balance mismatch for CashFlow [{}]: {}", ex.getCashFlowId().id(), ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CASHFLOW_BALANCE_MISMATCH, ex.getMessage());
         return ResponseEntity.status(error.httpStatus()).body(error);
     }
 

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
@@ -1,0 +1,201 @@
+package com.multi.vidulum.cashflow.app;
+
+import com.multi.vidulum.cashflow.domain.Type;
+import com.multi.vidulum.common.Money;
+import com.multi.vidulum.common.error.ApiError;
+import com.multi.vidulum.config.FixedClockConfig;
+import com.multi.vidulum.portfolio.app.PortfolioAppConfig;
+import com.multi.vidulum.trading.app.TradingAppConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * HTTP integration tests for CashFlow error handling.
+ * Tests that domain exceptions are properly mapped to HTTP responses with correct status codes and ApiError bodies.
+ *
+ * This class follows the pattern established in AuthenticationControllerTest.
+ * New error handling tests should be added to this class in future pull requests.
+ */
+@Slf4j
+@SpringBootTest(
+        classes = {FixedClockConfig.class, CashFlowErrorHandlingTest.TestSecurityConfig.class},
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@Import({PortfolioAppConfig.class, TradingAppConfig.class})
+@Testcontainers
+@DirtiesContext
+class CashFlowErrorHandlingTest {
+
+    /**
+     * Test security configuration that disables authentication for HTTP integration tests.
+     */
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Bean
+        @Order(1)
+        public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(req -> req.anyRequest().permitAll());
+            return http.build();
+        }
+    }
+
+    @Container
+    public static KafkaContainer kafka =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.4.0"));
+
+    @Container
+    protected static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.4.6");
+
+    @LocalServerPort
+    private int port;
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+        registry.add("mongodb.port", mongoDBContainer::getFirstMappedPort);
+        registry.add("spring.kafka.bootstrap-servers", () -> kafka.getBootstrapServers());
+    }
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private CashFlowHttpActor actor;
+
+    @BeforeEach
+    void setUp() {
+        actor = new CashFlowHttpActor(restTemplate, port);
+    }
+
+    @Nested
+    @DisplayName("Attestation - Balance Mismatch Error")
+    class AttestationBalanceMismatchError {
+
+        @Test
+        @DisplayName("Should return 409 CONFLICT with CASHFLOW_BALANCE_MISMATCH error when balance does not match")
+        void shouldReturn409ConflictWhenBalanceMismatch() {
+            // given - create CashFlow with history
+            String userId = "errortest_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowName = "Test Balance Mismatch CashFlow";
+            YearMonth startPeriod = YearMonth.of(2021, 9);
+            Money initialBalance = Money.of(1000, "USD");
+
+            String cashFlowId = actor.createCashFlowWithHistory(userId, cashFlowName, startPeriod, initialBalance);
+
+            // Create category and import a transaction
+            actor.createCategory(cashFlowId, "Salary", Type.INFLOW);
+            actor.importHistoricalTransaction(
+                    cashFlowId,
+                    "Salary",
+                    "September Salary",
+                    "Monthly salary payment",
+                    Money.of(2000, "USD"),
+                    Type.INFLOW,
+                    ZonedDateTime.parse("2021-09-25T00:00:00Z"),
+                    ZonedDateTime.parse("2021-09-25T00:00:00Z")
+            );
+
+            // Expected balance: 1000 (initial) + 2000 (inflow) = 3000 USD
+            // But user tries to confirm with 5000 USD (mismatch!)
+            Money wrongConfirmedBalance = Money.of(5000, "USD");
+
+            // when - attest with wrong balance
+            ResponseEntity<ApiError> response = actor.attestHistoricalImportExpectingError(
+                    cashFlowId,
+                    wrongConfirmedBalance,
+                    false,  // forceAttestation
+                    false   // createAdjustment
+            );
+
+            // then - should return 409 CONFLICT with proper error structure
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(response.getBody()).isNotNull();
+
+            ApiError error = response.getBody();
+            assertThat(error.status()).isEqualTo(409);
+            assertThat(error.code()).isEqualTo("CASHFLOW_BALANCE_MISMATCH");
+            assertThat(error.message()).contains(cashFlowName);  // Error message should include CashFlow name
+            assertThat(error.message()).contains("5000");  // Confirmed balance
+            assertThat(error.message()).contains("3000");  // Calculated balance
+            assertThat(error.fieldErrors()).isNull();  // No field errors for business exception
+            assertThat(error.timestamp()).isNotNull();
+
+            log.info("Balance mismatch correctly returned 409 CONFLICT: code={}, message={}",
+                    error.code(), error.message());
+        }
+
+        @Test
+        @DisplayName("Should return 200 OK when attestation succeeds with correct balance")
+        void shouldReturn200OkWhenBalanceMatches() {
+            // given - create CashFlow with history
+            String userId = "successtest_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowName = "Test Successful Attestation CashFlow";
+            YearMonth startPeriod = YearMonth.of(2021, 10);
+            Money initialBalance = Money.of(500, "PLN");
+
+            String cashFlowId = actor.createCashFlowWithHistory(userId, cashFlowName, startPeriod, initialBalance);
+
+            // Create category and import a transaction
+            actor.createCategory(cashFlowId, "Bonus", Type.INFLOW);
+            actor.importHistoricalTransaction(
+                    cashFlowId,
+                    "Bonus",
+                    "October Bonus",
+                    "Performance bonus",
+                    Money.of(1500, "PLN"),
+                    Type.INFLOW,
+                    ZonedDateTime.parse("2021-10-15T00:00:00Z"),
+                    ZonedDateTime.parse("2021-10-15T00:00:00Z")
+            );
+
+            // Correct balance: 500 (initial) + 1500 (inflow) = 2000 PLN
+            Money correctConfirmedBalance = Money.of(2000, "PLN");
+
+            // when - attest with correct balance
+            ResponseEntity<CashFlowDto.AttestHistoricalImportResponseJson> response = actor.attestHistoricalImport(
+                    cashFlowId,
+                    correctConfirmedBalance,
+                    false,  // forceAttestation
+                    false   // createAdjustment
+            );
+
+            // then - should return 200 OK
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCashFlowId()).isEqualTo(cashFlowId);
+
+            log.info("Attestation succeeded with correct balance: cashFlowId={}", cashFlowId);
+        }
+    }
+}

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
@@ -1,0 +1,206 @@
+package com.multi.vidulum.cashflow.app;
+
+import com.multi.vidulum.cashflow.domain.BankAccount;
+import com.multi.vidulum.cashflow.domain.BankAccountNumber;
+import com.multi.vidulum.cashflow.domain.BankName;
+import com.multi.vidulum.cashflow.domain.Type;
+import com.multi.vidulum.common.Currency;
+import com.multi.vidulum.common.Money;
+import com.multi.vidulum.common.error.ApiError;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * HTTP Actor for CashFlow API testing.
+ * Encapsulates all REST interactions with /cash-flow endpoints.
+ * Follows the same pattern as AuthenticationHttpActor.
+ */
+@Slf4j
+public class CashFlowHttpActor {
+
+    private final TestRestTemplate restTemplate;
+    private final RestTemplate rawRestTemplate;
+    private final String baseUrl;
+
+    public CashFlowHttpActor(TestRestTemplate restTemplate, int port) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = "http://localhost:" + port;
+        this.rawRestTemplate = createRawRestTemplate();
+    }
+
+    private RestTemplate createRawRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setOutputStreaming(false);
+        return new RestTemplate(factory);
+    }
+
+    // ============ CashFlow Operations ============
+
+    /**
+     * Creates a CashFlow with history support via HTTP.
+     * The CashFlow will be in SETUP mode, ready for historical data import.
+     */
+    public String createCashFlowWithHistory(String userId, String name, YearMonth startPeriod, Money initialBalance) {
+        CashFlowDto.CreateCashFlowWithHistoryJson request = CashFlowDto.CreateCashFlowWithHistoryJson.builder()
+                .userId(userId)
+                .name(name)
+                .description("CashFlow for HTTP integration testing")
+                .bankAccount(new BankAccount(
+                        new BankName("Test Bank"),
+                        new BankAccountNumber("PL12345678901234567890123456", Currency.of(initialBalance.getCurrency())),
+                        Money.zero(initialBalance.getCurrency())
+                ))
+                .startPeriod(startPeriod.toString())
+                .initialBalance(initialBalance)
+                .build();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/with-history",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String cashFlowId = response.getBody();
+        assertThat(cashFlowId).isNotNull().isNotEmpty();
+
+        log.info("Created CashFlow with history via HTTP: id={}, name={}, startPeriod={}",
+                cashFlowId, name, startPeriod);
+        return cashFlowId;
+    }
+
+    /**
+     * Creates a category in a CashFlow via HTTP.
+     * Uses isImport=true to allow category creation in SETUP mode.
+     */
+    public void createCategory(String cashFlowId, String categoryName, Type type) {
+        CashFlowDto.CreateCategoryJson request = CashFlowDto.CreateCategoryJson.builder()
+                .category(categoryName)
+                .type(type)
+                .build();
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/" + cashFlowId + "/category?isImport=true",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        log.debug("Created category via HTTP: cashFlowId={}, category={}, type={}",
+                cashFlowId, categoryName, type);
+    }
+
+    /**
+     * Imports a historical transaction via HTTP.
+     */
+    public String importHistoricalTransaction(String cashFlowId, String categoryName, String name,
+                                              String description, Money money, Type type,
+                                              ZonedDateTime dueDate, ZonedDateTime paidDate) {
+        CashFlowDto.ImportHistoricalCashChangeJson request = CashFlowDto.ImportHistoricalCashChangeJson.builder()
+                .category(categoryName)
+                .name(name)
+                .description(description)
+                .money(money)
+                .type(type)
+                .dueDate(dueDate)
+                .paidDate(paidDate)
+                .build();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/" + cashFlowId + "/import-historical",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String cashChangeId = response.getBody();
+        assertThat(cashChangeId).isNotNull().isNotEmpty();
+
+        log.debug("Imported historical transaction via HTTP: cashFlowId={}, cashChangeId={}, category={}",
+                cashFlowId, cashChangeId, categoryName);
+        return cashChangeId;
+    }
+
+    /**
+     * Attests historical import - transitions CashFlow from SETUP to OPEN mode.
+     */
+    public ResponseEntity<CashFlowDto.AttestHistoricalImportResponseJson> attestHistoricalImport(
+            String cashFlowId, Money confirmedBalance, boolean forceAttestation, boolean createAdjustment) {
+
+        CashFlowDto.AttestHistoricalImportJson request = CashFlowDto.AttestHistoricalImportJson.builder()
+                .confirmedBalance(confirmedBalance)
+                .forceAttestation(forceAttestation)
+                .createAdjustment(createAdjustment)
+                .build();
+
+        return restTemplate.exchange(
+                baseUrl + "/cash-flow/" + cashFlowId + "/attest-historical-import",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                CashFlowDto.AttestHistoricalImportResponseJson.class
+        );
+    }
+
+    /**
+     * Attests historical import expecting an error response.
+     * Uses rawRestTemplate to capture error responses properly.
+     */
+    public ResponseEntity<ApiError> attestHistoricalImportExpectingError(
+            String cashFlowId, Money confirmedBalance, boolean forceAttestation, boolean createAdjustment) {
+
+        CashFlowDto.AttestHistoricalImportJson request = CashFlowDto.AttestHistoricalImportJson.builder()
+                .confirmedBalance(confirmedBalance)
+                .forceAttestation(forceAttestation)
+                .createAdjustment(createAdjustment)
+                .build();
+
+        HttpHeaders headers = jsonHeaders();
+        HttpEntity<CashFlowDto.AttestHistoricalImportJson> entity = new HttpEntity<>(request, headers);
+
+        try {
+            ResponseEntity<ApiError> response = rawRestTemplate.exchange(
+                    baseUrl + "/cash-flow/" + cashFlowId + "/attest-historical-import",
+                    HttpMethod.POST,
+                    entity,
+                    ApiError.class
+            );
+            return response;
+        } catch (HttpClientErrorException e) {
+            return ResponseEntity.status(e.getStatusCode())
+                    .body(e.getResponseBodyAs(ApiError.class));
+        }
+    }
+
+    /**
+     * Gets CashFlow summary via HTTP.
+     */
+    public CashFlowDto.CashFlowSummaryJson getCashFlow(String cashFlowId) {
+        ResponseEntity<CashFlowDto.CashFlowSummaryJson> response = restTemplate.getForEntity(
+                baseUrl + "/cash-flow/" + cashFlowId,
+                CashFlowDto.CashFlowSummaryJson.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        return response.getBody();
+    }
+
+    // ============ Helper Methods ============
+
+    private HttpHeaders jsonHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+}


### PR DESCRIPTION
  ## Summary
  - Add dedicated `@ExceptionHandler` for `BalanceMismatchException` returning HTTP 409 CONFLICT
  - Include CashFlow name in error message for better user experience
  - Add `CASHFLOW_BALANCE_MISMATCH` error code to `ErrorCode` enum
  - Add HTTP integration tests for error handling (`CashFlowErrorHandlingTest`)
  - Add `CashFlowHttpActor` test helper for REST API interactions

