### PR TITLE
VID-117: Add CashFlow name validation (length 5-30 chars, unique per user)

### DIFF
--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
@@ -29,6 +29,7 @@ public final class CashFlowDto {
         private String userId;
 
         @NotBlank(message = "name is required")
+        @Size(min = 5, max = 30, message = "CashFlow name must be between 5 and 30 characters")
         private String name;
 
         private String description;
@@ -175,6 +176,7 @@ public final class CashFlowDto {
         private String userId;
 
         @NotBlank(message = "name is required")
+        @Size(min = 5, max = 30, message = "CashFlow name must be between 5 and 30 characters")
         private String name;
 
         private String description;

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowCommandHandler.java
@@ -25,6 +25,11 @@ public class CreateCashFlowCommandHandler implements CommandHandler<CreateCashFl
 
     @Override
     public CashFlowSnapshot handle(CreateCashFlowCommand command) {
+        // Validate uniqueness of CashFlow name for this user
+        if (domainCashFlowRepository.existsByUserIdAndName(command.userId(), command.name().name())) {
+            throw new CashFlowNameAlreadyExistsException(command.name().name(), command.userId());
+        }
+
         CashFlow cashFlow  = new CashFlow();
         CashFlowEvent.CashFlowCreatedEvent event = new CashFlowEvent.CashFlowCreatedEvent(
                 CashFlowId.generate(),

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowWithHistoryCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowWithHistoryCommandHandler.java
@@ -28,6 +28,11 @@ public class CreateCashFlowWithHistoryCommandHandler implements CommandHandler<C
         ZonedDateTime now = ZonedDateTime.now(clock);
         YearMonth activePeriod = YearMonth.from(now);
 
+        // Validate uniqueness of CashFlow name for this user
+        if (domainCashFlowRepository.existsByUserIdAndName(command.userId(), command.name().name())) {
+            throw new CashFlowNameAlreadyExistsException(command.name().name(), command.userId());
+        }
+
         // Validate: startPeriod must be before or equal to activePeriod
         if (command.startPeriod().isAfter(activePeriod)) {
             throw new StartPeriodInFutureException(command.startPeriod(), activePeriod);

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowNameAlreadyExistsException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowNameAlreadyExistsException.java
@@ -1,0 +1,29 @@
+package com.multi.vidulum.cashflow.domain;
+
+import com.multi.vidulum.common.UserId;
+
+/**
+ * Exception thrown when attempting to create a CashFlow with a name that already exists
+ * for the given user.
+ */
+public class CashFlowNameAlreadyExistsException extends RuntimeException {
+
+    private final String cashFlowName;
+    private final UserId userId;
+
+    public CashFlowNameAlreadyExistsException(String cashFlowName, UserId userId) {
+        super(String.format(
+                "CashFlow with name '%s' already exists for user '%s'",
+                cashFlowName, userId.getId()));
+        this.cashFlowName = cashFlowName;
+        this.userId = userId;
+    }
+
+    public String getCashFlowName() {
+        return cashFlowName;
+    }
+
+    public UserId getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow/domain/DomainCashFlowRepository.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/DomainCashFlowRepository.java
@@ -20,4 +20,13 @@ public interface DomainCashFlowRepository extends DomainRepository<CashFlowId, C
      * @return list of CashFlows needing rollover
      */
     List<CashFlow> findOpenCashFlowsNeedingRollover(YearMonth targetPeriod);
+
+    /**
+     * Checks if a CashFlow with the given name already exists for the specified user.
+     *
+     * @param userId the user ID
+     * @param name the CashFlow name
+     * @return true if a CashFlow with this name exists for this user, false otherwise
+     */
+    boolean existsByUserIdAndName(UserId userId, String name);
 }

--- a/src/main/java/com/multi/vidulum/cashflow/infrastructure/CashFlowMongoRepository.java
+++ b/src/main/java/com/multi/vidulum/cashflow/infrastructure/CashFlowMongoRepository.java
@@ -24,4 +24,13 @@ public interface CashFlowMongoRepository extends MongoRepository<CashFlowEntity,
      */
     @Query("{ 'status': ?0, 'activePeriod': { $lt: ?1 } }")
     List<CashFlowEntity> findByStatusAndActivePeriodBefore(CashFlow.CashFlowStatus status, String targetPeriod);
+
+    /**
+     * Checks if a CashFlow with the given name already exists for the specified user.
+     *
+     * @param userId the user ID
+     * @param name the CashFlow name
+     * @return true if a CashFlow with this name exists for this user, false otherwise
+     */
+    boolean existsByUserIdAndName(String userId, String name);
 }

--- a/src/main/java/com/multi/vidulum/cashflow/infrastructure/DomainCashFlowRepositoryImpl.java
+++ b/src/main/java/com/multi/vidulum/cashflow/infrastructure/DomainCashFlowRepositoryImpl.java
@@ -88,4 +88,9 @@ public class DomainCashFlowRepositoryImpl implements DomainCashFlowRepository {
                 .map(CashFlow::from)
                 .toList();
     }
+
+    @Override
+    public boolean existsByUserIdAndName(UserId userId, String name) {
+        return cashFlowMongoRepository.existsByUserIdAndName(userId.getId(), name);
+    }
 }

--- a/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
+++ b/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     // CashFlow - Conflicts
     CASHFLOW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "Access to CashFlow denied"),
     CASHFLOW_BALANCE_MISMATCH(HttpStatus.CONFLICT, "Balance mismatch during attestation"),
+    CASHFLOW_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "CashFlow with this name already exists"),
     CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "Category already exists"),
     BUDGETING_ALREADY_EXISTS(HttpStatus.CONFLICT, "Budgeting already exists"),
     CATEGORY_UNARCHIVE_CONFLICT(HttpStatus.CONFLICT, "Cannot unarchive - active category exists"),

--- a/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
+++ b/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
@@ -4,6 +4,7 @@ import com.multi.vidulum.cashflow.app.commands.archive.CannotArchiveSystemCatego
 import com.multi.vidulum.cashflow.app.commands.archive.CategoryNotFoundException;
 import com.multi.vidulum.cashflow.domain.*;
 import com.multi.vidulum.common.InvalidUserIdFormatException;
+import com.multi.vidulum.cashflow.domain.CashFlowNameAlreadyExistsException;
 import com.multi.vidulum.common.error.ApiError;
 import com.multi.vidulum.common.error.ErrorCode;
 import com.multi.vidulum.common.error.FieldError;
@@ -117,6 +118,13 @@ public class ErrorHttpHandler {
     }
 
     // ============ CashFlow - Conflicts (409) ============
+
+    @ExceptionHandler(CashFlowNameAlreadyExistsException.class)
+    public ResponseEntity<ApiError> handleCashFlowNameAlreadyExists(CashFlowNameAlreadyExistsException ex) {
+        log.debug("CashFlow name already exists: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CASHFLOW_NAME_ALREADY_EXISTS, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
 
     @ExceptionHandler(CategoryAlreadyExistsException.class)
     public ResponseEntity<ApiError> handleCategoryAlreadyExists(CategoryAlreadyExistsException ex) {

--- a/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionHttpIntegrationTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionHttpIntegrationTest.java
@@ -52,6 +52,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -81,6 +82,12 @@ public class BankDataIngestionHttpIntegrationTest {
 
     // FixedClockConfig sets clock to 2022-01-01T00:00:00Z
     private static final ZonedDateTime FIXED_NOW = ZonedDateTime.parse("2022-01-01T00:00:00Z[UTC]");
+
+    private static final AtomicInteger NAME_COUNTER = new AtomicInteger(0);
+
+    private String uniqueCashFlowName() {
+        return "Ingestion-" + NAME_COUNTER.incrementAndGet();
+    }
 
     /**
      * Test security configuration that disables authentication for HTTP integration tests.
@@ -172,10 +179,11 @@ public class BankDataIngestionHttpIntegrationTest {
         // given
         YearMonth startPeriod = YearMonth.of(2021, 7);
         YearMonth activePeriod = YearMonth.of(2022, 1);
+        String cashFlowName = uniqueCashFlowName();
 
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                cashFlowName,
                 startPeriod,
                 Money.of(10000.0, "PLN")
         );
@@ -187,7 +195,7 @@ public class BankDataIngestionHttpIntegrationTest {
         // Only ignore cashFlowId (generated), lastMessageChecksum (internal), importCutoffDateTime (not set)
         assertThat(cashFlow.getCashFlowId()).isEqualTo(cashFlowId);
         assertThat(cashFlow.getUserId()).isEqualTo("U10000006");
-        assertThat(cashFlow.getName()).isEqualTo("Test CashFlow");
+        assertThat(cashFlow.getName()).isEqualTo(cashFlowName);
         assertThat(cashFlow.getDescription()).isEqualTo("CashFlow for HTTP integration testing");
         assertThat(cashFlow.getStatus()).isEqualTo(CashFlow.CashFlowStatus.SETUP);
         assertThat(cashFlow.getStartPeriod()).isEqualTo(startPeriod);
@@ -240,7 +248,7 @@ public class BankDataIngestionHttpIntegrationTest {
         // given
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 YearMonth.of(2021, 7),
                 Money.of(10000.0, "PLN")
         );
@@ -281,7 +289,7 @@ public class BankDataIngestionHttpIntegrationTest {
         // given
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 YearMonth.of(2021, 7),
                 Money.of(10000.0, "PLN")
         );
@@ -326,7 +334,7 @@ public class BankDataIngestionHttpIntegrationTest {
 
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 startPeriod,
                 Money.of(10000.0, "PLN")
         );
@@ -628,7 +636,7 @@ public class BankDataIngestionHttpIntegrationTest {
         // given
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 YearMonth.of(2021, 7),
                 Money.of(10000.0, "PLN")
         );
@@ -686,7 +694,7 @@ public class BankDataIngestionHttpIntegrationTest {
 
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 startPeriod,
                 Money.of(10000.0, "PLN")
         );
@@ -736,7 +744,7 @@ public class BankDataIngestionHttpIntegrationTest {
 
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 startPeriod,
                 Money.of(10000.0, "PLN")
         );
@@ -762,7 +770,7 @@ public class BankDataIngestionHttpIntegrationTest {
 
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 startPeriod,
                 Money.of(10000.0, "PLN")
         );
@@ -832,7 +840,7 @@ public class BankDataIngestionHttpIntegrationTest {
 
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 startPeriod,
                 Money.of(10000.0, "PLN")
         );
@@ -878,7 +886,7 @@ public class BankDataIngestionHttpIntegrationTest {
 
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 startPeriod,
                 Money.of(10000.0, "PLN")
         );
@@ -942,7 +950,7 @@ public class BankDataIngestionHttpIntegrationTest {
 
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000006",
-                "Test CashFlow",
+                uniqueCashFlowName(),
                 startPeriod,
                 Money.of(10000.0, "PLN")
         );
@@ -1204,7 +1212,7 @@ public class BankDataIngestionHttpIntegrationTest {
 
         String cashFlowId = actor.createCashFlowWithHistory(
                 "U10000008",
-                "Test CashFlow for Invalid Transactions",
+                uniqueCashFlowName(),
                 startPeriod,
                 Money.of(10000.0, "PLN")
         );

--- a/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
@@ -25,6 +25,7 @@ import java.time.ZonedDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.multi.vidulum.cashflow.domain.CashChangeStatus.*;
 import static com.multi.vidulum.cashflow.domain.Type.INFLOW;
@@ -34,16 +35,35 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class CashFlowControllerTest extends IntegrationTest {
 
+    private static final AtomicInteger NAME_COUNTER = new AtomicInteger(0);
+
     @Autowired
     private CashFlowRestController cashFlowRestController;
+
+    private String uniqueCashFlowName() {
+        return "CashFlow-" + NAME_COUNTER.incrementAndGet();
+    }
+
+    private String uniqueHistoricalName() {
+        return "Historical-" + NAME_COUNTER.incrementAndGet();
+    }
+
+    private String uniqueTestCashFlowName() {
+        return "TestCash-" + NAME_COUNTER.incrementAndGet();
+    }
+
+    private String uniqueNormalCashFlowName() {
+        return "NormalCF-" + NAME_COUNTER.incrementAndGet();
+    }
 
     @Test
     void shouldCreateAndGetCashFlow() {
         // given
+        String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -65,7 +85,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
                                 .userId("U10000009")
-                                .name("cash-flow name")
+                                .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
                                         new BankName("bank"),
@@ -94,10 +114,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldAppendCashChange() {
         // when
+        String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -133,7 +154,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
                                 .userId("U10000009")
-                                .name("cash-flow name")
+                                .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
                                         new BankName("bank"),
@@ -180,10 +201,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldAppendPaidCashChange() {
         // when
+        String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -219,7 +241,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
                                 .userId("U10000009")
-                                .name("cash-flow name")
+                                .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
                                         new BankName("bank"),
@@ -268,7 +290,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -313,10 +335,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldConfirmCashChange() {
         // when
+        String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -357,7 +380,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
                                 .userId("U10000009")
-                                .name("cash-flow name")
+                                .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
                                         new BankName("bank"),
@@ -404,10 +427,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldEditCashChange() {
         // when
+        String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -453,7 +477,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
                                 .userId("U10000009")
-                                .name("cash-flow name")
+                                .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
                                         new BankName("bank"),
@@ -501,10 +525,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldRejectCashChange() {
         // when
+        String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -546,7 +571,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
                                 .userId("U10000009")
-                                .name("cash-flow name")
+                                .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
                                         new BankName("bank"),
@@ -595,10 +620,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldAppendCashChangeToNewCategory() {
         // when
+        String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -640,7 +666,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
                                 .userId("U10000009")
-                                .name("cash-flow name")
+                                .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
                                         new BankName("bank"),
@@ -695,10 +721,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldAppendCashChangeToSubCategory() {
         // when
+        String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -758,7 +785,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
                                 .userId("U10000009")
-                                .name("cash-flow name")
+                                .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
                                         new BankName("bank"),
@@ -986,7 +1013,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1038,7 +1065,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1102,7 +1129,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1172,7 +1199,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1224,7 +1251,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1255,7 +1282,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1286,7 +1313,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1325,7 +1352,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1356,7 +1383,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1387,7 +1414,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1430,7 +1457,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1463,7 +1490,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1499,7 +1526,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1533,7 +1560,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1561,7 +1588,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1590,7 +1617,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("test cash flow")
+                        .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1624,11 +1651,13 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldCreateCashFlowWithHistoryInSetupStatus() {
         // given - FixedClockConfig sets clock to 2022-01-01, so startPeriod 2021-06 is in the past
+        String cashFlowName = uniqueHistoricalName();
+
         // when
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(cashFlowName)
                         .description("Cash flow with historical data support")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Chase Bank"),
@@ -1644,7 +1673,7 @@ public class CashFlowControllerTest extends IntegrationTest {
 
         assertThat(result.getCashFlowId()).isEqualTo(cashFlowId);
         assertThat(result.getUserId()).isEqualTo("U10000009");
-        assertThat(result.getName()).isEqualTo("Historical Cash Flow");
+        assertThat(result.getName()).isEqualTo(cashFlowName);
         assertThat(result.getStatus()).isEqualTo(CashFlow.CashFlowStatus.SETUP);
         assertThat(result.getBankAccount().balance()).isEqualTo(Money.of(5000, "USD"));
 
@@ -1672,7 +1701,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1782,7 +1811,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For import testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1833,7 +1862,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("Normal Cash Flow")
+                        .name(uniqueNormalCashFlowName())
                         .description("In OPEN mode")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1864,7 +1893,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For import testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1896,7 +1925,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For import testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -1928,7 +1957,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("Multiple imports")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2000,7 +2029,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For forecast testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2065,7 +2094,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For outflow forecast testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2130,7 +2159,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("Multiple transactions same month")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2246,7 +2275,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For cutoff testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2283,7 +2312,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For cutoff testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2316,7 +2345,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For cutoff testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2360,7 +2389,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For cutoff testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2400,7 +2429,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For same-day testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2439,7 +2468,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For future date testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2471,7 +2500,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For future month testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2503,7 +2532,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("Multiple same-day imports")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2576,7 +2605,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For activation testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2666,7 +2695,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For balance mismatch testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2718,7 +2747,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For force activation testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2780,7 +2809,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("Normal Cash Flow")
+                        .name(uniqueNormalCashFlowName())
                         .description("In OPEN mode")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2843,7 +2872,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For status change testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2909,7 +2938,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For negative difference testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -2964,7 +2993,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For adjustment testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3033,7 +3062,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For negative adjustment testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3094,7 +3123,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For no-adjustment testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3152,7 +3181,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For importCutoffDateTime testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3192,7 +3221,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For forecast adjustment testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3265,7 +3294,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For rollback testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3336,7 +3365,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For rollback with categories")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3415,7 +3444,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("Will be attested")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3460,7 +3489,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For forecast clearing test")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3568,7 +3597,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId("U10000009")
-                        .name("Historical Cash Flow")
+                        .name(uniqueHistoricalName())
                         .description("For re-import testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3653,7 +3682,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3713,7 +3742,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3780,7 +3809,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3805,7 +3834,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3830,7 +3859,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3890,7 +3919,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3924,7 +3953,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -3970,7 +3999,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -4019,7 +4048,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -4082,7 +4111,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -4116,7 +4145,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -4172,7 +4201,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -4225,7 +4254,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),
@@ -4294,7 +4323,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000009")
-                        .name("cash-flow name")
+                        .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("bank"),

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
@@ -670,6 +670,34 @@ public class CashFlowHttpActor {
     }
 
     /**
+     * Creates a standard CashFlow expecting an error response.
+     */
+    public ResponseEntity<ApiError> createCashFlowExpectingError(String userId, String name, String currency) {
+        CashFlowDto.CreateCashFlowJson request = CashFlowDto.CreateCashFlowJson.builder()
+                .userId(userId)
+                .name(name)
+                .description("CashFlow for HTTP integration testing")
+                .bankAccount(CashFlowDto.BankAccountJson.builder()
+                        .bankName("Test Bank")
+                        .bankAccountNumber(CashFlowDto.BankAccountNumberJson.builder()
+                                .account("PL12345678901234567890123456")
+                                .denomination(CashFlowDto.CurrencyJson.builder().id(currency).build())
+                                .build())
+                        .balance(CashFlowDto.MoneyJson.builder()
+                                .amount(java.math.BigDecimal.ZERO)
+                                .currency(currency)
+                                .build())
+                        .build())
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
      * Creates a standard CashFlow (not with history) via HTTP.
      */
     public String createCashFlow(String userId, String name, String currency) {

--- a/src/test/java/com/multi/vidulum/cashflow/app/RolloverMonthIntegrationTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/RolloverMonthIntegrationTest.java
@@ -18,6 +18,7 @@ import java.time.Clock;
 import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +31,8 @@ import static org.awaitility.Awaitility.await;
  */
 @Slf4j
 public class RolloverMonthIntegrationTest extends IntegrationTest {
+
+    private static final AtomicInteger NAME_COUNTER = new AtomicInteger(0);
 
     @Autowired
     private CashFlowRestController cashFlowRestController;
@@ -44,6 +47,10 @@ public class RolloverMonthIntegrationTest extends IntegrationTest {
     private Clock clock;
 
     private static final String TEST_USER = "U10000001";
+
+    private String uniqueCashFlowName() {
+        return "RolloverCF-" + NAME_COUNTER.incrementAndGet();
+    }
 
     @Test
     void shouldRolloverMonthAndTransitionToRolledOverStatus() {
@@ -230,7 +237,7 @@ public class RolloverMonthIntegrationTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
                         .userId(TEST_USER)
-                        .name("Rollover Test CashFlow")
+                        .name(uniqueCashFlowName())
                         .description("Test CashFlow for rollover")
                         .bankAccount(CashFlowDto.BankAccountJson.builder()
                                 .bankName("Test Bank")

--- a/src/test/java/com/multi/vidulum/cashflow_forecast_processor/CashFlowForecastControllerTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow_forecast_processor/CashFlowForecastControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.multi.vidulum.cashflow.domain.Type.INFLOW;
 import static com.multi.vidulum.cashflow.domain.Type.OUTFLOW;
@@ -22,11 +23,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CashFlowForecastControllerTest extends IntegrationTest {
 
+    private static final AtomicInteger NAME_COUNTER = new AtomicInteger(0);
+
     @Autowired
     private CashFlowRestController cashFlowRestController;
 
     @Autowired
     private CashFlowForecastRestController cashFlowForecastRestController;
+
+    private String uniqueCashFlowName() {
+        return "ForecastCF-" + NAME_COUNTER.incrementAndGet();
+    }
 
     @Test
     void shouldGetForecastStatementForCashFlow() {
@@ -34,7 +41,7 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000012")
-                        .name("Test Cash Flow")
+                        .name(uniqueCashFlowName())
                         .description("Test description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
@@ -85,7 +92,7 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000012")
-                        .name("Test Cash Flow with transactions")
+                        .name(uniqueCashFlowName())
                         .description("Test description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
@@ -243,7 +250,7 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000012")
-                        .name("Cash Flow with confirmed transaction")
+                        .name(uniqueCashFlowName())
                         .description("Test description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
@@ -462,7 +469,7 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000012")
-                        .name("Cash Flow with paid transaction")
+                        .name(uniqueCashFlowName())
                         .description("Test description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),
@@ -611,7 +618,7 @@ public class CashFlowForecastControllerTest extends IntegrationTest {
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId("U10000012")
-                        .name("Cash Flow with paid outflow")
+                        .name(uniqueCashFlowName())
                         .description("Test description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
                                 new BankName("Test Bank"),


### PR DESCRIPTION
  ## Summary
  - Add `@Size(min=5, max=30)` validation to CashFlow name field in DTOs
  - Add uniqueness constraint for CashFlow name within same user
  - Return HTTP 409 CONFLICT when attempting to create CashFlow with duplicate name

