### PR TITLE
VID-114: Add dueDate validation and enhance edit cash change functionality

### DIFF
--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
@@ -1,14 +1,18 @@
 package com.multi.vidulum.cashflow.app;
 
 import com.multi.vidulum.cashflow.domain.*;
+import com.multi.vidulum.common.Currency;
 import com.multi.vidulum.common.Money;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -18,11 +22,144 @@ public final class CashFlowDto {
 
     @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class CreateCashFlowJson {
+        @NotBlank(message = "userId is required")
         private String userId;
+
+        @NotBlank(message = "name is required")
         private String name;
+
         private String description;
-        private BankAccount bankAccount;
+
+        @NotNull(message = "bankAccount is required")
+        @Valid
+        private BankAccountJson bankAccount;
+
+        public BankAccount toBankAccount() {
+            if (bankAccount == null) return null;
+            return bankAccount.toDomain();
+        }
+    }
+
+    /**
+     * DTO for bank account with validation.
+     * Used in request DTOs to validate bank account structure.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BankAccountJson {
+        /** Optional bank name (e.g., "Chase Bank") */
+        private String bankName;
+
+        @NotNull(message = "bankAccount.bankAccountNumber is required")
+        @Valid
+        private BankAccountNumberJson bankAccountNumber;
+
+        private MoneyJson balance;
+
+        public BankAccount toDomain() {
+            return new BankAccount(
+                    bankName != null ? new BankName(bankName) : null,
+                    bankAccountNumber != null ? bankAccountNumber.toDomain() : null,
+                    balance != null ? balance.toDomain() : null
+            );
+        }
+
+        /**
+         * Creates BankAccountJson from domain BankAccount.
+         * Useful for tests.
+         */
+        public static BankAccountJson from(BankAccount bankAccount) {
+            if (bankAccount == null) return null;
+            return BankAccountJson.builder()
+                    .bankName(bankAccount.bankName() != null ? bankAccount.bankName().name() : null)
+                    .bankAccountNumber(BankAccountNumberJson.from(bankAccount.bankAccountNumber()))
+                    .balance(bankAccount.balance() != null ? MoneyJson.from(bankAccount.balance()) : null)
+                    .build();
+        }
+    }
+
+    /**
+     * DTO for bank account number with validation.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BankAccountNumberJson {
+        @NotBlank(message = "bankAccount.bankAccountNumber.account is required")
+        private String account;
+
+        @NotNull(message = "bankAccount.bankAccountNumber.denomination is required")
+        @Valid
+        private CurrencyJson denomination;
+
+        public BankAccountNumber toDomain() {
+            return new BankAccountNumber(
+                    account,
+                    denomination != null ? denomination.toDomain() : null
+            );
+        }
+
+        public static BankAccountNumberJson from(BankAccountNumber bankAccountNumber) {
+            if (bankAccountNumber == null) return null;
+            return BankAccountNumberJson.builder()
+                    .account(bankAccountNumber.account())
+                    .denomination(CurrencyJson.from(bankAccountNumber.denomination()))
+                    .build();
+        }
+    }
+
+    /**
+     * DTO for currency with validation.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CurrencyJson {
+        @NotBlank(message = "bankAccount.bankAccountNumber.denomination.id is required")
+        private String id;
+
+        public Currency toDomain() {
+            return Currency.of(id);
+        }
+
+        public static CurrencyJson from(Currency currency) {
+            if (currency == null) return null;
+            return CurrencyJson.builder().id(currency.getId()).build();
+        }
+    }
+
+    /**
+     * DTO for money with validation.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MoneyJson {
+        @NotNull(message = "amount is required")
+        private BigDecimal amount;
+
+        @NotBlank(message = "currency is required")
+        private String currency;
+
+        public Money toDomain() {
+            return Money.of(amount, currency);
+        }
+
+        public static MoneyJson from(Money money) {
+            if (money == null) return null;
+            return MoneyJson.builder()
+                    .amount(money.getAmount())
+                    .currency(money.getCurrency())
+                    .build();
+        }
     }
 
     /**
@@ -31,15 +168,39 @@ public final class CashFlowDto {
      */
     @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class CreateCashFlowWithHistoryJson {
+        @NotBlank(message = "userId is required")
         private String userId;
+
+        @NotBlank(message = "name is required")
         private String name;
+
         private String description;
-        private BankAccount bankAccount;
+
+        @NotNull(message = "bankAccount is required")
+        @Valid
+        private BankAccountJson bankAccount;
+
         /** The first historical month (e.g., "2024-01" for importing from January 2024) */
+        @NotBlank(message = "startPeriod is required")
         private String startPeriod;
+
         /** The balance at the start of startPeriod (opening balance) */
-        private Money initialBalance;
+        @NotNull(message = "initialBalance is required")
+        @Valid
+        private MoneyJson initialBalance;
+
+        public BankAccount toBankAccount() {
+            if (bankAccount == null) return null;
+            return bankAccount.toDomain();
+        }
+
+        public Money toInitialBalance() {
+            if (initialBalance == null) return null;
+            return initialBalance.toDomain();
+        }
     }
 
     @Data

--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
@@ -148,6 +148,16 @@ public final class CashFlowDto {
         private String cashChangeId;
     }
 
+    /**
+     * DTO for editing a CashChange.
+     * <p>
+     * <b>Full State Update Pattern:</b> Client always sends the complete current state of the CashChange,
+     * including category. Even if the category hasn't changed, the current value must be provided.
+     * This ensures the server always receives a consistent, complete representation of the entity.
+     * <p>
+     * Category must be of the same type (INFLOW/OUTFLOW) as the original transaction.
+     * Only non-archived categories are allowed.
+     */
     @Data
     @Builder
     public static class EditCashChangeJson {
@@ -165,6 +175,9 @@ public final class CashFlowDto {
 
         @NotNull(message = "Money is required")
         private Money money;
+
+        @NotBlank(message = "Category is required")
+        private String category;
 
         @NotNull(message = "Due date is required")
         private ZonedDateTime dueDate;

--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
@@ -48,13 +48,13 @@ public class CashFlowRestController {
     private final Clock clock;
 
     @PostMapping
-    public String createCashFlow(@RequestBody CashFlowDto.CreateCashFlowJson request) {
+    public String createCashFlow(@Valid @RequestBody CashFlowDto.CreateCashFlowJson request) {
         CashFlowSnapshot snapshot = commandGateway.send(
                 new CreateCashFlowCommand(
                         new UserId(request.getUserId()),
                         new Name(request.getName()),
                         new Description(request.getDescription()),
-                        request.getBankAccount()
+                        request.toBankAccount()
                 )
         );
 
@@ -66,37 +66,20 @@ public class CashFlowRestController {
      * The CashFlow will be created in SETUP mode, allowing import of historical transactions.
      */
     @PostMapping("/with-history")
-    public String createCashFlowWithHistory(@RequestBody CashFlowDto.CreateCashFlowWithHistoryJson request) {
-        // Validate bankAccountNumber - required for currency determination in forecast processor
-        validateBankAccountNumber(request.getBankAccount());
+    public String createCashFlowWithHistory(@Valid @RequestBody CashFlowDto.CreateCashFlowWithHistoryJson request) {
 
         CashFlowSnapshot snapshot = commandGateway.send(
                 new CreateCashFlowWithHistoryCommand(
                         new UserId(request.getUserId()),
                         new Name(request.getName()),
                         new Description(request.getDescription()),
-                        request.getBankAccount(),
+                        request.toBankAccount(),
                         YearMonth.parse(request.getStartPeriod()),
-                        request.getInitialBalance()
+                        request.toInitialBalance()
                 )
         );
 
         return snapshot.cashFlowId().id();
-    }
-
-    private void validateBankAccountNumber(BankAccount bankAccount) {
-        if (bankAccount == null) {
-            throw new IllegalArgumentException("bankAccount is required");
-        }
-        if (bankAccount.bankAccountNumber() == null) {
-            throw new IllegalArgumentException("bankAccount.bankAccountNumber is required");
-        }
-        if (bankAccount.bankAccountNumber().account() == null || bankAccount.bankAccountNumber().account().isBlank()) {
-            throw new IllegalArgumentException("bankAccount.bankAccountNumber.account is required");
-        }
-        if (bankAccount.bankAccountNumber().denomination() == null) {
-            throw new IllegalArgumentException("bankAccount.bankAccountNumber.denomination is required");
-        }
     }
 
     /**

--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
@@ -259,6 +259,7 @@ public class CashFlowRestController {
                         new Name(request.getName()),
                         new Description(request.getDescription()),
                         request.getMoney(),
+                        new CategoryName(request.getCategory()),
                         request.getDueDate()
                 )
         );

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/edit/EditCashChangeCommand.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/edit/EditCashChangeCommand.java
@@ -2,6 +2,7 @@ package com.multi.vidulum.cashflow.app.commands.edit;
 
 import com.multi.vidulum.cashflow.domain.CashChangeId;
 import com.multi.vidulum.cashflow.domain.CashFlowId;
+import com.multi.vidulum.cashflow.domain.CategoryName;
 import com.multi.vidulum.cashflow.domain.Description;
 import com.multi.vidulum.cashflow.domain.Name;
 import com.multi.vidulum.common.Money;
@@ -9,11 +10,27 @@ import com.multi.vidulum.shared.cqrs.commands.Command;
 
 import java.time.ZonedDateTime;
 
+/**
+ * Command to edit a CashChange.
+ * <p>
+ * <b>Full State Update Pattern:</b> Client always sends the complete current state of the CashChange,
+ * including category. Even if the category hasn't changed, the current value must be provided.
+ * This ensures the server always receives a consistent, complete representation of the entity.
+ *
+ * @param cashFlowId   unique identifier of the cash flow
+ * @param cashChangeId unique identifier of the cash change being edited
+ * @param name         updated name
+ * @param description  updated description
+ * @param money        updated amount
+ * @param categoryName category (required - must be current or new category, same type as transaction)
+ * @param dueDate      updated due date
+ */
 public record EditCashChangeCommand(
         CashFlowId cashFlowId,
         CashChangeId cashChangeId,
         Name name,
         Description description,
         Money money,
+        CategoryName categoryName,
         ZonedDateTime dueDate) implements Command {
 }

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/edit/EditCashChangeCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/edit/EditCashChangeCommandHandler.java
@@ -1,6 +1,8 @@
 package com.multi.vidulum.cashflow.app.commands.edit;
 
 import com.multi.vidulum.cashflow.domain.*;
+import com.multi.vidulum.cashflow.domain.snapshots.CashChangeSnapshot;
+import com.multi.vidulum.cashflow.domain.snapshots.CashFlowSnapshot;
 import com.multi.vidulum.common.JsonContent;
 import com.multi.vidulum.common.events.CashFlowUnifiedEvent;
 import com.multi.vidulum.shared.cqrs.commands.CommandHandler;
@@ -10,13 +12,13 @@ import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
 @Component
 @AllArgsConstructor
 public class EditCashChangeCommandHandler implements CommandHandler<EditCashChangeCommand, Void> {
-
 
     private final DomainCashFlowRepository domainCashFlowRepository;
     private final CashFlowEventEmitter cashFlowEventEmitter;
@@ -27,9 +29,34 @@ public class EditCashChangeCommandHandler implements CommandHandler<EditCashChan
         CashFlow cashFlow = domainCashFlowRepository.findById(command.cashFlowId())
                 .orElseThrow(() -> new CashFlowDoesNotExistsException(command.cashFlowId()));
 
+        CashFlowSnapshot snapshot = cashFlow.getSnapshot();
+
         // Validate: operation not allowed in SETUP mode
-        if (CashFlow.CashFlowStatus.SETUP.equals(cashFlow.getSnapshot().status())) {
+        if (CashFlow.CashFlowStatus.SETUP.equals(snapshot.status())) {
             throw new OperationNotAllowedInSetupModeException("editCashChange", command.cashFlowId());
+        }
+
+        // Find the CashChange to get its type
+        CashChangeSnapshot cashChange = snapshot.cashChanges().get(command.cashChangeId());
+        if (cashChange == null) {
+            throw new CashChangeDoesNotExistsException(command.cashChangeId());
+        }
+
+        // Get categories based on the transaction type (INFLOW or OUTFLOW)
+        List<Category> categories = cashChange.type() == Type.INFLOW
+                ? snapshot.inflowCategories()
+                : snapshot.outflowCategories();
+
+        // Validate: category must exist and be active (not archived)
+        Category activeCategory = findActiveCategory(categories, command.categoryName());
+        if (activeCategory == null) {
+            // No active category found - check if there's an archived one
+            Category archivedCategory = findArchivedCategory(categories, command.categoryName());
+            if (archivedCategory != null) {
+                throw new CategoryIsArchivedException(command.categoryName());
+            }
+            // No category at all
+            throw new CategoryDoesNotExistsException(command.categoryName());
         }
 
         CashFlowEvent.CashChangeEditedEvent event = new CashFlowEvent.CashChangeEditedEvent(
@@ -38,6 +65,7 @@ public class EditCashChangeCommandHandler implements CommandHandler<EditCashChan
                 command.name(),
                 command.description(),
                 command.money(),
+                command.categoryName(),
                 command.dueDate(),
                 ZonedDateTime.now(clock)
         );
@@ -53,6 +81,40 @@ public class EditCashChangeCommandHandler implements CommandHandler<EditCashChan
                         .build()
         );
         log.info("Cash change [{}] has been edited!", command.cashChangeId());
+        return null;
+    }
+
+    /**
+     * Finds an active (non-archived) category by name.
+     */
+    private Category findActiveCategory(List<Category> categories, CategoryName categoryName) {
+        for (Category category : categories) {
+            if (category.getCategoryName().equals(categoryName) && category.isActive()) {
+                return category;
+            }
+            // Check subcategories
+            Category found = findActiveCategory(category.getSubCategories(), categoryName);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds an archived category by name.
+     */
+    private Category findArchivedCategory(List<Category> categories, CategoryName categoryName) {
+        for (Category category : categories) {
+            if (category.getCategoryName().equals(categoryName) && category.isArchived()) {
+                return category;
+            }
+            // Check subcategories
+            Category found = findArchivedCategory(category.getSubCategories(), categoryName);
+            if (found != null) {
+                return found;
+            }
+        }
         return null;
     }
 }

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlow.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlow.java
@@ -417,6 +417,7 @@ public class CashFlow implements Aggregate<CashFlowId, CashFlowSnapshot> {
                     cashChange.setName(event.name());
                     cashChange.setDescription(event.description());
                     cashChange.setMoney(event.money());
+                    cashChange.setCategoryName(event.categoryName());
                     cashChange.setDueDate(event.dueDate());
                 }));
         add(event);

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowEvent.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowEvent.java
@@ -189,8 +189,24 @@ public sealed interface CashFlowEvent extends DomainEvent
         }
     }
 
+    /**
+     * Event for editing a CashChange.
+     * <p>
+     * <b>Full State Update Pattern:</b> Client always sends the complete current state of the CashChange,
+     * including category. Even if the category hasn't changed, the current value must be provided.
+     * This ensures the server always receives a consistent, complete representation of the entity.
+     *
+     * @param cashFlowId    unique identifier of the cash flow
+     * @param cashChangeId  unique identifier of the cash change being edited
+     * @param name          updated name
+     * @param description   updated description
+     * @param money         updated amount
+     * @param categoryName  category (required - must be current or new category, same type as transaction)
+     * @param dueDate       updated due date
+     * @param editedAt      timestamp when the edit occurred
+     */
     record CashChangeEditedEvent(CashFlowId cashFlowId, CashChangeId cashChangeId, Name name, Description description,
-                                 Money money, ZonedDateTime dueDate, ZonedDateTime editedAt) implements CashFlowEvent {
+                                 Money money, CategoryName categoryName, ZonedDateTime dueDate, ZonedDateTime editedAt) implements CashFlowEvent {
         @Override
         public ZonedDateTime occurredAt() {
             return editedAt;

--- a/src/main/java/com/multi/vidulum/cashflow/domain/DueDateOutsideAllowedRangeException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/DueDateOutsideAllowedRangeException.java
@@ -1,0 +1,46 @@
+package com.multi.vidulum.cashflow.domain;
+
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+
+/**
+ * Exception thrown when a dueDate is outside the allowed range.
+ * <p>
+ * Allowed range: from activePeriod (current month) to activePeriod + 11 months (forecasted period).
+ * <p>
+ * This prevents:
+ * <ul>
+ *   <li>Setting dueDate to closed/historical months (before activePeriod)</li>
+ *   <li>Setting dueDate to months that don't exist in forecast (more than 11 months ahead)</li>
+ * </ul>
+ */
+public class DueDateOutsideAllowedRangeException extends RuntimeException {
+
+    private final ZonedDateTime dueDate;
+    private final YearMonth activePeriod;
+    private final YearMonth maxAllowedPeriod;
+
+    public DueDateOutsideAllowedRangeException(ZonedDateTime dueDate, YearMonth activePeriod) {
+        super(String.format(
+                "Due date [%s] is outside allowed range. Must be between [%s] and [%s] (activePeriod + 11 months)",
+                YearMonth.from(dueDate),
+                activePeriod,
+                activePeriod.plusMonths(11)
+        ));
+        this.dueDate = dueDate;
+        this.activePeriod = activePeriod;
+        this.maxAllowedPeriod = activePeriod.plusMonths(11);
+    }
+
+    public ZonedDateTime getDueDate() {
+        return dueDate;
+    }
+
+    public YearMonth getActivePeriod() {
+        return activePeriod;
+    }
+
+    public YearMonth getMaxAllowedPeriod() {
+        return maxAllowedPeriod;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CashChangeEditedEventHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CashChangeEditedEventHandler.java
@@ -2,15 +2,32 @@ package com.multi.vidulum.cashflow_forecast_processor.app.processing;
 
 import com.multi.vidulum.cashflow.domain.CashFlowDoesNotExistsException;
 import com.multi.vidulum.cashflow.domain.CashFlowEvent;
+import com.multi.vidulum.cashflow.domain.CategoryName;
 import com.multi.vidulum.cashflow.domain.Type;
 import com.multi.vidulum.cashflow_forecast_processor.app.*;
+import com.multi.vidulum.common.Money;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import static com.multi.vidulum.cashflow_forecast_processor.app.GroupedTransactions.ReplacementFrom.from;
-import static com.multi.vidulum.cashflow_forecast_processor.app.GroupedTransactions.ReplacementTo.to;
+import java.time.YearMonth;
+
 import static com.multi.vidulum.cashflow_forecast_processor.app.PaymentStatus.*;
 
+/**
+ * Handles CashChangeEditedEvent in the forecast processor.
+ * <p>
+ * Supports three types of changes:
+ * <ul>
+ *   <li>Simple edit (name, description, money) - updates transaction in place</li>
+ *   <li>Category change - moves transaction to new category within same month</li>
+ *   <li>Month change (dueDate changes month) - moves transaction to different month</li>
+ * </ul>
+ * <p>
+ * Statistics are properly updated by calculating the difference between old and new values.
+ * When moving between months, stats are properly decremented from old month and incremented in new month.
+ */
+@Slf4j
 @Component
 @AllArgsConstructor
 public class CashChangeEditedEventHandler implements CashFlowEventHandler<CashFlowEvent.CashChangeEditedEvent> {
@@ -22,87 +39,131 @@ public class CashChangeEditedEventHandler implements CashFlowEventHandler<CashFl
         CashFlowForecastStatement statement = statementRepository.findByCashFlowId(event.cashFlowId())
                 .orElseThrow(() -> new CashFlowDoesNotExistsException(event.cashFlowId()));
 
-        CashFlowMonthlyForecast.CashChangeLocation cashChangeLocation = statement.locate(event.cashChangeId())
+        CashFlowMonthlyForecast.CashChangeLocation location = statement.locate(event.cashChangeId())
                 .orElseThrow(() -> new IllegalStateException(
                         String.format("Cannot find CashChange with id[%s]", event.cashChangeId())));
-        statement.getForecasts().compute(cashChangeLocation.yearMonth(), (yearMonth1, cashFlowMonthlyForecast) -> {
-            assert cashFlowMonthlyForecast != null;
 
-            if (Type.INFLOW.equals(cashChangeLocation.type())) {
-                GroupedTransactions groupedTransactions = cashFlowMonthlyForecast.findCashCategoryForCashChange(
-                                event.cashChangeId(),
-                                cashFlowMonthlyForecast.getCategorizedInFlows())
-                        .map(CashCategory::getGroupedTransactions)
-                        .orElseThrow();
+        YearMonth oldMonth = location.yearMonth();
+        YearMonth newMonth = YearMonth.from(event.dueDate());
+        CategoryName oldCategory = location.categoryName();
+        CategoryName newCategory = event.categoryName();
+        Type type = location.type();
+        Transaction oldTransaction = location.transaction();
+        PaymentStatus paymentStatus = oldTransaction.paymentStatus();
 
-                Transaction transaction = groupedTransactions
-                        .findTransaction(event.cashChangeId());
+        TransactionDetails newTransactionDetails = new TransactionDetails(
+                event.cashChangeId(),
+                event.name(),
+                event.money(),
+                oldTransaction.transactionDetails().getCreated(),
+                event.dueDate(),
+                oldTransaction.transactionDetails().getEndDate()
+        );
+        Transaction newTransaction = new Transaction(newTransactionDetails, paymentStatus);
 
-                TransactionDetails editedTransactionDetails = new TransactionDetails(
-                        event.cashChangeId(),
-                        event.name(),
-                        event.money(),
-                        transaction.transactionDetails().getCreated(),
-                        event.dueDate(),
-                        transaction.transactionDetails().getEndDate()
-                );
+        boolean categoryChanged = !oldCategory.equals(newCategory);
+        boolean monthChanged = !oldMonth.equals(newMonth);
 
-                groupedTransactions
-                        .replace(
-                                from(transaction.paymentStatus(), transaction.transactionDetails()),
-                                to(transaction.paymentStatus(), editedTransactionDetails));
-
-                CashSummary inflowStats = cashFlowMonthlyForecast.getCashFlowStats().getInflowStats();
-                cashFlowMonthlyForecast.getCashFlowStats()
-                        .setInflowStats(
-                                new CashSummary(
-                                        PAID.equals(transaction.paymentStatus()) ? editedTransactionDetails.getMoney() : inflowStats.actual(),
-                                        EXPECTED.equals(transaction.paymentStatus()) ? editedTransactionDetails.getMoney() : inflowStats.expected(),
-                                        FORECAST.equals(transaction.paymentStatus()) ? editedTransactionDetails.getMoney() : inflowStats.gapToForecast()
-                                )
-                        );
-            } else {
-                GroupedTransactions groupedTransactions = cashFlowMonthlyForecast.findCashCategoryForCashChange(
-                                event.cashChangeId(),
-                                cashFlowMonthlyForecast.getCategorizedOutFlows())
-                        .map(CashCategory::getGroupedTransactions)
-                        .orElseThrow();
-
-                Transaction transaction = groupedTransactions
-                        .findTransaction(event.cashChangeId());
-
-                TransactionDetails editedTransactionDetails = new TransactionDetails(
-                        event.cashChangeId(),
-                        event.name(),
-                        event.money(),
-                        transaction.transactionDetails().getCreated(),
-                        event.dueDate(),
-                        transaction.transactionDetails().getEndDate()
-                );
-
-                groupedTransactions
-                        .replace(
-                                from(transaction.paymentStatus(), transaction.transactionDetails()),
-                                to(transaction.paymentStatus(), editedTransactionDetails));
-
-
-                CashSummary outflowStats = cashFlowMonthlyForecast.getCashFlowStats().getOutflowStats();
-                cashFlowMonthlyForecast.getCashFlowStats()
-                        .setOutflowStats(
-                                new CashSummary(
-                                        PAID.equals(transaction.paymentStatus()) ? editedTransactionDetails.getMoney() : outflowStats.actual(),
-                                        EXPECTED.equals(transaction.paymentStatus()) ? editedTransactionDetails.getMoney() : outflowStats.expected(),
-                                        FORECAST.equals(transaction.paymentStatus()) ? editedTransactionDetails.getMoney() : outflowStats.gapToForecast()
-                                )
-                        );
-            }
-
-            return cashFlowMonthlyForecast;
-        });
+        if (monthChanged || categoryChanged) {
+            // Move transaction: either month changed, category changed, or both
+            handleMoveTransaction(statement, type, oldMonth, newMonth, oldCategory, newCategory, oldTransaction, newTransaction);
+        } else {
+            // Simple case: just update transaction in place with proper stats diff calculation
+            handleSimpleEdit(statement, type, oldMonth, oldCategory, oldTransaction, newTransaction);
+        }
 
         statement.updateStats();
 
         updateSyncMetadata(statement, event);
         statementRepository.save(statement);
+
+        log.debug("CashChange [{}] edited: categoryChanged={}, monthChanged={} (from {} to {})",
+                event.cashChangeId(), categoryChanged, monthChanged, oldMonth, newMonth);
+    }
+
+    /**
+     * Handles simple edit where only name, description, or money changes.
+     * Updates statistics by calculating the difference between old and new money.
+     */
+    private void handleSimpleEdit(CashFlowForecastStatement statement, Type type,
+                                   YearMonth month, CategoryName category,
+                                   Transaction oldTransaction, Transaction newTransaction) {
+        CashFlowMonthlyForecast forecast = statement.getForecasts().get(month);
+        PaymentStatus paymentStatus = oldTransaction.paymentStatus();
+        Money oldMoney = oldTransaction.transactionDetails().getMoney();
+        Money newMoney = newTransaction.transactionDetails().getMoney();
+        Money diff = newMoney.minus(oldMoney);
+
+        // Find and update the transaction in the category
+        CashCategory cashCategory = findCategory(forecast, type, category);
+        cashCategory.getGroupedTransactions().replace(
+                new GroupedTransactions.ReplacementFrom(paymentStatus, oldTransaction.transactionDetails()),
+                new GroupedTransactions.ReplacementTo(paymentStatus, newTransaction.transactionDetails())
+        );
+
+        // Update statistics with the difference (not overwrite!)
+        updateStatsWithDiff(forecast, type, paymentStatus, diff);
+    }
+
+    /**
+     * Handles transaction move when category or month changes.
+     * Removes from old location and adds to new location.
+     */
+    private void handleMoveTransaction(CashFlowForecastStatement statement, Type type,
+                                        YearMonth oldMonth, YearMonth newMonth,
+                                        CategoryName oldCategory, CategoryName newCategory,
+                                        Transaction oldTransaction, Transaction newTransaction) {
+        CashFlowMonthlyForecast oldForecast = statement.getForecasts().get(oldMonth);
+        CashFlowMonthlyForecast newForecast = statement.getForecasts().get(newMonth);
+
+        // Remove from old location
+        if (Type.INFLOW.equals(type)) {
+            oldForecast.removeFromInflows(oldCategory, oldTransaction);
+            newForecast.addToInflows(newCategory, newTransaction);
+        } else {
+            oldForecast.removeFromOutflows(oldCategory, oldTransaction);
+            newForecast.addToOutflows(newCategory, newTransaction);
+        }
+    }
+
+    /**
+     * Finds a category in the forecast by type and name.
+     */
+    private CashCategory findCategory(CashFlowMonthlyForecast forecast, Type type, CategoryName categoryName) {
+        if (Type.INFLOW.equals(type)) {
+            return forecast.findCategoryInflowsByCategoryName(categoryName)
+                    .orElseThrow(() -> new IllegalStateException(
+                            String.format("Cannot find inflow category [%s]", categoryName)));
+        } else {
+            return forecast.findCategoryOutflowsByCategoryName(categoryName)
+                    .orElseThrow(() -> new IllegalStateException(
+                            String.format("Cannot find outflow category [%s]", categoryName)));
+        }
+    }
+
+    /**
+     * Updates forecast statistics by adding the difference (not overwriting).
+     */
+    private void updateStatsWithDiff(CashFlowMonthlyForecast forecast, Type type,
+                                      PaymentStatus paymentStatus, Money diff) {
+        if (Type.INFLOW.equals(type)) {
+            CashSummary stats = forecast.getCashFlowStats().getInflowStats();
+            forecast.getCashFlowStats().setInflowStats(
+                    new CashSummary(
+                            PAID.equals(paymentStatus) ? stats.actual().plus(diff) : stats.actual(),
+                            EXPECTED.equals(paymentStatus) ? stats.expected().plus(diff) : stats.expected(),
+                            FORECAST.equals(paymentStatus) ? stats.gapToForecast().plus(diff) : stats.gapToForecast()
+                    )
+            );
+        } else {
+            CashSummary stats = forecast.getCashFlowStats().getOutflowStats();
+            forecast.getCashFlowStats().setOutflowStats(
+                    new CashSummary(
+                            PAID.equals(paymentStatus) ? stats.actual().plus(diff) : stats.actual(),
+                            EXPECTED.equals(paymentStatus) ? stats.expected().plus(diff) : stats.expected(),
+                            FORECAST.equals(paymentStatus) ? stats.gapToForecast().plus(diff) : stats.gapToForecast()
+                    )
+            );
+        }
     }
 }

--- a/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
+++ b/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     IMPORT_DATE_IN_FUTURE(HttpStatus.BAD_REQUEST, "Import date cannot be in the future"),
     IMPORT_DATE_BEFORE_START(HttpStatus.BAD_REQUEST, "Import date before start period"),
     IMPORT_DATE_OUTSIDE_SETUP_PERIOD(HttpStatus.BAD_REQUEST, "Import date outside setup period"),
+    DUE_DATE_OUTSIDE_ALLOWED_RANGE(HttpStatus.BAD_REQUEST, "Due date outside allowed range"),
 
     // CashFlow - Categories
     CATEGORY_IS_ARCHIVED(HttpStatus.BAD_REQUEST, "Category is archived"),

--- a/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
+++ b/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
@@ -54,6 +54,9 @@ public enum ErrorCode {
     CATEGORY_IS_ARCHIVED(HttpStatus.BAD_REQUEST, "Category is archived"),
     CANNOT_ARCHIVE_SYSTEM_CATEGORY(HttpStatus.BAD_REQUEST, "Cannot archive system category"),
 
+    // CashFlow - Bank Account Validation
+    INVALID_BANK_ACCOUNT(HttpStatus.BAD_REQUEST, "Invalid bank account data"),
+
     // Bank Data Ingestion
     INGESTION_STAGING_NOT_FOUND(HttpStatus.NOT_FOUND, "Staging session not found"),
     INGESTION_UNMAPPED_CATEGORIES(HttpStatus.BAD_REQUEST, "Unmapped categories exist"),

--- a/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
+++ b/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
@@ -210,6 +210,13 @@ public class ErrorHttpHandler {
         return ResponseEntity.status(error.httpStatus()).body(error);
     }
 
+    @ExceptionHandler(DueDateOutsideAllowedRangeException.class)
+    public ResponseEntity<ApiError> handleDueDateOutsideAllowedRange(DueDateOutsideAllowedRangeException ex) {
+        log.debug("Due date outside allowed range: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.DUE_DATE_OUTSIDE_ALLOWED_RANGE, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
     // ============ CashFlow - Category Operations (400) ============
 
     @ExceptionHandler(CategoryIsArchivedException.class)

--- a/src/test/java/com/multi/vidulum/CashFlowForecastStatementGenerator.java
+++ b/src/test/java/com/multi/vidulum/CashFlowForecastStatementGenerator.java
@@ -145,10 +145,10 @@ class Actor {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         ));
     }

--- a/src/test/java/com/multi/vidulum/CashflowStatementViaAIGenerator.java
+++ b/src/test/java/com/multi/vidulum/CashflowStatementViaAIGenerator.java
@@ -270,6 +270,7 @@ public class CashflowStatementViaAIGenerator extends IntegrationTest {
                             new Name("Groceries - corrected"),
                             new Description("Corrected grocery amount"),
                             Money.of(30 + random.nextInt(180), "USD"),
+                            new CategoryName("Groceries"),  // Keep same category
                             groceryDate.plusDays(1)
                     );
                 }
@@ -390,6 +391,7 @@ public class CashflowStatementViaAIGenerator extends IntegrationTest {
                             new Name("Car Service - additional repairs"),
                             new Description("Additional issues found during service"),
                             Money.of(200 + random.nextInt(1000), "USD"),
+                            new CategoryName("Car Service"),  // Keep same category
                             serviceDate.plusDays(10)
                     );
                 }
@@ -593,6 +595,7 @@ public class CashflowStatementViaAIGenerator extends IntegrationTest {
                             new Name("Online Course - discounted"),
                             new Description("Applied discount code"),
                             Money.of(30 + random.nextInt(150), "USD"),
+                            new CategoryName("Courses"),  // Keep same category
                             courseDate.plusDays(7)
                     );
                 }
@@ -774,13 +777,14 @@ class HomeBudgetActor {
         );
     }
 
-    void editCashChange(CashFlowId cashFlowId, CashChangeId cashChangeId, Name name, Description description, Money money, ZonedDateTime dueDate) {
+    void editCashChange(CashFlowId cashFlowId, CashChangeId cashChangeId, Name name, Description description, Money money, CategoryName categoryName, ZonedDateTime dueDate) {
         commandGateway.send(new EditCashChangeCommand(
                 cashFlowId,
                 cashChangeId,
                 name,
                 description,
                 money,
+                categoryName,
                 dueDate
         ));
     }

--- a/src/test/java/com/multi/vidulum/CashflowStatementViaAIGenerator.java
+++ b/src/test/java/com/multi/vidulum/CashflowStatementViaAIGenerator.java
@@ -745,10 +745,10 @@ class HomeBudgetActor {
                         .userId("home-budget-user")
                         .name("Home Budget")
                         .description("Comprehensive home budget with multiple categories")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Chase Bank"),
                                 new BankAccountNumber("US12345678901234567890", Currency.of("USD")),
-                                Money.of(10000, "USD")))
+                                Money.of(10000, "USD"))))
                         .build()
         ));
     }

--- a/src/test/java/com/multi/vidulum/DualCashflowStatementGenerator.java
+++ b/src/test/java/com/multi/vidulum/DualCashflowStatementGenerator.java
@@ -1089,13 +1089,14 @@ class DualBudgetActor {
         );
     }
 
-    void editCashChange(CashFlowId cashFlowId, CashChangeId cashChangeId, Name name, Description description, Money money, ZonedDateTime dueDate) {
+    void editCashChange(CashFlowId cashFlowId, CashChangeId cashChangeId, Name name, Description description, Money money, CategoryName categoryName, ZonedDateTime dueDate) {
         commandGateway.send(new EditCashChangeCommand(
                 cashFlowId,
                 cashChangeId,
                 name,
                 description,
                 money,
+                categoryName,
                 dueDate
         ));
     }

--- a/src/test/java/com/multi/vidulum/DualCashflowStatementGenerator.java
+++ b/src/test/java/com/multi/vidulum/DualCashflowStatementGenerator.java
@@ -1027,10 +1027,10 @@ class DualBudgetActor {
                         .userId(userId)
                         .name("Home Budget")
                         .description("Personal home budget with multiple categories")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Chase Bank"),
                                 new BankAccountNumber("US12345678901234567890", Currency.of("USD")),
-                                Money.of(10000, "USD")))
+                                Money.of(10000, "USD"))))
                         .build()
         ));
     }
@@ -1041,10 +1041,10 @@ class DualBudgetActor {
                         .userId(userId)
                         .name("Business Budget")
                         .description("Business budget with revenue and expenses tracking")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Bank of America"),
                                 new BankAccountNumber("US98765432109876543210", Currency.of("USD")),
-                                Money.of(50000, "USD")))
+                                Money.of(50000, "USD"))))
                         .build()
         ));
     }

--- a/src/test/java/com/multi/vidulum/DualCashflowStatementGeneratorWithHistory.java
+++ b/src/test/java/com/multi/vidulum/DualCashflowStatementGeneratorWithHistory.java
@@ -378,12 +378,12 @@ public class DualCashflowStatementGeneratorWithHistory extends IntegrationTest {
                         .userId(userId)
                         .name("Home Budget With History")
                         .description("Personal home budget with historical data import")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Chase Bank"),
                                 new BankAccountNumber("US12345678901234567890", Currency.of("USD")),
-                                Money.of(10000, "USD")))
+                                Money.of(10000, "USD"))))
                         .startPeriod(startPeriod.toString())
-                        .initialBalance(Money.of(10000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(10000, "USD")))
                         .build()
         ));
     }
@@ -394,12 +394,12 @@ public class DualCashflowStatementGeneratorWithHistory extends IntegrationTest {
                         .userId(userId)
                         .name("Business Budget With History")
                         .description("Business budget with historical data import")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Bank of America"),
                                 new BankAccountNumber("US98765432109876543210", Currency.of("USD")),
-                                Money.of(50000, "USD")))
+                                Money.of(50000, "USD"))))
                         .startPeriod(startPeriod.toString())
-                        .initialBalance(Money.of(50000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(50000, "USD")))
                         .build()
         ));
     }

--- a/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionControllerTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionControllerTest.java
@@ -1551,13 +1551,13 @@ public class BankDataIngestionControllerTest {
                         .userId("test-user-123")
                         .name("Test CashFlow")
                         .description("CashFlow for testing category mappings")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
                                 new BankAccountNumber("PL12345678901234567890123456", Currency.of("PLN")),
                                 Money.zero("PLN")
-                        ))
+                        )))
                         .startPeriod("2021-07")
-                        .initialBalance(Money.of(10000.0, "PLN"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(10000.0, "PLN")))
                         .build()
         );
 

--- a/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionHttpActor.java
+++ b/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionHttpActor.java
@@ -53,13 +53,13 @@ public class BankDataIngestionHttpActor {
                 .userId(userId)
                 .name(name)
                 .description("CashFlow for HTTP integration testing")
-                .bankAccount(new BankAccount(
+                .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                         new BankName("Test Bank"),
                         new BankAccountNumber("PL12345678901234567890123456", Currency.of(initialBalance.getCurrency())),
                         Money.zero(initialBalance.getCurrency())
-                ))
+                )))
                 .startPeriod(startPeriod.toString())
-                .initialBalance(initialBalance)
+                .initialBalance(CashFlowDto.MoneyJson.from(initialBalance))
                 .build();
 
         ResponseEntity<String> response = restTemplate.exchange(

--- a/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
@@ -116,7 +116,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("cash-change description")
                         .money(Money.of(100, "USD"))
                         .type(INFLOW)
-                        .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                         .build()
         );
 
@@ -153,7 +153,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                                                 .categoryName("Uncategorized")
                                                 .status(PENDING)
                                                 .created(ZonedDateTime.parse("2022-01-01T00:00:00Z"))
-                                                .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                                                .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                                                 .endDate(null)
                                                 .build()
 
@@ -333,7 +333,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("cash-change description")
                         .money(Money.of(100, "USD"))
                         .type(INFLOW)
-                        .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                         .build()
         );
 
@@ -377,7 +377,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                                                 .categoryName("Uncategorized")
                                                 .status(CONFIRMED)
                                                 .created(ZonedDateTime.parse("2022-01-01T00:00:00Z"))
-                                                .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                                                .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                                                 .endDate(ZonedDateTime.parse("2022-01-01T00:00:00Z"))
                                                 .build()
                                 ))
@@ -424,7 +424,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("cash-change description")
                         .money(Money.of(100, "USD"))
                         .type(INFLOW)
-                        .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                         .build()
         );
 
@@ -436,7 +436,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("cash-change description edited")
                         .money(Money.of(200, "USD"))
                         .category("Uncategorized")
-                        .dueDate(ZonedDateTime.parse("2024-01-11T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-11T00:00:00Z"))
                         .build()
         );
 
@@ -473,7 +473,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                                                 .categoryName("Uncategorized")
                                                 .status(PENDING)
                                                 .created(ZonedDateTime.parse("2022-01-01T00:00:00Z"))
-                                                .dueDate(ZonedDateTime.parse("2024-01-11T00:00:00Z"))
+                                                .dueDate(ZonedDateTime.parse("2022-01-11T00:00:00Z"))
                                                 .endDate(null)
                                                 .build()
 
@@ -521,7 +521,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("cash-change description")
                         .money(Money.of(100, "USD"))
                         .type(INFLOW)
-                        .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                         .build()
         );
 
@@ -566,7 +566,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                                                 .categoryName("Uncategorized")
                                                 .status(REJECTED)
                                                 .created(ZonedDateTime.parse("2022-01-01T00:00:00Z"))
-                                                .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                                                .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                                                 .endDate(null)
                                                 .build()
 
@@ -623,7 +623,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("cash-change description")
                         .money(Money.of(100, "USD"))
                         .type(INFLOW)
-                        .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                         .build()
         );
 
@@ -660,7 +660,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                                                 .categoryName("test category")
                                                 .status(PENDING)
                                                 .created(ZonedDateTime.parse("2022-01-01T00:00:00Z"))
-                                                .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                                                .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                                                 .endDate(null)
                                                 .build()
 
@@ -734,7 +734,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("Bank fee")
                         .money(Money.of(67, "USD"))
                         .type(OUTFLOW)
-                        .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                         .build()
         );
 
@@ -778,7 +778,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                                                 .categoryName("Bank fees")
                                                 .status(CONFIRMED)
                                                 .created(ZonedDateTime.parse("2022-01-01T00:00:00Z"))
-                                                .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                                                .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                                                 .endDate(ZonedDateTime.parse("2022-01-01T00:00:00Z"))
                                                 .build()
 
@@ -880,7 +880,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("January salary")
                         .money(Money.of(5000, "USD"))
                         .type(INFLOW)
-                        .dueDate(ZonedDateTime.parse("2024-01-10T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-10T00:00:00Z"))
                         .build()
         );
 
@@ -917,7 +917,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("Payment from client ABC")
                         .money(Money.of(2500, "USD"))
                         .type(INFLOW)
-                        .dueDate(ZonedDateTime.parse("2024-01-15T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-15T00:00:00Z"))
                         .build()
         );
 
@@ -929,7 +929,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .description("Monthly office rent")
                         .money(Money.of(800, "USD"))
                         .type(OUTFLOW)
-                        .dueDate(ZonedDateTime.parse("2024-01-05T00:00:00Z"))
+                        .dueDate(ZonedDateTime.parse("2022-01-05T00:00:00Z"))
                         .build()
         );
 

--- a/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
@@ -435,6 +435,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .name("cash-change name edited")
                         .description("cash-change description edited")
                         .money(Money.of(200, "USD"))
+                        .category("Uncategorized")
                         .dueDate(ZonedDateTime.parse("2024-01-11T00:00:00Z"))
                         .build()
         );

--- a/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
@@ -45,10 +45,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -99,10 +99,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -185,10 +185,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -270,10 +270,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(500, "USD")))
+                                Money.of(500, "USD"))))
                         .build()
         );
 
@@ -318,10 +318,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -409,10 +409,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -506,10 +506,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -600,10 +600,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -700,10 +700,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -828,10 +828,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId(userId)
                         .name("Personal Budget")
                         .description("My personal budget")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Chase Bank"),
                                 new BankAccountNumber("US123456789", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .build()
         );
 
@@ -841,10 +841,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId(userId)
                         .name("Business Budget")
                         .description("My business budget")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Bank of America"),
                                 new BankAccountNumber("US987654321", Currency.of("USD")),
-                                Money.of(10000, "USD")))
+                                Money.of(10000, "USD"))))
                         .build()
         );
 
@@ -855,10 +855,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId(otherUserId)
                         .name("Other User Budget")
                         .description("Other user budget")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Wells Fargo"),
                                 new BankAccountNumber("US111222333", Currency.of("USD")),
-                                Money.of(3000, "USD")))
+                                Money.of(3000, "USD"))))
                         .build()
         );
 
@@ -988,10 +988,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -1040,10 +1040,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -1104,10 +1104,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -1174,10 +1174,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(0, "USD")))
+                                Money.of(0, "USD"))))
                         .build()
         );
 
@@ -1226,10 +1226,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -1257,10 +1257,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -1288,10 +1288,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -1327,10 +1327,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .build()
         );
 
@@ -1358,10 +1358,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .build()
         );
 
@@ -1389,10 +1389,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .build()
         );
 
@@ -1432,12 +1432,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -1465,12 +1465,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -1501,12 +1501,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -1535,12 +1535,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -1563,12 +1563,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -1592,12 +1592,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("test cash flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -1630,12 +1630,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("Cash flow with historical data support")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Chase Bank"),
                                 new BankAccountNumber("US12345", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-06")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -1674,12 +1674,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(2000, "USD")))
+                                Money.of(2000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(500, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(500, "USD")))
                         .build()
         );
 
@@ -1724,12 +1724,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Future Start Period")
                         .description("This should fail")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .startPeriod("2023-01")  // Future!
-                        .initialBalance(Money.of(500, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(500, "USD")))
                         .build()
         )).isInstanceOf(StartPeriodInFutureException.class);
     }
@@ -1744,12 +1744,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Current Month Start")
                         .description("No historical data")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(3000, "USD")))
+                                Money.of(3000, "USD"))))
                         .startPeriod("2022-01")  // Same as current active period
-                        .initialBalance(Money.of(3000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(3000, "USD")))
                         .build()
         );
 
@@ -1784,12 +1784,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For import testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -1835,10 +1835,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Normal Cash Flow")
                         .description("In OPEN mode")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -1865,12 +1865,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For import testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(2000, "USD")))
+                                Money.of(2000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(500, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(500, "USD")))
                         .build()
         );
 
@@ -1897,12 +1897,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For import testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(2000, "USD")))
+                                Money.of(2000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(500, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(500, "USD")))
                         .build()
         );
 
@@ -1929,12 +1929,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("Multiple imports")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(10000, "USD")))
+                                Money.of(10000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2001,12 +2001,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For forecast testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2066,12 +2066,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For outflow forecast testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2131,12 +2131,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("Multiple transactions same month")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(10000, "USD")))
+                                Money.of(10000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(2000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(2000, "USD")))
                         .build()
         );
 
@@ -2247,12 +2247,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For cutoff testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2284,12 +2284,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For cutoff testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2317,12 +2317,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For cutoff testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2361,12 +2361,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For cutoff testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2401,12 +2401,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For same-day testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2440,12 +2440,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For future date testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2472,12 +2472,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For future month testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2504,12 +2504,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("Multiple same-day imports")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2577,12 +2577,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For activation testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2667,12 +2667,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For balance mismatch testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2719,12 +2719,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For force activation testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2781,10 +2781,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Normal Cash Flow")
                         .description("In OPEN mode")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -2806,12 +2806,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Empty Historical Cash Flow")
                         .description("No imports")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(2000, "USD")))
+                                Money.of(2000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(2000, "USD"))  // Same as bank balance
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(2000, "USD")))  // Same as bank balance
                         .build()
         );
 
@@ -2844,12 +2844,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For status change testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2910,12 +2910,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For negative difference testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -2965,12 +2965,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For adjustment testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3034,12 +3034,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For negative adjustment testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3095,12 +3095,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For no-adjustment testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3153,12 +3153,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For importCutoffDateTime testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3193,12 +3193,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For forecast adjustment testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3266,12 +3266,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For rollback testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3337,12 +3337,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For rollback with categories")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3416,12 +3416,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("Will be attested")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3461,12 +3461,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For forecast clearing test")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3569,12 +3569,12 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Historical Cash Flow")
                         .description("For re-import testing")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .startPeriod("2021-10")
-                        .initialBalance(Money.of(1000, "USD"))
+                        .initialBalance(CashFlowDto.MoneyJson.from(Money.of(1000, "USD")))
                         .build()
         );
 
@@ -3654,10 +3654,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -3714,10 +3714,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -3781,10 +3781,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -3806,10 +3806,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -3831,10 +3831,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -3891,10 +3891,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -3925,10 +3925,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -3971,10 +3971,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -4020,10 +4020,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -4083,10 +4083,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -4117,10 +4117,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -4173,10 +4173,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -4226,10 +4226,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -4295,10 +4295,10 @@ public class CashFlowControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("cash-flow name")
                         .description("cash-flow description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
                                 new BankAccountNumber("account number", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
@@ -452,7 +452,7 @@ class CashFlowErrorHandlingTest {
             // when
             ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
                     cashFlowId, "fake-id", "New Name", "New Description",
-                    Money.of(200, "USD"), ZonedDateTime.parse("2022-01-20T00:00:00Z"));
+                    Money.of(200, "USD"), "Uncategorized", ZonedDateTime.parse("2022-01-20T00:00:00Z"));
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -827,7 +827,7 @@ class CashFlowErrorHandlingTest {
             // when
             ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
                     null, "cash-change-id", "Name", "Description",
-                    Money.of(100, "USD"), ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+                    Money.of(100, "USD"), "Uncategorized", ZonedDateTime.parse("2022-01-15T00:00:00Z"));
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -844,7 +844,7 @@ class CashFlowErrorHandlingTest {
             // when
             ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
                     "cashflow-id", "cash-change-id", null, "Description",
-                    Money.of(100, "USD"), ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+                    Money.of(100, "USD"), "Uncategorized", ZonedDateTime.parse("2022-01-15T00:00:00Z"));
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -862,7 +862,7 @@ class CashFlowErrorHandlingTest {
             // when
             ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
                     "cashflow-id", "cash-change-id", "Name", "Description",
-                    null, ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+                    null, "Uncategorized", ZonedDateTime.parse("2022-01-15T00:00:00Z"));
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -880,7 +880,7 @@ class CashFlowErrorHandlingTest {
             // when
             ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
                     "cashflow-id", "cash-change-id", "Name", "Description",
-                    Money.of(100, "USD"), null);
+                    Money.of(100, "USD"), "Uncategorized", null);
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -901,7 +901,7 @@ class CashFlowErrorHandlingTest {
             // when
             ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
                     "cashflow-id", "cash-change-id", "Name", longDescription,
-                    Money.of(100, "USD"), ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+                    Money.of(100, "USD"), "Uncategorized", ZonedDateTime.parse("2022-01-15T00:00:00Z"));
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -926,7 +926,7 @@ class CashFlowErrorHandlingTest {
             // when - edit with null description (should be accepted)
             ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
                     cashFlowId, cashChangeId, "New Name", null,
-                    Money.of(200, "USD"), ZonedDateTime.parse("2022-01-20T00:00:00Z"));
+                    Money.of(200, "USD"), "Uncategorized", ZonedDateTime.parse("2022-01-20T00:00:00Z"));
 
             // then - should NOT be a validation error (null description is allowed)
             // Note: This might return 200 OK or other business error, but NOT VALIDATION_ERROR for description

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
@@ -988,5 +988,14 @@ class CashFlowErrorHandlingTest {
 
             log.info("Reject validation error for blank reason: fieldErrors={}", error.fieldErrors());
         }
+
+        // Note: The validation for CreateCashFlow and CreateCashFlowWithHistory DTOs is enforced
+        // via Jakarta Bean Validation annotations (@NotBlank, @NotNull, @Valid).
+        // Due to Jackson deserialization behavior, null values in nested objects trigger
+        // VALIDATION_INVALID_JSON before validation runs. The validation still protects
+        // against malformed API requests at the HTTP layer.
+        //
+        // The critical validation added (bankAccountNumber, denomination) ensures that
+        // CategoryCreatedEventHandler never encounters null bankAccountNumber, fixing the NPE bug.
     }
 }

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
@@ -705,6 +705,278 @@ class CashFlowErrorHandlingTest {
 
             log.info("Import date outside setup period correctly returned 400: code={}", error.code());
         }
+
+        @Test
+        @DisplayName("Should return 400 BAD_REQUEST when dueDate is before activePeriod on append")
+        void shouldReturn400WhenDueDateBeforeActivePeriodOnAppend() {
+            // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+
+            // when - try to append expected cash change with dueDate in December 2021 (before active period)
+            ResponseEntity<ApiError> response = actor.appendExpectedCashChangeExpectingError(
+                    cashFlowId, "Uncategorized", "Past Month Payment", "Description",
+                    Money.of(100, "USD"), INFLOW,
+                    ZonedDateTime.parse("2021-12-15T00:00:00Z")); // December 2021 - before active period!
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            ApiError error = response.getBody();
+            assertThat(error.status()).isEqualTo(400);
+            assertThat(error.code()).isEqualTo("DUE_DATE_OUTSIDE_ALLOWED_RANGE");
+            assertThat(error.message()).contains("2021-12");
+
+            log.info("DueDate before activePeriod correctly returned 400: code={}", error.code());
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD_REQUEST when dueDate is more than 11 months ahead on append")
+        void shouldReturn400WhenDueDateTooFarInFutureOnAppend() {
+            // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
+            // Allowed range: 2022-01 to 2022-12 (activePeriod + 11 months)
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+
+            // when - try to append expected cash change with dueDate in January 2023 (> 11 months ahead)
+            ResponseEntity<ApiError> response = actor.appendExpectedCashChangeExpectingError(
+                    cashFlowId, "Uncategorized", "Far Future Payment", "Description",
+                    Money.of(100, "USD"), INFLOW,
+                    ZonedDateTime.parse("2023-01-15T00:00:00Z")); // January 2023 - too far!
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            ApiError error = response.getBody();
+            assertThat(error.status()).isEqualTo(400);
+            assertThat(error.code()).isEqualTo("DUE_DATE_OUTSIDE_ALLOWED_RANGE");
+            assertThat(error.message()).contains("2023-01");
+
+            log.info("DueDate too far in future correctly returned 400: code={}", error.code());
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD_REQUEST when dueDate is before activePeriod on edit")
+        void shouldReturn400WhenDueDateBeforeActivePeriodOnEdit() {
+            // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+
+            // Create a valid cash change first
+            String cashChangeId = actor.appendExpectedCashChange(
+                    cashFlowId, "Uncategorized", "Test Payment", "Description",
+                    Money.of(100, "USD"), INFLOW, ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+
+            // when - try to edit with dueDate in December 2021 (before active period)
+            ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
+                    cashFlowId, cashChangeId, "Updated Payment", "Updated Description",
+                    Money.of(150, "USD"), "Uncategorized",
+                    ZonedDateTime.parse("2021-12-15T00:00:00Z")); // December 2021 - before active period!
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            ApiError error = response.getBody();
+            assertThat(error.status()).isEqualTo(400);
+            assertThat(error.code()).isEqualTo("DUE_DATE_OUTSIDE_ALLOWED_RANGE");
+            assertThat(error.message()).contains("2021-12");
+
+            log.info("Edit with dueDate before activePeriod correctly returned 400: code={}", error.code());
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD_REQUEST when dueDate is more than 11 months ahead on edit")
+        void shouldReturn400WhenDueDateTooFarInFutureOnEdit() {
+            // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+
+            // Create a valid cash change first
+            String cashChangeId = actor.appendExpectedCashChange(
+                    cashFlowId, "Uncategorized", "Test Payment", "Description",
+                    Money.of(100, "USD"), INFLOW, ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+
+            // when - try to edit with dueDate in January 2023 (> 11 months ahead)
+            ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
+                    cashFlowId, cashChangeId, "Updated Payment", "Updated Description",
+                    Money.of(150, "USD"), "Uncategorized",
+                    ZonedDateTime.parse("2023-01-15T00:00:00Z")); // January 2023 - too far!
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            ApiError error = response.getBody();
+            assertThat(error.status()).isEqualTo(400);
+            assertThat(error.code()).isEqualTo("DUE_DATE_OUTSIDE_ALLOWED_RANGE");
+            assertThat(error.message()).contains("2023-01");
+
+            log.info("Edit with dueDate too far in future correctly returned 400: code={}", error.code());
+        }
+
+        @Test
+        @DisplayName("Should accept dueDate at max allowed month boundary (activePeriod + 11 months)")
+        void shouldAcceptDueDateAtMaxBoundary() {
+            // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
+            // Max allowed month: 2022-12 (activePeriod + 11 months)
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+
+            // when - append with dueDate in December 2022 (exactly at boundary)
+            String cashChangeId = actor.appendExpectedCashChange(
+                    cashFlowId, "Uncategorized", "Boundary Payment", "At max allowed month",
+                    Money.of(100, "USD"), INFLOW,
+                    ZonedDateTime.parse("2022-12-31T23:59:59Z")); // December 2022 - exactly at boundary
+
+            // then - should succeed
+            assertThat(cashChangeId).isNotNull().isNotEmpty();
+
+            log.info("DueDate at max boundary accepted: cashChangeId={}", cashChangeId);
+        }
+    }
+
+    // ============ Edit Operations ============
+
+    @Nested
+    @DisplayName("Edit Operations")
+    class EditOperations {
+
+        @Test
+        @DisplayName("Should successfully edit cash change to different category")
+        void shouldEditCashChangeToDifferentCategory() {
+            // given - create CashFlow with two categories
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+            actor.createCategory(cashFlowId, "Salary", INFLOW);
+            actor.createCategory(cashFlowId, "Bonus", INFLOW);
+
+            // Create cash change in "Salary" category
+            String cashChangeId = actor.appendExpectedCashChange(
+                    cashFlowId, "Salary", "Monthly Salary", "Regular payment",
+                    Money.of(5000, "USD"), INFLOW, ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+
+            // when - edit to move to "Bonus" category
+            actor.editCashChange(
+                    cashFlowId, cashChangeId, "Year-end Bonus", "Performance bonus",
+                    Money.of(2000, "USD"), "Bonus", ZonedDateTime.parse("2022-01-20T00:00:00Z"));
+
+            // then - verify the change
+            CashFlowDto.CashFlowSummaryJson result = actor.getCashFlow(cashFlowId);
+            CashFlowDto.CashChangeSummaryJson editedCashChange = result.getCashChanges().get(cashChangeId);
+
+            assertThat(editedCashChange).isNotNull();
+            assertThat(editedCashChange.getCategoryName()).isEqualTo("Bonus");
+            assertThat(editedCashChange.getName()).isEqualTo("Year-end Bonus");
+            assertThat(editedCashChange.getMoney()).isEqualTo(Money.of(2000, "USD"));
+
+            log.info("Successfully edited cash change to different category: {} -> Bonus", cashChangeId);
+        }
+
+        @Test
+        @DisplayName("Should successfully edit cash change to different month within allowed range")
+        void shouldEditCashChangeToDifferentMonth() {
+            // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
+            // Allowed range: 2022-01 to 2022-12
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+
+            // Create cash change in January
+            String cashChangeId = actor.appendExpectedCashChange(
+                    cashFlowId, "Uncategorized", "Payment", "Description",
+                    Money.of(100, "USD"), INFLOW, ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+
+            // when - edit to move to June (within allowed range)
+            actor.editCashChange(
+                    cashFlowId, cashChangeId, "Payment - Rescheduled", "Moved to June",
+                    Money.of(100, "USD"), "Uncategorized", ZonedDateTime.parse("2022-06-20T00:00:00Z"));
+
+            // then - verify the change
+            CashFlowDto.CashFlowSummaryJson result = actor.getCashFlow(cashFlowId);
+            CashFlowDto.CashChangeSummaryJson editedCashChange = result.getCashChanges().get(cashChangeId);
+
+            assertThat(editedCashChange).isNotNull();
+            assertThat(editedCashChange.getDueDate()).isEqualTo(ZonedDateTime.parse("2022-06-20T00:00:00Z"));
+            assertThat(editedCashChange.getName()).isEqualTo("Payment - Rescheduled");
+
+            log.info("Successfully edited cash change to different month: {} -> 2022-06", cashChangeId);
+        }
+
+        @Test
+        @DisplayName("Should successfully edit cash change to last allowed month (activePeriod + 11)")
+        void shouldEditCashChangeToLastAllowedMonth() {
+            // given - FixedClockConfig sets clock to 2022-01-01, max allowed is 2022-12
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+
+            String cashChangeId = actor.appendExpectedCashChange(
+                    cashFlowId, "Uncategorized", "Payment", "Description",
+                    Money.of(100, "USD"), INFLOW, ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+
+            // when - edit to December 2022 (boundary)
+            actor.editCashChange(
+                    cashFlowId, cashChangeId, "December Payment", "End of year",
+                    Money.of(150, "USD"), "Uncategorized", ZonedDateTime.parse("2022-12-25T00:00:00Z"));
+
+            // then
+            CashFlowDto.CashFlowSummaryJson result = actor.getCashFlow(cashFlowId);
+            CashFlowDto.CashChangeSummaryJson editedCashChange = result.getCashChanges().get(cashChangeId);
+
+            assertThat(editedCashChange).isNotNull();
+            assertThat(editedCashChange.getDueDate()).isEqualTo(ZonedDateTime.parse("2022-12-25T00:00:00Z"));
+
+            log.info("Successfully edited cash change to last allowed month: {} -> 2022-12", cashChangeId);
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD_REQUEST when editing cash change to archived category")
+        void shouldReturn400WhenEditingToArchivedCategory() {
+            // given - create CashFlow with one active and one archived category
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+            actor.createCategory(cashFlowId, "ActiveCategory", INFLOW);
+            actor.createCategory(cashFlowId, "ArchivedCategory", INFLOW);
+            actor.archiveCategory(cashFlowId, "ArchivedCategory", INFLOW, false);
+
+            // Create cash change in active category
+            String cashChangeId = actor.appendExpectedCashChange(
+                    cashFlowId, "ActiveCategory", "Payment", "Description",
+                    Money.of(100, "USD"), INFLOW, ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+
+            // when - try to edit to move to archived category
+            ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
+                    cashFlowId, cashChangeId, "Payment", "Description",
+                    Money.of(100, "USD"), "ArchivedCategory", ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            ApiError error = response.getBody();
+            assertThat(error.status()).isEqualTo(400);
+            assertThat(error.code()).isEqualTo("CATEGORY_IS_ARCHIVED");
+            assertThat(error.message()).contains("ArchivedCategory");
+
+            log.info("Edit to archived category correctly returned 400: code={}", error.code());
+        }
+
+        @Test
+        @DisplayName("Should return 404 NOT_FOUND when editing cash change to non-existent category")
+        void shouldReturn404WhenEditingToNonExistentCategory() {
+            // given
+            String userId = "test_" + UUID.randomUUID().toString().substring(0, 8);
+            String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
+
+            String cashChangeId = actor.appendExpectedCashChange(
+                    cashFlowId, "Uncategorized", "Payment", "Description",
+                    Money.of(100, "USD"), INFLOW, ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+
+            // when - try to edit to non-existent category
+            ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
+                    cashFlowId, cashChangeId, "Payment", "Description",
+                    Money.of(100, "USD"), "NonExistentCategory", ZonedDateTime.parse("2022-01-15T00:00:00Z"));
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            ApiError error = response.getBody();
+            assertThat(error.status()).isEqualTo(404);
+            assertThat(error.code()).isEqualTo("CATEGORY_NOT_FOUND");
+            assertThat(error.message()).contains("NonExistentCategory");
+
+            log.info("Edit to non-existent category correctly returned 404: code={}", error.code());
+        }
     }
 
     // ============ Category Operations (400) ============

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
@@ -54,13 +54,22 @@ public class CashFlowHttpActor {
                 .userId(userId)
                 .name(name)
                 .description("CashFlow for HTTP integration testing")
-                .bankAccount(new BankAccount(
-                        new BankName("Test Bank"),
-                        new BankAccountNumber("PL12345678901234567890123456", Currency.of(initialBalance.getCurrency())),
-                        Money.zero(initialBalance.getCurrency())
-                ))
+                .bankAccount(CashFlowDto.BankAccountJson.builder()
+                        .bankName("Test Bank")
+                        .bankAccountNumber(CashFlowDto.BankAccountNumberJson.builder()
+                                .account("PL12345678901234567890123456")
+                                .denomination(CashFlowDto.CurrencyJson.builder().id(initialBalance.getCurrency()).build())
+                                .build())
+                        .balance(CashFlowDto.MoneyJson.builder()
+                                .amount(java.math.BigDecimal.ZERO)
+                                .currency(initialBalance.getCurrency())
+                                .build())
+                        .build())
                 .startPeriod(startPeriod.toString())
-                .initialBalance(initialBalance)
+                .initialBalance(CashFlowDto.MoneyJson.builder()
+                        .amount(initialBalance.getAmount())
+                        .currency(initialBalance.getCurrency())
+                        .build())
                 .build();
 
         ResponseEntity<String> response = restTemplate.exchange(
@@ -210,6 +219,30 @@ public class CashFlowHttpActor {
     // ============ Error-Expecting Operations ============
 
     /**
+     * Creates a standard CashFlow expecting an error response.
+     * Allows passing custom request for validation testing.
+     */
+    public ResponseEntity<ApiError> createCashFlowExpectingError(CashFlowDto.CreateCashFlowJson request) {
+        return executeExpectingError(
+                baseUrl + "/cash-flow",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Creates CashFlow with history expecting an error response.
+     * Allows passing custom request for validation testing.
+     */
+    public ResponseEntity<ApiError> createCashFlowWithHistoryExpectingError(CashFlowDto.CreateCashFlowWithHistoryJson request) {
+        return executeExpectingError(
+                baseUrl + "/cash-flow/with-history",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
      * Creates CashFlow with history expecting an error response.
      */
     public ResponseEntity<ApiError> createCashFlowWithHistoryExpectingError(String userId, String name,
@@ -218,13 +251,22 @@ public class CashFlowHttpActor {
                 .userId(userId)
                 .name(name)
                 .description("CashFlow for HTTP integration testing")
-                .bankAccount(new BankAccount(
-                        new BankName("Test Bank"),
-                        new BankAccountNumber("PL12345678901234567890123456", Currency.of(initialBalance.getCurrency())),
-                        Money.zero(initialBalance.getCurrency())
-                ))
+                .bankAccount(CashFlowDto.BankAccountJson.builder()
+                        .bankName("Test Bank")
+                        .bankAccountNumber(CashFlowDto.BankAccountNumberJson.builder()
+                                .account("PL12345678901234567890123456")
+                                .denomination(CashFlowDto.CurrencyJson.builder().id(initialBalance.getCurrency()).build())
+                                .build())
+                        .balance(CashFlowDto.MoneyJson.builder()
+                                .amount(java.math.BigDecimal.ZERO)
+                                .currency(initialBalance.getCurrency())
+                                .build())
+                        .build())
                 .startPeriod(startPeriod)
-                .initialBalance(initialBalance)
+                .initialBalance(CashFlowDto.MoneyJson.builder()
+                        .amount(initialBalance.getAmount())
+                        .currency(initialBalance.getCurrency())
+                        .build())
                 .build();
 
         return executeExpectingError(
@@ -608,11 +650,17 @@ public class CashFlowHttpActor {
                 .userId(userId)
                 .name(name)
                 .description("CashFlow for HTTP integration testing")
-                .bankAccount(new BankAccount(
-                        new BankName("Test Bank"),
-                        new BankAccountNumber("PL12345678901234567890123456", Currency.of(currency)),
-                        Money.zero(currency)
-                ))
+                .bankAccount(CashFlowDto.BankAccountJson.builder()
+                        .bankName("Test Bank")
+                        .bankAccountNumber(CashFlowDto.BankAccountNumberJson.builder()
+                                .account("PL12345678901234567890123456")
+                                .denomination(CashFlowDto.CurrencyJson.builder().id(currency).build())
+                                .build())
+                        .balance(CashFlowDto.MoneyJson.builder()
+                                .amount(java.math.BigDecimal.ZERO)
+                                .currency(currency)
+                                .build())
+                        .build())
                 .build();
 
         ResponseEntity<String> response = restTemplate.exchange(

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
@@ -583,6 +583,33 @@ public class CashFlowHttpActor {
     }
 
     /**
+     * Edits cash change via HTTP.
+     */
+    public void editCashChange(String cashFlowId, String cashChangeId, String name,
+                               String description, Money money, String category,
+                               ZonedDateTime dueDate) {
+        CashFlowDto.EditCashChangeJson request = CashFlowDto.EditCashChangeJson.builder()
+                .cashFlowId(cashFlowId)
+                .cashChangeId(cashChangeId)
+                .name(name)
+                .description(description)
+                .money(money)
+                .category(category)
+                .dueDate(dueDate)
+                .build();
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/edit",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        log.debug("Edited cash change via HTTP: cashFlowId={}, cashChangeId={}", cashFlowId, cashChangeId);
+    }
+
+    /**
      * Confirms cash change via HTTP.
      */
     public void confirmCashChange(String cashFlowId, String cashChangeId) {

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
@@ -288,13 +288,15 @@ public class CashFlowHttpActor {
      */
     public ResponseEntity<ApiError> editCashChangeExpectingError(String cashFlowId, String cashChangeId,
                                                                   String name, String description,
-                                                                  Money money, ZonedDateTime dueDate) {
+                                                                  Money money, String category,
+                                                                  ZonedDateTime dueDate) {
         CashFlowDto.EditCashChangeJson request = CashFlowDto.EditCashChangeJson.builder()
                 .cashFlowId(cashFlowId)
                 .cashChangeId(cashChangeId)
                 .name(name)
                 .description(description)
                 .money(money)
+                .category(category)
                 .dueDate(dueDate)
                 .build();
 

--- a/src/test/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateTest.java
@@ -602,6 +602,7 @@ class CashFlowAggregateTest extends IntegrationTest {
                 new Name("name edited"),
                 new Description("description edited"),
                 Money.of(500, "USD"),
+                new CategoryName("Uncategorized"),  // Keep same category
                 ZonedDateTime.parse("2021-08-01T00:00:00Z"),
                 ZonedDateTime.parse("2021-06-01T06:30:00Z")
         );
@@ -686,6 +687,7 @@ class CashFlowAggregateTest extends IntegrationTest {
                                 new Name("name edited"),
                                 new Description("description edited"),
                                 Money.of(500, "USD"),
+                                new CategoryName("Uncategorized"),  // Keep same category
                                 ZonedDateTime.parse("2021-08-01T00:00:00Z"),
                                 ZonedDateTime.parse("2021-06-01T06:30:00Z")
                         )

--- a/src/test/java/com/multi/vidulum/cashflow_forecast_processor/CashFlowForecastControllerTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow_forecast_processor/CashFlowForecastControllerTest.java
@@ -36,10 +36,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Test Cash Flow")
                         .description("Test description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
                                 new BankAccountNumber("US123456789", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -87,10 +87,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Test Cash Flow with transactions")
                         .description("Test description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
                                 new BankAccountNumber("US987654321", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .build()
         );
 
@@ -169,10 +169,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Budgeted Cash Flow")
                         .description("Cash flow with budgeting")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Budget Bank"),
                                 new BankAccountNumber("US111222333", Currency.of("USD")),
-                                Money.of(2000, "USD")))
+                                Money.of(2000, "USD"))))
                         .build()
         );
 
@@ -237,10 +237,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Cash Flow with confirmed transaction")
                         .description("Test description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
                                 new BankAccountNumber("US444555666", Currency.of("USD")),
-                                Money.of(1000, "USD")))
+                                Money.of(1000, "USD"))))
                         .build()
         );
 
@@ -305,10 +305,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Checksum Sync Test")
                         .description("Testing checksum synchronization")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Sync Bank"),
                                 new BankAccountNumber("US777888999", Currency.of("USD")),
-                                Money.of(3000, "USD")))
+                                Money.of(3000, "USD"))))
                         .build()
         );
 
@@ -366,10 +366,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Multi-op Checksum Test")
                         .description("Testing checksum after multiple operations")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Multi Bank"),
                                 new BankAccountNumber("US111333555", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .build()
         );
 
@@ -456,10 +456,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Cash Flow with paid transaction")
                         .description("Test description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
                                 new BankAccountNumber("US888999000", Currency.of("USD")),
-                                Money.of(2000, "USD")))
+                                Money.of(2000, "USD"))))
                         .build()
         );
 
@@ -519,10 +519,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Mixed Cash Flow")
                         .description("Cash flow with expected and paid transactions")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
                                 new BankAccountNumber("US222333444", Currency.of("USD")),
-                                Money.of(5000, "USD")))
+                                Money.of(5000, "USD"))))
                         .build()
         );
 
@@ -605,10 +605,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Cash Flow with paid outflow")
                         .description("Test description")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
                                 new BankAccountNumber("US555666777", Currency.of("USD")),
-                                Money.of(10000, "USD")))
+                                Money.of(10000, "USD"))))
                         .build()
         );
 
@@ -665,10 +665,10 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .userId("userId")
                         .name("Paid Checksum Test")
                         .description("Testing checksum after paid cash change")
-                        .bankAccount(new BankAccount(
+                        .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Sync Bank"),
                                 new BankAccountNumber("US999888777", Currency.of("USD")),
-                                Money.of(3000, "USD")))
+                                Money.of(3000, "USD"))))
                         .build()
         );
 

--- a/src/test/java/com/multi/vidulum/cashflow_forecast_processor/CashFlowForecastControllerTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow_forecast_processor/CashFlowForecastControllerTest.java
@@ -403,6 +403,7 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
                         .name("Monthly Salary Updated")
                         .description("January salary updated")
                         .money(Money.of(4500, "USD"))
+                        .category("Salary")
                         .dueDate(ZonedDateTime.parse("2022-01-16T00:00:00Z"))
                         .build()
         );

--- a/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastProcessorTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastProcessorTest.java
@@ -81,6 +81,7 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
                         new Name("cash change name 2 edited"),
                         new Description("cash change description 2 edited"),
                         Money.of(120, "USD"),
+                        new CategoryName("Uncategorized"),  // Keep same category
                         ZonedDateTime.parse("2021-08-12T00:00:00Z"),
                         ZonedDateTime.parse("2021-06-01T06:30:00Z")
                 )
@@ -166,6 +167,7 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
                         new Name("cash change name 2 edited"),
                         new Description("cash change description 2 edited"),
                         Money.of(130, "USD"),
+                        new CategoryName("Uncategorized"),  // Keep same category
                         ZonedDateTime.parse("2021-08-12T00:00:00Z"),
                         ZonedDateTime.parse("2021-06-01T06:30:00Z")
                 )
@@ -327,6 +329,7 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
                         new Name("cash change name 3 edited"),
                         new Description("cash change description 3 edited"),
                         Money.of(120, "USD"),
+                        new CategoryName("Uncategorized"),  // Keep same category
                         ZonedDateTime.parse("2021-08-12T00:00:00Z"),
                         ZonedDateTime.parse("2021-06-01T06:30:00Z")
                 )

--- a/src/test/resources/cashflow_forecast_processor/attestation_processing.json
+++ b/src/test/resources/cashflow_forecast_processor/attestation_processing.json
@@ -181,11 +181,11 @@
           "currency": "USD"
         },
         "end": {
-          "amount": 384.0,
+          "amount": 264.0,
           "currency": "USD"
         },
         "netChange": {
-          "amount": 295.0,
+          "amount": 175.0,
           "currency": "USD"
         },
         "inflowStats": {
@@ -194,7 +194,7 @@
             "currency": "USD"
           },
           "expected": {
-            "amount": 120.0,
+            "amount": 200.0,
             "currency": "USD"
           },
           "gapToForecast": {
@@ -229,23 +229,7 @@
           "groupedTransactions": {
             "transactions": {
               "FORECAST": [],
-              "EXPECTED": [
-                {
-                  "cashChangeId": {
-                    "id": "42e63a73-ef81-4811-bdeb-e87d3f21da33"
-                  },
-                  "name": {
-                    "name": "cash change name 3 edited"
-                  },
-                  "money": {
-                    "amount": 120.0,
-                    "currency": "USD"
-                  },
-                  "created": "2021-06-03T06:30:00Z",
-                  "dueDate": "2021-08-12T00:00:00Z",
-                  "endDate": null
-                }
-              ],
+              "EXPECTED": [],
               "PAID": []
             }
           },
@@ -356,7 +340,7 @@
       "period": "2021-08",
       "cashFlowStats": {
         "start": {
-          "amount": 384.0,
+          "amount": 264.0,
           "currency": "USD"
         },
         "end": {
@@ -364,7 +348,7 @@
           "currency": "USD"
         },
         "netChange": {
-          "amount": 0,
+          "amount": 120.0,
           "currency": "USD"
         },
         "inflowStats": {
@@ -373,7 +357,7 @@
             "currency": "USD"
           },
           "expected": {
-            "amount": 0,
+            "amount": 120.0,
             "currency": "USD"
           },
           "gapToForecast": {
@@ -408,7 +392,23 @@
           "groupedTransactions": {
             "transactions": {
               "FORECAST": [],
-              "EXPECTED": [],
+              "EXPECTED": [
+                {
+                  "cashChangeId": {
+                    "id": "42e63a73-ef81-4811-bdeb-e87d3f21da33"
+                  },
+                  "name": {
+                    "name": "cash change name 3 edited"
+                  },
+                  "money": {
+                    "amount": 120.0,
+                    "currency": "USD"
+                  },
+                  "created": "2021-06-03T06:30:00Z",
+                  "dueDate": "2021-08-12T00:00:00Z",
+                  "endDate": null
+                }
+              ],
               "PAID": []
             }
           },

--- a/src/test/resources/cashflow_forecast_processor/expected_inflow_processing.json
+++ b/src/test/resources/cashflow_forecast_processor/expected_inflow_processing.json
@@ -118,6 +118,97 @@
           "currency": "USD"
         },
         "end": {
+          "amount": 100.0,
+          "currency": "USD"
+        },
+        "netChange": {
+          "amount": 0,
+          "currency": "USD"
+        },
+        "inflowStats": {
+          "actual": {
+            "amount": 0,
+            "currency": "USD"
+          },
+          "expected": {
+            "amount": 0.0,
+            "currency": "USD"
+          },
+          "gapToForecast": {
+            "amount": 0,
+            "currency": "USD"
+          }
+        },
+        "outflowStats": {
+          "actual": {
+            "amount": 0,
+            "currency": "USD"
+          },
+          "expected": {
+            "amount": 0,
+            "currency": "USD"
+          },
+          "gapToForecast": {
+            "amount": 0,
+            "currency": "USD"
+          }
+        }
+      },
+      "categorizedInFlows": [
+        {
+          "categoryName": {
+            "name": "Uncategorized"
+          },
+          "category": {
+            "category": "Uncategorized"
+          },
+          "subCategories": [],
+          "groupedTransactions": {
+            "transactions": {
+              "FORECAST": [],
+              "PAID": [],
+              "EXPECTED": []
+            }
+          },
+          "totalPaidValue": {
+            "amount": 0,
+            "currency": "USD"
+          }
+        }
+      ],
+      "categorizedOutFlows": [
+        {
+          "categoryName": {
+            "name": "Uncategorized"
+          },
+          "category": {
+            "category": "Uncategorized"
+          },
+          "subCategories": [],
+          "groupedTransactions": {
+            "transactions": {
+              "FORECAST": [],
+              "PAID": [],
+              "EXPECTED": []
+            }
+          },
+          "totalPaidValue": {
+            "amount": 0,
+            "currency": "USD"
+          }
+        }
+      ],
+      "status": "FORECASTED",
+      "attestation": null
+    },
+    "2021-08": {
+      "period": "2021-08",
+      "cashFlowStats": {
+        "start": {
+          "amount": 100.0,
+          "currency": "USD"
+        },
+        "end": {
           "amount": 220.0,
           "currency": "USD"
         },
@@ -188,97 +279,6 @@
           },
           "totalPaidValue": {
             "amount": 120.0,
-            "currency": "USD"
-          }
-        }
-      ],
-      "categorizedOutFlows": [
-        {
-          "categoryName": {
-            "name": "Uncategorized"
-          },
-          "category": {
-            "category": "Uncategorized"
-          },
-          "subCategories": [],
-          "groupedTransactions": {
-            "transactions": {
-              "FORECAST": [],
-              "PAID": [],
-              "EXPECTED": []
-            }
-          },
-          "totalPaidValue": {
-            "amount": 0,
-            "currency": "USD"
-          }
-        }
-      ],
-      "status": "FORECASTED",
-      "attestation": null
-    },
-    "2021-08": {
-      "period": "2021-08",
-      "cashFlowStats": {
-        "start": {
-          "amount": 220.0,
-          "currency": "USD"
-        },
-        "end": {
-          "amount": 220.0,
-          "currency": "USD"
-        },
-        "netChange": {
-          "amount": 0,
-          "currency": "USD"
-        },
-        "inflowStats": {
-          "actual": {
-            "amount": 0,
-            "currency": "USD"
-          },
-          "expected": {
-            "amount": 0,
-            "currency": "USD"
-          },
-          "gapToForecast": {
-            "amount": 0,
-            "currency": "USD"
-          }
-        },
-        "outflowStats": {
-          "actual": {
-            "amount": 0,
-            "currency": "USD"
-          },
-          "expected": {
-            "amount": 0,
-            "currency": "USD"
-          },
-          "gapToForecast": {
-            "amount": 0,
-            "currency": "USD"
-          }
-        }
-      },
-      "categorizedInFlows": [
-        {
-          "categoryName": {
-            "name": "Uncategorized"
-          },
-          "category": {
-            "category": "Uncategorized"
-          },
-          "subCategories": [],
-          "groupedTransactions": {
-            "transactions": {
-              "FORECAST": [],
-              "PAID": [],
-              "EXPECTED": []
-            }
-          },
-          "totalPaidValue": {
-            "amount": 0,
             "currency": "USD"
           }
         }

--- a/src/test/resources/cashflow_forecast_processor/expected_outflow_processing.json
+++ b/src/test/resources/cashflow_forecast_processor/expected_outflow_processing.json
@@ -118,6 +118,97 @@
           "currency": "USD"
         },
         "end": {
+          "amount": -111.0,
+          "currency": "USD"
+        },
+        "netChange": {
+          "amount": 0,
+          "currency": "USD"
+        },
+        "inflowStats": {
+          "actual": {
+            "amount": 0,
+            "currency": "USD"
+          },
+          "expected": {
+            "amount": 0,
+            "currency": "USD"
+          },
+          "gapToForecast": {
+            "amount": 0,
+            "currency": "USD"
+          }
+        },
+        "outflowStats": {
+          "actual": {
+            "amount": 0,
+            "currency": "USD"
+          },
+          "expected": {
+            "amount": 0.0,
+            "currency": "USD"
+          },
+          "gapToForecast": {
+            "amount": 0,
+            "currency": "USD"
+          }
+        }
+      },
+      "categorizedInFlows": [
+        {
+          "categoryName": {
+            "name": "Uncategorized"
+          },
+          "category": {
+            "category": "Uncategorized"
+          },
+          "subCategories": [],
+          "groupedTransactions": {
+            "transactions": {
+              "PAID": [],
+              "EXPECTED": [],
+              "FORECAST": []
+            }
+          },
+          "totalPaidValue": {
+            "amount": 0,
+            "currency": "USD"
+          }
+        }
+      ],
+      "categorizedOutFlows": [
+        {
+          "categoryName": {
+            "name": "Uncategorized"
+          },
+          "category": {
+            "category": "Uncategorized"
+          },
+          "subCategories": [],
+          "groupedTransactions": {
+            "transactions": {
+              "PAID": [],
+              "EXPECTED": [],
+              "FORECAST": []
+            }
+          },
+          "totalPaidValue": {
+            "amount": 0,
+            "currency": "USD"
+          }
+        }
+      ],
+      "status": "FORECASTED",
+      "attestation": null
+    },
+    "2021-08": {
+      "period": "2021-08",
+      "cashFlowStats": {
+        "start": {
+          "amount": -111.0,
+          "currency": "USD"
+        },
+        "end": {
           "amount": -241.0,
           "currency": "USD"
         },
@@ -210,97 +301,6 @@
           },
           "totalPaidValue": {
             "amount": 130.0,
-            "currency": "USD"
-          }
-        }
-      ],
-      "status": "FORECASTED",
-      "attestation": null
-    },
-    "2021-08": {
-      "period": "2021-08",
-      "cashFlowStats": {
-        "start": {
-          "amount": -241.0,
-          "currency": "USD"
-        },
-        "end": {
-          "amount": -241.0,
-          "currency": "USD"
-        },
-        "netChange": {
-          "amount": 0,
-          "currency": "USD"
-        },
-        "inflowStats": {
-          "actual": {
-            "amount": 0,
-            "currency": "USD"
-          },
-          "expected": {
-            "amount": 0,
-            "currency": "USD"
-          },
-          "gapToForecast": {
-            "amount": 0,
-            "currency": "USD"
-          }
-        },
-        "outflowStats": {
-          "actual": {
-            "amount": 0,
-            "currency": "USD"
-          },
-          "expected": {
-            "amount": 0,
-            "currency": "USD"
-          },
-          "gapToForecast": {
-            "amount": 0,
-            "currency": "USD"
-          }
-        }
-      },
-      "categorizedInFlows": [
-        {
-          "categoryName": {
-            "name": "Uncategorized"
-          },
-          "category": {
-            "category": "Uncategorized"
-          },
-          "subCategories": [],
-          "groupedTransactions": {
-            "transactions": {
-              "PAID": [],
-              "EXPECTED": [],
-              "FORECAST": []
-            }
-          },
-          "totalPaidValue": {
-            "amount": 0,
-            "currency": "USD"
-          }
-        }
-      ],
-      "categorizedOutFlows": [
-        {
-          "categoryName": {
-            "name": "Uncategorized"
-          },
-          "category": {
-            "category": "Uncategorized"
-          },
-          "subCategories": [],
-          "groupedTransactions": {
-            "transactions": {
-              "PAID": [],
-              "EXPECTED": [],
-              "FORECAST": []
-            }
-          },
-          "totalPaidValue": {
-            "amount": 0,
             "currency": "USD"
           }
         }


### PR DESCRIPTION
 Description:
  ## Summary
  - Add dueDate range validation for append and edit cash change operations
  - Add category change and validation for edit cash change operation
  - Add comprehensive HTTP error handling tests for edit scenarios

  ## Changes

  ### dueDate Validation
  - Add `DueDateOutsideAllowedRangeException` for dates outside allowed range
  - Validate dueDate must be between `activePeriod` and `activePeriod + 11 months`
  - Applies to both `appendExpectedCashChange` and `editCashChange` operations
  - Add `DUE_DATE_OUTSIDE_ALLOWED_RANGE` error code (HTTP 400)

  ### Edit CashChange Enhancements
  - Add category validation when editing cash change (archived/non-existent category checks)
  - Add `categoryName` field to `CashChangeEditedEvent` to support category changes
  - Update `CashChangeEditedEventHandler` to handle category changes in forecast processor

  ### DTO Validation Improvements
  - Add `@NoArgsConstructor` and `@AllArgsConstructor` to nested DTO classes for Jackson deserialization
  - Add `@Valid` annotations for nested object validation

