### PR TITLE
VID-113: Add comprehensive error handling and field validation for CashFlow REST API

### DIFF
--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
@@ -2,6 +2,9 @@ package com.multi.vidulum.cashflow.app;
 
 import com.multi.vidulum.cashflow.domain.*;
 import com.multi.vidulum.common.Money;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -138,26 +141,45 @@ public final class CashFlowDto {
     @Data
     @Builder
     public static class ConfirmCashChangeJson {
+        @NotBlank(message = "CashFlow ID is required")
         private String cashFlowId;
+
+        @NotBlank(message = "CashChange ID is required")
         private String cashChangeId;
     }
 
     @Data
     @Builder
     public static class EditCashChangeJson {
+        @NotBlank(message = "CashFlow ID is required")
         private String cashFlowId;
+
+        @NotBlank(message = "CashChange ID is required")
         private String cashChangeId;
+
+        @NotBlank(message = "Name is required")
         private String name;
+
+        @Size(max = 500, message = "Description cannot exceed 500 characters")
         private String description;
+
+        @NotNull(message = "Money is required")
         private Money money;
+
+        @NotNull(message = "Due date is required")
         private ZonedDateTime dueDate;
     }
 
     @Data
     @Builder
     public static class RejectCashChangeJson {
+        @NotBlank(message = "CashFlow ID is required")
         private String cashFlowId;
+
+        @NotBlank(message = "CashChange ID is required")
         private String cashChangeId;
+
+        @NotBlank(message = "Reason is required")
         private String reason;
     }
 

--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
@@ -25,6 +25,7 @@ import com.multi.vidulum.common.Reason;
 import com.multi.vidulum.common.UserId;
 import com.multi.vidulum.shared.cqrs.CommandGateway;
 import com.multi.vidulum.shared.cqrs.QueryGateway;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -241,7 +242,7 @@ public class CashFlowRestController {
     }
 
     @PostMapping("/confirm")
-    public void confirm(@RequestBody CashFlowDto.ConfirmCashChangeJson request) {
+    public void confirm(@Valid @RequestBody CashFlowDto.ConfirmCashChangeJson request) {
         commandGateway.send(
                 new ConfirmCashChangeCommand(
                         new CashFlowId(request.getCashFlowId()),
@@ -250,7 +251,7 @@ public class CashFlowRestController {
     }
 
     @PostMapping("/edit")
-    public void edit(@RequestBody CashFlowDto.EditCashChangeJson request) {
+    public void edit(@Valid @RequestBody CashFlowDto.EditCashChangeJson request) {
         commandGateway.send(
                 new EditCashChangeCommand(
                         new CashFlowId(request.getCashFlowId()),
@@ -264,7 +265,7 @@ public class CashFlowRestController {
     }
 
     @PostMapping("/reject")
-    public void reject(@RequestBody CashFlowDto.RejectCashChangeJson request) {
+    public void reject(@Valid @RequestBody CashFlowDto.RejectCashChangeJson request) {
         commandGateway.send(
                 new RejectCashChangeCommand(
                         new CashFlowId(request.getCashFlowId()),

--- a/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
+++ b/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
@@ -21,11 +21,38 @@ public enum ErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "Request validation failed"),
     VALIDATION_INVALID_JSON(HttpStatus.BAD_REQUEST, "Invalid JSON format"),
 
-    // CashFlow
+    // CashFlow - Resources
     CASHFLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "CashFlow not found"),
+    CASHCHANGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CashChange not found"),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "Category not found"),
+    BUDGETING_NOT_FOUND(HttpStatus.NOT_FOUND, "Budgeting not found"),
+
+    // CashFlow - Conflicts
     CASHFLOW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "Access to CashFlow denied"),
-    CASHFLOW_INVALID_STATE(HttpStatus.BAD_REQUEST, "Operation not allowed in current state"),
     CASHFLOW_BALANCE_MISMATCH(HttpStatus.CONFLICT, "Balance mismatch during attestation"),
+    CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "Category already exists"),
+    BUDGETING_ALREADY_EXISTS(HttpStatus.CONFLICT, "Budgeting already exists"),
+    CATEGORY_UNARCHIVE_CONFLICT(HttpStatus.CONFLICT, "Cannot unarchive - active category exists"),
+
+    // CashFlow - Invalid State
+    CASHFLOW_INVALID_STATE(HttpStatus.BAD_REQUEST, "Operation not allowed in current state"),
+    CASHFLOW_OPERATION_NOT_ALLOWED_IN_SETUP(HttpStatus.BAD_REQUEST, "Operation not allowed in SETUP mode"),
+    CASHFLOW_IMPORT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "Import only allowed in SETUP mode"),
+    CASHFLOW_ATTESTATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "Attestation only allowed in SETUP mode"),
+    CASHFLOW_ROLLBACK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "Rollback only allowed in SETUP mode"),
+    CASHCHANGE_NOT_PENDING(HttpStatus.BAD_REQUEST, "CashChange is not in PENDING status"),
+
+    // CashFlow - Date Validation
+    PAID_DATE_IN_FUTURE(HttpStatus.BAD_REQUEST, "Paid date cannot be in the future"),
+    PAID_DATE_OUTSIDE_ACTIVE_PERIOD(HttpStatus.BAD_REQUEST, "Paid date must be in active period"),
+    START_PERIOD_IN_FUTURE(HttpStatus.BAD_REQUEST, "Start period cannot be in the future"),
+    IMPORT_DATE_IN_FUTURE(HttpStatus.BAD_REQUEST, "Import date cannot be in the future"),
+    IMPORT_DATE_BEFORE_START(HttpStatus.BAD_REQUEST, "Import date before start period"),
+    IMPORT_DATE_OUTSIDE_SETUP_PERIOD(HttpStatus.BAD_REQUEST, "Import date outside setup period"),
+
+    // CashFlow - Categories
+    CATEGORY_IS_ARCHIVED(HttpStatus.BAD_REQUEST, "Category is archived"),
+    CANNOT_ARCHIVE_SYSTEM_CATEGORY(HttpStatus.BAD_REQUEST, "Cannot archive system category"),
 
     // Bank Data Ingestion
     INGESTION_STAGING_NOT_FOUND(HttpStatus.NOT_FOUND, "Staging session not found"),

--- a/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
+++ b/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
@@ -1,11 +1,14 @@
 package com.multi.vidulum.security.config;
 
-import com.multi.vidulum.cashflow.domain.BalanceMismatchException;
+import com.multi.vidulum.cashflow.app.commands.archive.CannotArchiveSystemCategoryException;
+import com.multi.vidulum.cashflow.app.commands.archive.CategoryNotFoundException;
+import com.multi.vidulum.cashflow.domain.*;
 import com.multi.vidulum.common.error.ApiError;
 import com.multi.vidulum.common.error.ErrorCode;
 import com.multi.vidulum.common.error.FieldError;
 import com.multi.vidulum.security.auth.EmailAlreadyTakenException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -13,8 +16,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-
-import org.springframework.core.annotation.Order;
 
 import java.util.List;
 
@@ -67,6 +68,165 @@ public class ErrorHttpHandler {
         ApiError error = ApiError.of(ErrorCode.CASHFLOW_BALANCE_MISMATCH, ex.getMessage());
         return ResponseEntity.status(error.httpStatus()).body(error);
     }
+
+    // ============ CashFlow - Resources Not Found (404) ============
+
+    @ExceptionHandler(CashFlowDoesNotExistsException.class)
+    public ResponseEntity<ApiError> handleCashFlowNotFound(CashFlowDoesNotExistsException ex) {
+        log.debug("CashFlow not found: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CASHFLOW_NOT_FOUND, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(CashChangeDoesNotExistsException.class)
+    public ResponseEntity<ApiError> handleCashChangeNotFound(CashChangeDoesNotExistsException ex) {
+        log.debug("CashChange not found: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CASHCHANGE_NOT_FOUND, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(CategoryDoesNotExistsException.class)
+    public ResponseEntity<ApiError> handleCategoryDoesNotExist(CategoryDoesNotExistsException ex) {
+        log.debug("Category not found: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CATEGORY_NOT_FOUND, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(CategoryNotFoundException.class)
+    public ResponseEntity<ApiError> handleCategoryNotFound(CategoryNotFoundException ex) {
+        log.debug("Category not found: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CATEGORY_NOT_FOUND, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(BudgetingDoesNotExistsException.class)
+    public ResponseEntity<ApiError> handleBudgetingNotFound(BudgetingDoesNotExistsException ex) {
+        log.debug("Budgeting not found: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.BUDGETING_NOT_FOUND, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    // ============ CashFlow - Conflicts (409) ============
+
+    @ExceptionHandler(CategoryAlreadyExistsException.class)
+    public ResponseEntity<ApiError> handleCategoryAlreadyExists(CategoryAlreadyExistsException ex) {
+        log.debug("Category already exists: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CATEGORY_ALREADY_EXISTS, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(BudgetingAlreadyExistsException.class)
+    public ResponseEntity<ApiError> handleBudgetingAlreadyExists(BudgetingAlreadyExistsException ex) {
+        log.debug("Budgeting already exists: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.BUDGETING_ALREADY_EXISTS, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(CannotUnarchiveCategoryException.class)
+    public ResponseEntity<ApiError> handleCannotUnarchiveCategory(CannotUnarchiveCategoryException ex) {
+        log.debug("Cannot unarchive category: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CATEGORY_UNARCHIVE_CONFLICT, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    // ============ CashFlow - Invalid State (400) ============
+
+    @ExceptionHandler(OperationNotAllowedInSetupModeException.class)
+    public ResponseEntity<ApiError> handleOperationNotAllowedInSetupMode(OperationNotAllowedInSetupModeException ex) {
+        log.debug("Operation not allowed in SETUP mode: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CASHFLOW_OPERATION_NOT_ALLOWED_IN_SETUP, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(ImportNotAllowedInNonSetupModeException.class)
+    public ResponseEntity<ApiError> handleImportNotAllowed(ImportNotAllowedInNonSetupModeException ex) {
+        log.debug("Import not allowed: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CASHFLOW_IMPORT_NOT_ALLOWED, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(AttestationNotAllowedInNonSetupModeException.class)
+    public ResponseEntity<ApiError> handleAttestationNotAllowed(AttestationNotAllowedInNonSetupModeException ex) {
+        log.debug("Attestation not allowed: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CASHFLOW_ATTESTATION_NOT_ALLOWED, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(RollbackNotAllowedInNonSetupModeException.class)
+    public ResponseEntity<ApiError> handleRollbackNotAllowed(RollbackNotAllowedInNonSetupModeException ex) {
+        log.debug("Rollback not allowed: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CASHFLOW_ROLLBACK_NOT_ALLOWED, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(CashChangeIsNotOpenedException.class)
+    public ResponseEntity<ApiError> handleCashChangeNotPending(CashChangeIsNotOpenedException ex) {
+        log.debug("CashChange not pending: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CASHCHANGE_NOT_PENDING, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    // ============ CashFlow - Date Validation (400) ============
+
+    @ExceptionHandler(PaidDateInFutureException.class)
+    public ResponseEntity<ApiError> handlePaidDateInFuture(PaidDateInFutureException ex) {
+        log.debug("Paid date in future: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.PAID_DATE_IN_FUTURE, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(PaidDateNotInActivePeriodException.class)
+    public ResponseEntity<ApiError> handlePaidDateNotInActivePeriod(PaidDateNotInActivePeriodException ex) {
+        log.debug("Paid date not in active period: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.PAID_DATE_OUTSIDE_ACTIVE_PERIOD, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(StartPeriodInFutureException.class)
+    public ResponseEntity<ApiError> handleStartPeriodInFuture(StartPeriodInFutureException ex) {
+        log.debug("Start period in future: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.START_PERIOD_IN_FUTURE, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(ImportDateInFutureException.class)
+    public ResponseEntity<ApiError> handleImportDateInFuture(ImportDateInFutureException ex) {
+        log.debug("Import date in future: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.IMPORT_DATE_IN_FUTURE, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(ImportDateBeforeStartPeriodException.class)
+    public ResponseEntity<ApiError> handleImportDateBeforeStartPeriod(ImportDateBeforeStartPeriodException ex) {
+        log.debug("Import date before start period: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.IMPORT_DATE_BEFORE_START, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(ImportDateOutsideSetupPeriodException.class)
+    public ResponseEntity<ApiError> handleImportDateOutsideSetupPeriod(ImportDateOutsideSetupPeriodException ex) {
+        log.debug("Import date outside setup period: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.IMPORT_DATE_OUTSIDE_SETUP_PERIOD, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    // ============ CashFlow - Category Operations (400) ============
+
+    @ExceptionHandler(CategoryIsArchivedException.class)
+    public ResponseEntity<ApiError> handleCategoryIsArchived(CategoryIsArchivedException ex) {
+        log.debug("Category is archived: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CATEGORY_IS_ARCHIVED, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(CannotArchiveSystemCategoryException.class)
+    public ResponseEntity<ApiError> handleCannotArchiveSystemCategory(CannotArchiveSystemCategoryException ex) {
+        log.debug("Cannot archive system category: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CANNOT_ARCHIVE_SYSTEM_CATEGORY, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    // ============ General Error Handler ============
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiError> handleGeneral(Exception ex) {

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
@@ -196,7 +196,456 @@ public class CashFlowHttpActor {
         return response.getBody();
     }
 
+    /**
+     * Gets CashFlow expecting an error response.
+     */
+    public ResponseEntity<ApiError> getCashFlowExpectingError(String cashFlowId) {
+        return executeExpectingError(
+                baseUrl + "/cash-flow/" + cashFlowId,
+                HttpMethod.GET,
+                null
+        );
+    }
+
+    // ============ Error-Expecting Operations ============
+
+    /**
+     * Creates CashFlow with history expecting an error response.
+     */
+    public ResponseEntity<ApiError> createCashFlowWithHistoryExpectingError(String userId, String name,
+                                                                             String startPeriod, Money initialBalance) {
+        CashFlowDto.CreateCashFlowWithHistoryJson request = CashFlowDto.CreateCashFlowWithHistoryJson.builder()
+                .userId(userId)
+                .name(name)
+                .description("CashFlow for HTTP integration testing")
+                .bankAccount(new BankAccount(
+                        new BankName("Test Bank"),
+                        new BankAccountNumber("PL12345678901234567890123456", Currency.of(initialBalance.getCurrency())),
+                        Money.zero(initialBalance.getCurrency())
+                ))
+                .startPeriod(startPeriod)
+                .initialBalance(initialBalance)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/with-history",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Appends expected cash change expecting an error response.
+     */
+    public ResponseEntity<ApiError> appendExpectedCashChangeExpectingError(String cashFlowId, String category,
+                                                                            String name, String description,
+                                                                            Money money, Type type,
+                                                                            ZonedDateTime dueDate) {
+        CashFlowDto.AppendExpectedCashChangeJson request = CashFlowDto.AppendExpectedCashChangeJson.builder()
+                .cashFlowId(cashFlowId)
+                .category(category)
+                .name(name)
+                .description(description)
+                .money(money)
+                .type(type)
+                .dueDate(dueDate)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/expected-cash-change",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Appends paid cash change expecting an error response.
+     */
+    public ResponseEntity<ApiError> appendPaidCashChangeExpectingError(String cashFlowId, String category,
+                                                                        String name, String description,
+                                                                        Money money, Type type,
+                                                                        ZonedDateTime dueDate, ZonedDateTime paidDate) {
+        CashFlowDto.AppendPaidCashChangeJson request = CashFlowDto.AppendPaidCashChangeJson.builder()
+                .cashFlowId(cashFlowId)
+                .category(category)
+                .name(name)
+                .description(description)
+                .money(money)
+                .type(type)
+                .dueDate(dueDate)
+                .paidDate(paidDate)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/paid-cash-change",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Edits cash change expecting an error response.
+     */
+    public ResponseEntity<ApiError> editCashChangeExpectingError(String cashFlowId, String cashChangeId,
+                                                                  String name, String description,
+                                                                  Money money, ZonedDateTime dueDate) {
+        CashFlowDto.EditCashChangeJson request = CashFlowDto.EditCashChangeJson.builder()
+                .cashFlowId(cashFlowId)
+                .cashChangeId(cashChangeId)
+                .name(name)
+                .description(description)
+                .money(money)
+                .dueDate(dueDate)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/edit",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Confirms cash change expecting an error response.
+     */
+    public ResponseEntity<ApiError> confirmCashChangeExpectingError(String cashFlowId, String cashChangeId) {
+        CashFlowDto.ConfirmCashChangeJson request = CashFlowDto.ConfirmCashChangeJson.builder()
+                .cashFlowId(cashFlowId)
+                .cashChangeId(cashChangeId)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/confirm",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Rejects cash change expecting an error response.
+     */
+    public ResponseEntity<ApiError> rejectCashChangeExpectingError(String cashFlowId, String cashChangeId, String reason) {
+        CashFlowDto.RejectCashChangeJson request = CashFlowDto.RejectCashChangeJson.builder()
+                .cashFlowId(cashFlowId)
+                .cashChangeId(cashChangeId)
+                .reason(reason)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/reject",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Creates category expecting an error response.
+     */
+    public ResponseEntity<ApiError> createCategoryExpectingError(String cashFlowId, String categoryName,
+                                                                  Type type, boolean isImport) {
+        CashFlowDto.CreateCategoryJson request = CashFlowDto.CreateCategoryJson.builder()
+                .category(categoryName)
+                .type(type)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/" + cashFlowId + "/category?isImport=" + isImport,
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Archives category expecting an error response.
+     */
+    public ResponseEntity<ApiError> archiveCategoryExpectingError(String cashFlowId, String categoryName,
+                                                                   Type categoryType, boolean forceArchiveChildren) {
+        CashFlowDto.ArchiveCategoryJson request = CashFlowDto.ArchiveCategoryJson.builder()
+                .categoryName(categoryName)
+                .categoryType(categoryType)
+                .forceArchiveChildren(forceArchiveChildren)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/" + cashFlowId + "/category/archive",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Unarchives category expecting an error response.
+     */
+    public ResponseEntity<ApiError> unarchiveCategoryExpectingError(String cashFlowId, String categoryName,
+                                                                     Type categoryType) {
+        CashFlowDto.UnarchiveCategoryJson request = CashFlowDto.UnarchiveCategoryJson.builder()
+                .categoryName(categoryName)
+                .categoryType(categoryType)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/" + cashFlowId + "/category/unarchive",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Sets budgeting expecting an error response.
+     */
+    public ResponseEntity<ApiError> setBudgetingExpectingError(String cashFlowId, String categoryName,
+                                                                Type categoryType, Money budget) {
+        CashFlowDto.SetBudgetingJson request = CashFlowDto.SetBudgetingJson.builder()
+                .cashFlowId(cashFlowId)
+                .categoryName(categoryName)
+                .categoryType(categoryType)
+                .budget(budget)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/budgeting",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Updates budgeting expecting an error response.
+     */
+    public ResponseEntity<ApiError> updateBudgetingExpectingError(String cashFlowId, String categoryName,
+                                                                   Type categoryType, Money newBudget) {
+        CashFlowDto.UpdateBudgetingJson request = CashFlowDto.UpdateBudgetingJson.builder()
+                .cashFlowId(cashFlowId)
+                .categoryName(categoryName)
+                .categoryType(categoryType)
+                .newBudget(newBudget)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/budgeting",
+                HttpMethod.PUT,
+                request
+        );
+    }
+
+    /**
+     * Removes budgeting expecting an error response.
+     */
+    public ResponseEntity<ApiError> removeBudgetingExpectingError(String cashFlowId, String categoryName,
+                                                                   Type categoryType) {
+        CashFlowDto.RemoveBudgetingJson request = CashFlowDto.RemoveBudgetingJson.builder()
+                .cashFlowId(cashFlowId)
+                .categoryName(categoryName)
+                .categoryType(categoryType)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/budgeting",
+                HttpMethod.DELETE,
+                request
+        );
+    }
+
+    /**
+     * Imports historical transaction expecting an error response.
+     */
+    public ResponseEntity<ApiError> importHistoricalTransactionExpectingError(String cashFlowId, String categoryName,
+                                                                               String name, String description,
+                                                                               Money money, Type type,
+                                                                               ZonedDateTime dueDate, ZonedDateTime paidDate) {
+        CashFlowDto.ImportHistoricalCashChangeJson request = CashFlowDto.ImportHistoricalCashChangeJson.builder()
+                .category(categoryName)
+                .name(name)
+                .description(description)
+                .money(money)
+                .type(type)
+                .dueDate(dueDate)
+                .paidDate(paidDate)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/" + cashFlowId + "/import-historical",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Rollbacks import expecting an error response.
+     * Note: DELETE with body can cause issues, so we use null body for simple cases.
+     */
+    public ResponseEntity<ApiError> rollbackImportExpectingError(String cashFlowId) {
+        return executeExpectingError(
+                baseUrl + "/cash-flow/" + cashFlowId + "/import",
+                HttpMethod.DELETE,
+                null
+        );
+    }
+
+    // ============ Success Operations (for test setup) ============
+
+    /**
+     * Appends expected cash change via HTTP.
+     */
+    public String appendExpectedCashChange(String cashFlowId, String category, String name,
+                                           String description, Money money, Type type, ZonedDateTime dueDate) {
+        CashFlowDto.AppendExpectedCashChangeJson request = CashFlowDto.AppendExpectedCashChangeJson.builder()
+                .cashFlowId(cashFlowId)
+                .category(category)
+                .name(name)
+                .description(description)
+                .money(money)
+                .type(type)
+                .dueDate(dueDate)
+                .build();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/expected-cash-change",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        return response.getBody();
+    }
+
+    /**
+     * Appends paid cash change via HTTP.
+     */
+    public String appendPaidCashChange(String cashFlowId, String category, String name,
+                                       String description, Money money, Type type,
+                                       ZonedDateTime dueDate, ZonedDateTime paidDate) {
+        CashFlowDto.AppendPaidCashChangeJson request = CashFlowDto.AppendPaidCashChangeJson.builder()
+                .cashFlowId(cashFlowId)
+                .category(category)
+                .name(name)
+                .description(description)
+                .money(money)
+                .type(type)
+                .dueDate(dueDate)
+                .paidDate(paidDate)
+                .build();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/paid-cash-change",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        return response.getBody();
+    }
+
+    /**
+     * Confirms cash change via HTTP.
+     */
+    public void confirmCashChange(String cashFlowId, String cashChangeId) {
+        CashFlowDto.ConfirmCashChangeJson request = CashFlowDto.ConfirmCashChangeJson.builder()
+                .cashFlowId(cashFlowId)
+                .cashChangeId(cashChangeId)
+                .build();
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/confirm",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    /**
+     * Archives category via HTTP.
+     */
+    public void archiveCategory(String cashFlowId, String categoryName, Type categoryType, boolean forceArchiveChildren) {
+        CashFlowDto.ArchiveCategoryJson request = CashFlowDto.ArchiveCategoryJson.builder()
+                .categoryName(categoryName)
+                .categoryType(categoryType)
+                .forceArchiveChildren(forceArchiveChildren)
+                .build();
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/" + cashFlowId + "/category/archive",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    /**
+     * Sets budgeting via HTTP.
+     */
+    public void setBudgeting(String cashFlowId, String categoryName, Type categoryType, Money budget) {
+        CashFlowDto.SetBudgetingJson request = CashFlowDto.SetBudgetingJson.builder()
+                .cashFlowId(cashFlowId)
+                .categoryName(categoryName)
+                .categoryType(categoryType)
+                .budget(budget)
+                .build();
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/budgeting",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    /**
+     * Creates a standard CashFlow (not with history) via HTTP.
+     */
+    public String createCashFlow(String userId, String name, String currency) {
+        CashFlowDto.CreateCashFlowJson request = CashFlowDto.CreateCashFlowJson.builder()
+                .userId(userId)
+                .name(name)
+                .description("CashFlow for HTTP integration testing")
+                .bankAccount(new BankAccount(
+                        new BankName("Test Bank"),
+                        new BankAccountNumber("PL12345678901234567890123456", Currency.of(currency)),
+                        Money.zero(currency)
+                ))
+                .build();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/cash-flow",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String cashFlowId = response.getBody();
+        assertThat(cashFlowId).isNotNull().isNotEmpty();
+
+        log.info("Created CashFlow via HTTP: id={}, name={}", cashFlowId, name);
+        return cashFlowId;
+    }
+
     // ============ Helper Methods ============
+
+    private <T> ResponseEntity<ApiError> executeExpectingError(String url, HttpMethod method, T body) {
+        HttpEntity<T> entity = body != null ? new HttpEntity<>(body, jsonHeaders()) : new HttpEntity<>(jsonHeaders());
+
+        try {
+            ResponseEntity<ApiError> response = rawRestTemplate.exchange(
+                    url,
+                    method,
+                    entity,
+                    ApiError.class
+            );
+            return response;
+        } catch (HttpClientErrorException e) {
+            return ResponseEntity.status(e.getStatusCode())
+                    .body(e.getResponseBodyAs(ApiError.class));
+        }
+    }
 
     private HttpHeaders jsonHeaders() {
         HttpHeaders headers = new HttpHeaders();


### PR DESCRIPTION
  ## Summary
  - Add standardized HTTP error responses for all CashFlow domain exceptions
  - Add Bean Validation (`@Valid`) for `/confirm`, `/edit`, `/reject` endpoints
  - Add comprehensive integration tests for error handling scenarios

