### PR TITLE
VID-118: Human-readable IDs (CF/CC format) with cf= URL prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,26 @@ When writing integration tests, follow these rules:
 - **Kafka**: Broker `kafka:9092`, consumer group `group-id`
 - **Docker**: `docker-compose-final.yml` for local development
 
+## Docker Rebuild (Full Restart)
+
+When the user asks to "restart Docker" or "rebuild Docker image", perform a **full clean rebuild**:
+
+```bash
+# 1. Build fresh Docker image
+docker build -t vidulum-app:latest .
+
+# 2. Stop and remove all containers
+docker-compose -f docker-compose-final.yml down
+
+# 3. Start fresh from scratch
+docker-compose -f docker-compose-final.yml up -d
+```
+
+This ensures:
+- New Docker image is built with latest code changes
+- All containers (MongoDB, Kafka, app) are stopped and removed
+- Fresh containers are started with clean state
+
 ## Sound Notification
 
 After completing long-running operations (tests, builds, compilations), play a notification sound to alert the user:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,15 +160,24 @@ When writing integration tests, follow these rules:
 When the user asks to "restart Docker" or "rebuild Docker image", perform a **full clean rebuild**:
 
 ```bash
-# 1. Build fresh Docker image
+# 1. Package the application (create JAR)
+./mvnw package -DskipTests
+
+# 2. Build fresh Docker image
+# IMPORTANT: Always use vidulum-app:latest (NOT vidulum:latest)
 docker build -t vidulum-app:latest .
 
-# 2. Stop and remove all containers
+# 3. Stop and remove all containers
 docker-compose -f docker-compose-final.yml down
 
-# 3. Start fresh from scratch
+# 4. Start fresh from scratch
 docker-compose -f docker-compose-final.yml up -d
 ```
+
+**IMPORTANT - Docker Image Naming:**
+- Always build with tag `vidulum-app:latest`
+- NEVER use `vidulum:latest` - this is an old deprecated name
+- The `docker-compose-final.yml` expects `vidulum-app:latest`
 
 This ensures:
 - New Docker image is built with latest code changes

--- a/docker-compose-final.yml
+++ b/docker-compose-final.yml
@@ -33,8 +33,8 @@ services:
     depends_on:
       - kafka
 
-  vidulum:
-    image: vidulum:latest
+  vidulum-app:
+    image: vidulum-app:latest
     container_name: "vidulum-app"
     ports:
       - 9090:8080
@@ -60,4 +60,4 @@ services:
       - kafka
     depends_on:
       - kafka
-      - vidulum
+      - vidulum-app

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionRestController.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionRestController.java
@@ -71,7 +71,7 @@ public class BankDataIngestionRestController {
 
         ConfigureCategoryMappingResult result = commandGateway.send(
                 new ConfigureCategoryMappingCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         mappingConfigs
                 )
         );
@@ -87,7 +87,7 @@ public class BankDataIngestionRestController {
             @PathVariable("cashFlowId") String cashFlowId) {
 
         GetCategoryMappingsResult result = queryGateway.send(
-                new GetCategoryMappingsQuery(new CashFlowId(cashFlowId))
+                new GetCategoryMappingsQuery(CashFlowId.of(cashFlowId))
         );
 
         return toGetMappingsResponse(result);
@@ -103,7 +103,7 @@ public class BankDataIngestionRestController {
 
         DeleteCategoryMappingResult result = commandGateway.send(
                 new DeleteCategoryMappingCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         MappingId.of(mappingId)
                 )
         );
@@ -123,7 +123,7 @@ public class BankDataIngestionRestController {
             @PathVariable("cashFlowId") String cashFlowId) {
 
         DeleteAllCategoryMappingsResult result = commandGateway.send(
-                new DeleteAllCategoryMappingsCommand(new CashFlowId(cashFlowId))
+                new DeleteAllCategoryMappingsCommand(CashFlowId.of(cashFlowId))
         );
 
         return BankDataIngestionDto.DeleteAllMappingsResponse.builder()
@@ -216,7 +216,7 @@ public class BankDataIngestionRestController {
             @PathVariable("cashFlowId") String cashFlowId) {
 
         ListStagingSessionsResult result = queryGateway.send(
-                new ListStagingSessionsQuery(new CashFlowId(cashFlowId))
+                new ListStagingSessionsQuery(CashFlowId.of(cashFlowId))
         );
 
         return toListStagingSessionsResponse(result);
@@ -237,7 +237,7 @@ public class BankDataIngestionRestController {
 
         StageTransactionsResult result = commandGateway.send(
                 new StageTransactionsCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         transactions
                 )
         );
@@ -255,7 +255,7 @@ public class BankDataIngestionRestController {
 
         GetStagingPreviewResult result = queryGateway.send(
                 new GetStagingPreviewQuery(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         StagingSessionId.of(stagingSessionId)
                 )
         );
@@ -273,7 +273,7 @@ public class BankDataIngestionRestController {
 
         DeleteStagingSessionResult result = commandGateway.send(
                 new DeleteStagingSessionCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         StagingSessionId.of(stagingSessionId)
                 )
         );
@@ -297,7 +297,7 @@ public class BankDataIngestionRestController {
 
         RevalidateStagingResult result = commandGateway.send(
                 new RevalidateStagingCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         StagingSessionId.of(stagingSessionId)
                 )
         );
@@ -316,7 +316,7 @@ public class BankDataIngestionRestController {
 
         UploadCsvResult result = commandGateway.send(
                 new UploadCsvCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         file
                 )
         );
@@ -601,7 +601,7 @@ public class BankDataIngestionRestController {
 
         StartImportJobResult result = commandGateway.send(
                 new StartImportJobCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         StagingSessionId.of(request.getStagingSessionId())
                 )
         );
@@ -619,7 +619,7 @@ public class BankDataIngestionRestController {
 
         GetImportProgressResult result = queryGateway.send(
                 new GetImportProgressQuery(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         ImportJobId.of(jobId)
                 )
         );
@@ -637,7 +637,7 @@ public class BankDataIngestionRestController {
 
         RollbackImportJobResult result = commandGateway.send(
                 new RollbackImportJobCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         ImportJobId.of(jobId)
                 )
         );
@@ -656,7 +656,7 @@ public class BankDataIngestionRestController {
 
         FinalizeImportJobResult result = commandGateway.send(
                 new FinalizeImportJobCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         ImportJobId.of(jobId),
                         request.isDeleteMappings()
                 )
@@ -679,7 +679,7 @@ public class BankDataIngestionRestController {
 
         ListImportJobsResult result = queryGateway.send(
                 new ListImportJobsQuery(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         statusFilters
                 )
         );

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionRestController.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionRestController.java
@@ -50,7 +50,7 @@ import java.util.List;
  */
 @AllArgsConstructor
 @RestController
-@RequestMapping("/api/v1/bank-data-ingestion/{cashFlowId}")
+@RequestMapping("/api/v1/bank-data-ingestion/cf={cashFlowId}")
 public class BankDataIngestionRestController {
 
     private final CommandGateway commandGateway;

--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
@@ -22,6 +22,7 @@ import com.multi.vidulum.cashflow.app.queries.GetCashFlowQuery;
 import com.multi.vidulum.cashflow.app.queries.GetDetailsOfCashFlowViaUserQuery;
 import com.multi.vidulum.cashflow.domain.*;
 import com.multi.vidulum.cashflow.domain.snapshots.CashFlowSnapshot;
+import com.multi.vidulum.common.BusinessIdGenerator;
 import com.multi.vidulum.common.Money;
 import com.multi.vidulum.common.Reason;
 import com.multi.vidulum.common.UserId;
@@ -47,6 +48,7 @@ public class CashFlowRestController {
     private final QueryGateway queryGateway;
     private final DomainCashFlowRepository domainCashFlowRepository;
     private final CashFlowSummaryMapper mapper;
+    private final BusinessIdGenerator businessIdGenerator;
     private final Clock clock;
 
     @PostMapping
@@ -94,7 +96,7 @@ public class CashFlowRestController {
             @RequestBody CashFlowDto.ImportHistoricalCashChangeJson request) {
         CashChangeId cashChangeId = commandGateway.send(
                 new ImportHistoricalCashChangeCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         new CategoryName(request.getCategory()),
                         new Name(request.getName()),
                         new Description(request.getDescription()),
@@ -118,13 +120,14 @@ public class CashFlowRestController {
             @Valid @RequestBody CashFlowDto.AttestHistoricalImportJson request) {
 
         // Get CashFlow before attestation to calculate the balance
-        CashFlow cashFlowBeforeAttestation = domainCashFlowRepository.findById(new CashFlowId(cashFlowId))
-                .orElseThrow(() -> new CashFlowDoesNotExistsException(new CashFlowId(cashFlowId)));
+        CashFlowId cfId = CashFlowId.of(cashFlowId);
+        CashFlow cashFlowBeforeAttestation = domainCashFlowRepository.findById(cfId)
+                .orElseThrow(() -> new CashFlowDoesNotExistsException(cfId));
         Money calculatedBalance = cashFlowBeforeAttestation.calculateCurrentBalance();
 
         CashFlowSnapshot snapshot = commandGateway.send(
                 new AttestHistoricalImportCommand(
-                        new CashFlowId(cashFlowId),
+                        cfId,
                         request.getConfirmedBalance(),
                         request.isForceAttestation(),
                         request.isCreateAdjustment()
@@ -173,7 +176,7 @@ public class CashFlowRestController {
 
         CashFlowSnapshot snapshot = commandGateway.send(
                 new RollbackImportCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         deleteCategories
                 )
         );
@@ -193,9 +196,9 @@ public class CashFlowRestController {
     public String appendExpectedCashChange(@RequestBody CashFlowDto.AppendExpectedCashChangeJson request) {
         CashChangeId cashChangeId = commandGateway.send(
                 new AppendExpectedCashChangeCommand(
-                        new CashFlowId(request.getCashFlowId()),
+                        CashFlowId.of(request.getCashFlowId()),
                         new CategoryName(request.getCategory()),
-                        new CashChangeId(CashChangeId.generate().id()),
+                        businessIdGenerator.generateCashChangeId(),
                         new Name(request.getName()),
                         new Description(request.getDescription()),
                         request.getMoney(),
@@ -211,9 +214,9 @@ public class CashFlowRestController {
     public String appendPaidCashChange(@RequestBody CashFlowDto.AppendPaidCashChangeJson request) {
         CashChangeId cashChangeId = commandGateway.send(
                 new AppendPaidCashChangeCommand(
-                        new CashFlowId(request.getCashFlowId()),
+                        CashFlowId.of(request.getCashFlowId()),
                         new CategoryName(request.getCategory()),
-                        new CashChangeId(CashChangeId.generate().id()),
+                        businessIdGenerator.generateCashChangeId(),
                         new Name(request.getName()),
                         new Description(request.getDescription()),
                         request.getMoney(),
@@ -230,8 +233,8 @@ public class CashFlowRestController {
     public void confirm(@Valid @RequestBody CashFlowDto.ConfirmCashChangeJson request) {
         commandGateway.send(
                 new ConfirmCashChangeCommand(
-                        new CashFlowId(request.getCashFlowId()),
-                        new CashChangeId(request.getCashChangeId()),
+                        CashFlowId.of(request.getCashFlowId()),
+                        CashChangeId.of(request.getCashChangeId()),
                         ZonedDateTime.now(clock)));
     }
 
@@ -239,8 +242,8 @@ public class CashFlowRestController {
     public void edit(@Valid @RequestBody CashFlowDto.EditCashChangeJson request) {
         commandGateway.send(
                 new EditCashChangeCommand(
-                        new CashFlowId(request.getCashFlowId()),
-                        new CashChangeId(request.getCashChangeId()),
+                        CashFlowId.of(request.getCashFlowId()),
+                        CashChangeId.of(request.getCashChangeId()),
                         new Name(request.getName()),
                         new Description(request.getDescription()),
                         request.getMoney(),
@@ -254,8 +257,8 @@ public class CashFlowRestController {
     public void reject(@Valid @RequestBody CashFlowDto.RejectCashChangeJson request) {
         commandGateway.send(
                 new RejectCashChangeCommand(
-                        new CashFlowId(request.getCashFlowId()),
-                        new CashChangeId(request.getCashChangeId()),
+                        CashFlowId.of(request.getCashFlowId()),
+                        CashChangeId.of(request.getCashChangeId()),
                         new Reason(request.getReason())
                 )
         );
@@ -264,7 +267,7 @@ public class CashFlowRestController {
     @GetMapping("/{cashFlowId}")
     public CashFlowDto.CashFlowSummaryJson getCashFlow(@PathVariable("cashFlowId") String cashFlowId) {
         CashFlowSnapshot snapshot = queryGateway.send(
-                new GetCashFlowQuery(new CashFlowId(cashFlowId))
+                new GetCashFlowQuery(CashFlowId.of(cashFlowId))
         );
 
         return mapper.mapCashFlow(snapshot);
@@ -298,14 +301,15 @@ public class CashFlowRestController {
      * In SETUP mode, only import operations (isImport=true) can create categories.
      */
     public void createCategory(String cashFlowId, CashFlowDto.CreateCategoryJson request, boolean isImport) {
+        CashFlowId cfId = CashFlowId.of(cashFlowId);
         CreateCategoryCommand command = isImport
                 ? CreateCategoryCommand.forImport(
-                        new CashFlowId(cashFlowId),
+                        cfId,
                         ofNullable(request.getParentCategoryName()).map(CategoryName::new).orElse(CategoryName.NOT_DEFINED),
                         new CategoryName(request.getCategory()),
                         request.getType())
                 : new CreateCategoryCommand(
-                        new CashFlowId(cashFlowId),
+                        cfId,
                         ofNullable(request.getParentCategoryName()).map(CategoryName::new).orElse(CategoryName.NOT_DEFINED),
                         new CategoryName(request.getCategory()),
                         request.getType());
@@ -324,7 +328,7 @@ public class CashFlowRestController {
     public void setBudgeting(@RequestBody CashFlowDto.SetBudgetingJson request) {
         commandGateway.send(
                 new SetBudgetingCommand(
-                        new CashFlowId(request.getCashFlowId()),
+                        CashFlowId.of(request.getCashFlowId()),
                         new CategoryName(request.getCategoryName()),
                         request.getCategoryType(),
                         request.getBudget()
@@ -336,7 +340,7 @@ public class CashFlowRestController {
     public void updateBudgeting(@RequestBody CashFlowDto.UpdateBudgetingJson request) {
         commandGateway.send(
                 new UpdateBudgetingCommand(
-                        new CashFlowId(request.getCashFlowId()),
+                        CashFlowId.of(request.getCashFlowId()),
                         new CategoryName(request.getCategoryName()),
                         request.getCategoryType(),
                         request.getNewBudget()
@@ -348,7 +352,7 @@ public class CashFlowRestController {
     public void removeBudgeting(@RequestBody CashFlowDto.RemoveBudgetingJson request) {
         commandGateway.send(
                 new RemoveBudgetingCommand(
-                        new CashFlowId(request.getCashFlowId()),
+                        CashFlowId.of(request.getCashFlowId()),
                         new CategoryName(request.getCategoryName()),
                         request.getCategoryType()
                 )
@@ -365,7 +369,7 @@ public class CashFlowRestController {
             @RequestBody CashFlowDto.ArchiveCategoryJson request) {
         commandGateway.send(
                 new ArchiveCategoryCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         new CategoryName(request.getCategoryName()),
                         request.getCategoryType(),
                         request.isForceArchiveChildren()
@@ -382,7 +386,7 @@ public class CashFlowRestController {
             @RequestBody CashFlowDto.UnarchiveCategoryJson request) {
         commandGateway.send(
                 new UnarchiveCategoryCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         new CategoryName(request.getCategoryName()),
                         request.getCategoryType()
                 )
@@ -414,7 +418,7 @@ public class CashFlowRestController {
 
         RolloverMonthResult result = commandGateway.send(
                 new RolloverMonthCommand(
-                        new CashFlowId(cashFlowId),
+                        CashFlowId.of(cashFlowId),
                         ZonedDateTime.now(clock)
                 )
         );
@@ -445,7 +449,7 @@ public class CashFlowRestController {
             @PathVariable("cashFlowId") String cashFlowId,
             @PathVariable("targetPeriod") String targetPeriod) {
 
-        CashFlowId cfId = new CashFlowId(cashFlowId);
+        CashFlowId cfId = CashFlowId.of(cashFlowId);
         YearMonth target = YearMonth.parse(targetPeriod);
         ZonedDateTime now = ZonedDateTime.now(clock);
 

--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
@@ -90,7 +90,7 @@ public class CashFlowRestController {
      * Import a historical cash change to a CashFlow in SETUP mode.
      * The transaction will be added to the appropriate historical month based on paidDate.
      */
-    @PostMapping("/{cashFlowId}/import-historical")
+    @PostMapping("/cf={cashFlowId}/import-historical")
     public String importHistoricalCashChange(
             @PathVariable("cashFlowId") String cashFlowId,
             @RequestBody CashFlowDto.ImportHistoricalCashChangeJson request) {
@@ -114,7 +114,7 @@ public class CashFlowRestController {
      * This marks the end of the historical import process.
      * All IMPORT_PENDING months will be changed to IMPORTED.
      */
-    @PostMapping("/{cashFlowId}/attest-historical-import")
+    @PostMapping("/cf={cashFlowId}/attest-historical-import")
     public CashFlowDto.AttestHistoricalImportResponseJson attestHistoricalImport(
             @PathVariable("cashFlowId") String cashFlowId,
             @Valid @RequestBody CashFlowDto.AttestHistoricalImportJson request) {
@@ -167,7 +167,7 @@ public class CashFlowRestController {
      * This allows the user to start the import process fresh if mistakes were made.
      * The CashFlow remains in SETUP mode after rollback.
      */
-    @DeleteMapping("/{cashFlowId}/import")
+    @DeleteMapping("/cf={cashFlowId}/import")
     public CashFlowDto.RollbackImportResponseJson rollbackImport(
             @PathVariable("cashFlowId") String cashFlowId,
             @RequestBody(required = false) CashFlowDto.RollbackImportJson request) {
@@ -264,7 +264,7 @@ public class CashFlowRestController {
         );
     }
 
-    @GetMapping("/{cashFlowId}")
+    @GetMapping("/cf={cashFlowId}")
     public CashFlowDto.CashFlowSummaryJson getCashFlow(@PathVariable("cashFlowId") String cashFlowId) {
         CashFlowSnapshot snapshot = queryGateway.send(
                 new GetCashFlowQuery(CashFlowId.of(cashFlowId))
@@ -288,7 +288,7 @@ public class CashFlowRestController {
      * REST endpoint for category creation.
      * Use isImport=true query parameter when creating categories during bank data import (allowed in SETUP mode).
      */
-    @PostMapping("/{cashFlowId}/category")
+    @PostMapping("/cf={cashFlowId}/category")
     public void createCategoryEndpoint(
             @PathVariable("cashFlowId") String cashFlowId,
             @RequestBody CashFlowDto.CreateCategoryJson request,
@@ -363,7 +363,7 @@ public class CashFlowRestController {
      * Archive a category, hiding it from new transaction creation.
      * Archived categories remain visible in historical transactions that used them.
      */
-    @PostMapping("/{cashFlowId}/category/archive")
+    @PostMapping("/cf={cashFlowId}/category/archive")
     public void archiveCategory(
             @PathVariable("cashFlowId") String cashFlowId,
             @RequestBody CashFlowDto.ArchiveCategoryJson request) {
@@ -380,7 +380,7 @@ public class CashFlowRestController {
     /**
      * Unarchive a category, making it available for new transaction creation again.
      */
-    @PostMapping("/{cashFlowId}/category/unarchive")
+    @PostMapping("/cf={cashFlowId}/category/unarchive")
     public void unarchiveCategory(
             @PathVariable("cashFlowId") String cashFlowId,
             @RequestBody CashFlowDto.UnarchiveCategoryJson request) {
@@ -412,7 +412,7 @@ public class CashFlowRestController {
      * @param cashFlowId the CashFlow to rollover
      * @return rollover result with old and new active periods
      */
-    @PostMapping("/{cashFlowId}/rollover")
+    @PostMapping("/cf={cashFlowId}/rollover")
     public CashFlowDto.RolloverMonthResponseJson rolloverMonth(
             @PathVariable("cashFlowId") String cashFlowId) {
 
@@ -444,7 +444,7 @@ public class CashFlowRestController {
      * @param targetPeriod the target period that should become ACTIVE (format: yyyy-MM)
      * @return batch rollover result
      */
-    @PostMapping("/{cashFlowId}/rollover/to/{targetPeriod}")
+    @PostMapping("/cf={cashFlowId}/rollover/to/{targetPeriod}")
     public CashFlowDto.BatchRolloverResponseJson rolloverMonthsTo(
             @PathVariable("cashFlowId") String cashFlowId,
             @PathVariable("targetPeriod") String targetPeriod) {

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/attesthistoricalimport/AttestHistoricalImportCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/attesthistoricalimport/AttestHistoricalImportCommandHandler.java
@@ -2,6 +2,7 @@ package com.multi.vidulum.cashflow.app.commands.attesthistoricalimport;
 
 import com.multi.vidulum.cashflow.domain.*;
 import com.multi.vidulum.cashflow.domain.snapshots.CashFlowSnapshot;
+import com.multi.vidulum.common.BusinessIdGenerator;
 import com.multi.vidulum.common.JsonContent;
 import com.multi.vidulum.common.Money;
 import com.multi.vidulum.common.events.CashFlowUnifiedEvent;
@@ -21,6 +22,7 @@ public class AttestHistoricalImportCommandHandler implements CommandHandler<Atte
 
     private final DomainCashFlowRepository domainCashFlowRepository;
     private final CashFlowEventEmitter cashFlowEventEmitter;
+    private final BusinessIdGenerator businessIdGenerator;
     private final Clock clock;
 
     @Override
@@ -59,7 +61,7 @@ public class AttestHistoricalImportCommandHandler implements CommandHandler<Atte
         // Determine if we should create an adjustment transaction
         CashChangeId adjustmentCashChangeId = null;
         if (!isZeroDifference && command.createAdjustment()) {
-            adjustmentCashChangeId = CashChangeId.generate();
+            adjustmentCashChangeId = businessIdGenerator.generateCashChangeId();
         }
 
         CashFlowEvent.HistoricalImportAttestedEvent event = new CashFlowEvent.HistoricalImportAttestedEvent(

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowCommandHandler.java
@@ -2,6 +2,7 @@ package com.multi.vidulum.cashflow.app.commands.create;
 
 import com.multi.vidulum.cashflow.domain.*;
 import com.multi.vidulum.cashflow.domain.snapshots.CashFlowSnapshot;
+import com.multi.vidulum.common.BusinessIdGenerator;
 import com.multi.vidulum.common.JsonContent;
 import com.multi.vidulum.common.events.CashFlowUnifiedEvent;
 import com.multi.vidulum.shared.cqrs.commands.CommandHandler;
@@ -20,7 +21,7 @@ public class CreateCashFlowCommandHandler implements CommandHandler<CreateCashFl
 
     private final DomainCashFlowRepository domainCashFlowRepository;
     private final CashFlowEventEmitter cashFlowEventEmitter;
-
+    private final BusinessIdGenerator businessIdGenerator;
     private final Clock clock;
 
     @Override
@@ -32,7 +33,7 @@ public class CreateCashFlowCommandHandler implements CommandHandler<CreateCashFl
 
         CashFlow cashFlow  = new CashFlow();
         CashFlowEvent.CashFlowCreatedEvent event = new CashFlowEvent.CashFlowCreatedEvent(
-                CashFlowId.generate(),
+                businessIdGenerator.generateCashFlowId(),
                 command.userId(),
                 command.name(),
                 command.description(),

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowWithHistoryCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/create/CreateCashFlowWithHistoryCommandHandler.java
@@ -2,6 +2,7 @@ package com.multi.vidulum.cashflow.app.commands.create;
 
 import com.multi.vidulum.cashflow.domain.*;
 import com.multi.vidulum.cashflow.domain.snapshots.CashFlowSnapshot;
+import com.multi.vidulum.common.BusinessIdGenerator;
 import com.multi.vidulum.common.JsonContent;
 import com.multi.vidulum.common.events.CashFlowUnifiedEvent;
 import com.multi.vidulum.shared.cqrs.commands.CommandHandler;
@@ -21,6 +22,7 @@ public class CreateCashFlowWithHistoryCommandHandler implements CommandHandler<C
 
     private final DomainCashFlowRepository domainCashFlowRepository;
     private final CashFlowEventEmitter cashFlowEventEmitter;
+    private final BusinessIdGenerator businessIdGenerator;
     private final Clock clock;
 
     @Override
@@ -40,7 +42,7 @@ public class CreateCashFlowWithHistoryCommandHandler implements CommandHandler<C
 
         CashFlow cashFlow = new CashFlow();
         CashFlowEvent.CashFlowWithHistoryCreatedEvent event = new CashFlowEvent.CashFlowWithHistoryCreatedEvent(
-                CashFlowId.generate(),
+                businessIdGenerator.generateCashFlowId(),
                 command.userId(),
                 command.name(),
                 command.description(),

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/importhistorical/ImportHistoricalCashChangeCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/importhistorical/ImportHistoricalCashChangeCommandHandler.java
@@ -2,6 +2,7 @@ package com.multi.vidulum.cashflow.app.commands.importhistorical;
 
 import com.multi.vidulum.cashflow.domain.*;
 import com.multi.vidulum.cashflow.domain.snapshots.CashFlowSnapshot;
+import com.multi.vidulum.common.BusinessIdGenerator;
 import com.multi.vidulum.common.JsonContent;
 import com.multi.vidulum.common.events.CashFlowUnifiedEvent;
 import com.multi.vidulum.shared.cqrs.commands.CommandHandler;
@@ -21,6 +22,7 @@ public class ImportHistoricalCashChangeCommandHandler implements CommandHandler<
 
     private final DomainCashFlowRepository domainCashFlowRepository;
     private final CashFlowEventEmitter cashFlowEventEmitter;
+    private final BusinessIdGenerator businessIdGenerator;
     private final Clock clock;
 
     @Override
@@ -68,7 +70,7 @@ public class ImportHistoricalCashChangeCommandHandler implements CommandHandler<
         if (command.paidDate().isAfter(now)) {
             throw new ImportDateInFutureException(command.paidDate(), now);
         }
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashChangeId cashChangeId = businessIdGenerator.generateCashChangeId();
 
         CashFlowEvent.HistoricalCashChangeImportedEvent event = new CashFlowEvent.HistoricalCashChangeImportedEvent(
                 command.cashFlowId(),

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashChangeId.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashChangeId.java
@@ -1,10 +1,48 @@
 package com.multi.vidulum.cashflow.domain;
 
-import java.util.UUID;
+import java.util.regex.Pattern;
 
+/**
+ * Value object representing a CashChange ID.
+ * Format: CC + 10 digits (e.g., CC1000000001)
+ *
+ * <p>Use {@link com.multi.vidulum.common.BusinessIdGenerator#generateCashChangeId()} to create new IDs.
+ * Use {@link CashChangeId#of(String)} to parse existing IDs (validates format).
+ *
+ * <p><b>Constraints:</b>
+ * <ul>
+ *   <li>Must match pattern: CC followed by exactly 10 digits</li>
+ *   <li>Valid range: CC0000000000 - CC9999999999 (10 billion unique IDs)</li>
+ *   <li>Starting value in production: CC1000000001</li>
+ * </ul>
+ */
 public record CashChangeId(String id) {
 
-    public static CashChangeId generate() {
-        return new CashChangeId(UUID.randomUUID().toString());
+    private static final Pattern PATTERN = Pattern.compile("CC\\d{10}");
+
+    /**
+     * Compact constructor - validates format.
+     * Allows null for deserialization edge cases, throws for invalid non-null values.
+     *
+     * @throws InvalidCashChangeIdFormatException if id is non-null and doesn't match CCXXXXXXXXXX pattern
+     */
+    public CashChangeId {
+        if (id != null && !PATTERN.matcher(id).matches()) {
+            throw new InvalidCashChangeIdFormatException(id);
+        }
+    }
+
+    /**
+     * Creates a CashChangeId from a string, validating the format.
+     *
+     * @param id the CashChange ID string (must match pattern CCXXXXXXXXXX)
+     * @return validated CashChangeId
+     * @throws InvalidCashChangeIdFormatException if the format is invalid or null
+     */
+    public static CashChangeId of(String id) {
+        if (id == null || !PATTERN.matcher(id).matches()) {
+            throw new InvalidCashChangeIdFormatException(id);
+        }
+        return new CashChangeId(id);
     }
 }

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowId.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowId.java
@@ -1,10 +1,48 @@
 package com.multi.vidulum.cashflow.domain;
 
-import java.util.UUID;
+import java.util.regex.Pattern;
 
+/**
+ * Value object representing a CashFlow ID.
+ * Format: CF + 8 digits (e.g., CF10000001)
+ *
+ * <p>Use {@link com.multi.vidulum.common.BusinessIdGenerator#generateCashFlowId()} to create new IDs.
+ * Use {@link CashFlowId#of(String)} to parse existing IDs (validates format).
+ *
+ * <p><b>Constraints:</b>
+ * <ul>
+ *   <li>Must match pattern: CF followed by exactly 8 digits</li>
+ *   <li>Valid range: CF00000000 - CF99999999 (100 million unique IDs)</li>
+ *   <li>Starting value in production: CF10000001</li>
+ * </ul>
+ */
 public record CashFlowId(String id) {
 
-    public static CashFlowId generate() {
-        return new CashFlowId(UUID.randomUUID().toString());
+    private static final Pattern PATTERN = Pattern.compile("CF\\d{8}");
+
+    /**
+     * Compact constructor - validates format.
+     * Allows null for deserialization edge cases, throws for invalid non-null values.
+     *
+     * @throws InvalidCashFlowIdFormatException if id is non-null and doesn't match CFXXXXXXXX pattern
+     */
+    public CashFlowId {
+        if (id != null && !PATTERN.matcher(id).matches()) {
+            throw new InvalidCashFlowIdFormatException(id);
+        }
+    }
+
+    /**
+     * Creates a CashFlowId from a string, validating the format.
+     *
+     * @param id the CashFlow ID string (must match pattern CFXXXXXXXX)
+     * @return validated CashFlowId
+     * @throws InvalidCashFlowIdFormatException if the format is invalid or null
+     */
+    public static CashFlowId of(String id) {
+        if (id == null || !PATTERN.matcher(id).matches()) {
+            throw new InvalidCashFlowIdFormatException(id);
+        }
+        return new CashFlowId(id);
     }
 }

--- a/src/main/java/com/multi/vidulum/cashflow/domain/InvalidCashChangeIdFormatException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/InvalidCashChangeIdFormatException.java
@@ -1,0 +1,18 @@
+package com.multi.vidulum.cashflow.domain;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when a CashChange ID does not match the expected format.
+ * Valid format: CCXXXXXXXXXX (CC followed by 10 digits, e.g., CC1000000001)
+ */
+@Getter
+public class InvalidCashChangeIdFormatException extends RuntimeException {
+
+    private final String providedId;
+
+    public InvalidCashChangeIdFormatException(String providedId) {
+        super("Invalid CashChange ID format: '" + providedId + "'. Expected: CCXXXXXXXXXX (e.g., CC1000000001)");
+        this.providedId = providedId;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow/domain/InvalidCashFlowIdFormatException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/InvalidCashFlowIdFormatException.java
@@ -1,0 +1,18 @@
+package com.multi.vidulum.cashflow.domain;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when a CashFlow ID does not match the expected format.
+ * Valid format: CFXXXXXXXX (CF followed by 8 digits, e.g., CF10000001)
+ */
+@Getter
+public class InvalidCashFlowIdFormatException extends RuntimeException {
+
+    private final String providedId;
+
+    public InvalidCashFlowIdFormatException(String providedId) {
+        super("Invalid CashFlow ID format: '" + providedId + "'. Expected: CFXXXXXXXX (e.g., CF10000001)");
+        this.providedId = providedId;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow/infrastructure/entity/CashChangeEntity.java
+++ b/src/main/java/com/multi/vidulum/cashflow/infrastructure/entity/CashChangeEntity.java
@@ -58,7 +58,7 @@ public class CashChangeEntity {
         ZonedDateTime endDateTime = endDate != null ? ZonedDateTime.ofInstant(endDate.toInstant(), ZoneOffset.UTC) : null;
 
         return new CashChangeSnapshot(
-                new CashChangeId(cashChangeId),
+                CashChangeId.of(cashChangeId),
                 new Name(name),
                 new Description(description),
                 money,

--- a/src/main/java/com/multi/vidulum/cashflow/infrastructure/entity/CashFlowEntity.java
+++ b/src/main/java/com/multi/vidulum/cashflow/infrastructure/entity/CashFlowEntity.java
@@ -94,8 +94,8 @@ public class CashFlowEntity {
                         Function.identity()));
 
         return new CashFlowSnapshot(
-                new CashFlowId(cashFlowId),
-                new UserId(userId),
+                CashFlowId.of(cashFlowId),
+                UserId.of(userId),
                 new Name(name),
                 new Description(description),
                 bankAccount,

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastRestController.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastRestController.java
@@ -20,7 +20,7 @@ public class CashFlowForecastRestController {
     private final CashFlowForecastStatementRepository statementRepository;
     private final CashFlowForecastMapper mapper;
 
-    @GetMapping("/{cashFlowId}")
+    @GetMapping("/cf={cashFlowId}")
     public CashFlowForecastDto.CashFlowForecastStatementJson getForecastStatement(
             @PathVariable("cashFlowId") String cashFlowId) {
         CashFlowId id = CashFlowId.of(cashFlowId);
@@ -36,7 +36,7 @@ public class CashFlowForecastRestController {
      * @param cashFlowId the CashFlow identifier
      * @return response with cashFlowId and map of YearMonth to ForecastMonthStatus
      */
-    @GetMapping("/{cashFlowId}/month-statuses")
+    @GetMapping("/cf={cashFlowId}/month-statuses")
     public CashFlowForecastDto.MonthStatusesResponse getMonthStatuses(@PathVariable("cashFlowId") String cashFlowId) {
         CashFlowId id = CashFlowId.of(cashFlowId);
         Map<YearMonth, CashFlowForecastDto.ForecastMonthStatus> monthStatuses = statementRepository.findByCashFlowId(id)

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastRestController.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastRestController.java
@@ -23,7 +23,7 @@ public class CashFlowForecastRestController {
     @GetMapping("/{cashFlowId}")
     public CashFlowForecastDto.CashFlowForecastStatementJson getForecastStatement(
             @PathVariable("cashFlowId") String cashFlowId) {
-        CashFlowId id = new CashFlowId(cashFlowId);
+        CashFlowId id = CashFlowId.of(cashFlowId);
         CashFlowForecastStatement statement = statementRepository.findByCashFlowId(id)
                 .orElseThrow(() -> new CashFlowDoesNotExistsException(id));
         return mapper.map(statement);
@@ -38,7 +38,7 @@ public class CashFlowForecastRestController {
      */
     @GetMapping("/{cashFlowId}/month-statuses")
     public CashFlowForecastDto.MonthStatusesResponse getMonthStatuses(@PathVariable("cashFlowId") String cashFlowId) {
-        CashFlowId id = new CashFlowId(cashFlowId);
+        CashFlowId id = CashFlowId.of(cashFlowId);
         Map<YearMonth, CashFlowForecastDto.ForecastMonthStatus> monthStatuses = statementRepository.findByCashFlowId(id)
                 .map(this::extractMonthStatuses)
                 .orElse(Map.of());

--- a/src/main/java/com/multi/vidulum/common/BusinessIdGenerator.java
+++ b/src/main/java/com/multi/vidulum/common/BusinessIdGenerator.java
@@ -1,5 +1,7 @@
 package com.multi.vidulum.common;
 
+import com.multi.vidulum.cashflow.domain.CashChangeId;
+import com.multi.vidulum.cashflow.domain.CashFlowId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -14,8 +16,10 @@ import org.springframework.stereotype.Service;
  *
  * ID formats:
  * - UserId: U + 8 digits (e.g., U10000001)
+ * - CashFlowId: CF + 8 digits (e.g., CF10000001)
+ * - CashChangeId: CC + 10 digits (e.g., CC1000000001)
  *
- * Starting value: 10000000 (so first ID is 10000001)
+ * Starting value: 10000000 for 8-digit IDs, 1000000000 for 10-digit IDs
  */
 @Service
 @RequiredArgsConstructor
@@ -24,7 +28,10 @@ public class BusinessIdGenerator {
     private final MongoTemplate mongoTemplate;
 
     private static final long INITIAL_VALUE = 10000000L;
+    private static final long INITIAL_VALUE_10_DIGITS = 1000000000L;
     private static final String USER_SEQUENCE = "user_sequence";
+    private static final String CASHFLOW_SEQUENCE = "cashflow_sequence";
+    private static final String CASHCHANGE_SEQUENCE = "cashchange_sequence";
 
     /**
      * Generates a new unique UserId.
@@ -33,18 +40,41 @@ public class BusinessIdGenerator {
      * @return new UserId with human-readable format
      */
     public UserId generateUserId() {
-        long seq = getNextSequence(USER_SEQUENCE);
+        long seq = getNextSequence(USER_SEQUENCE, INITIAL_VALUE);
         return UserId.of(String.format("U%08d", seq));
     }
 
     /**
+     * Generates a new unique CashFlowId.
+     * Format: CF + 8 digits (e.g., CF10000001)
+     *
+     * @return new CashFlowId with human-readable format
+     */
+    public CashFlowId generateCashFlowId() {
+        long seq = getNextSequence(CASHFLOW_SEQUENCE, INITIAL_VALUE);
+        return CashFlowId.of(String.format("CF%08d", seq));
+    }
+
+    /**
+     * Generates a new unique CashChangeId.
+     * Format: CC + 10 digits (e.g., CC1000000001)
+     *
+     * @return new CashChangeId with human-readable format
+     */
+    public CashChangeId generateCashChangeId() {
+        long seq = getNextSequence(CASHCHANGE_SEQUENCE, INITIAL_VALUE_10_DIGITS);
+        return CashChangeId.of(String.format("CC%010d", seq));
+    }
+
+    /**
      * Gets the next value from a named sequence using MongoDB's atomic findAndModify.
-     * If the sequence doesn't exist, it's created with INITIAL_VALUE.
+     * If the sequence doesn't exist, it's created with the specified initial value.
      *
      * @param sequenceName the name of the sequence
+     * @param initialValue the initial value for new sequences
      * @return the next sequence value
      */
-    private long getNextSequence(String sequenceName) {
+    private long getNextSequence(String sequenceName, long initialValue) {
         Query query = new Query(Criteria.where("_id").is(sequenceName));
         Update update = new Update().inc("value", 1);
         FindAndModifyOptions options = FindAndModifyOptions.options()
@@ -53,10 +83,10 @@ public class BusinessIdGenerator {
 
         SequenceDocument result = mongoTemplate.findAndModify(query, update, options, SequenceDocument.class);
 
-        if (result == null || result.getValue() <= INITIAL_VALUE) {
+        if (result == null || result.getValue() <= initialValue) {
             // Initialize sequence if it's new or below initial value
-            mongoTemplate.save(new SequenceDocument(sequenceName, INITIAL_VALUE + 1));
-            return INITIAL_VALUE + 1;
+            mongoTemplate.save(new SequenceDocument(sequenceName, initialValue + 1));
+            return initialValue + 1;
         }
 
         return result.getValue();

--- a/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
+++ b/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "Request validation failed"),
     VALIDATION_INVALID_JSON(HttpStatus.BAD_REQUEST, "Invalid JSON format"),
     INVALID_USER_ID_FORMAT(HttpStatus.BAD_REQUEST, "Invalid User ID format. Expected: UXXXXXXXX"),
+    INVALID_CASHFLOW_ID_FORMAT(HttpStatus.BAD_REQUEST, "Invalid CashFlow ID format. Expected: CFXXXXXXXX"),
+    INVALID_CASHCHANGE_ID_FORMAT(HttpStatus.BAD_REQUEST, "Invalid CashChange ID format. Expected: CCXXXXXXXXXX"),
 
     // CashFlow - Resources
     CASHFLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "CashFlow not found"),

--- a/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
+++ b/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
@@ -3,6 +3,8 @@ package com.multi.vidulum.security.config;
 import com.multi.vidulum.cashflow.app.commands.archive.CannotArchiveSystemCategoryException;
 import com.multi.vidulum.cashflow.app.commands.archive.CategoryNotFoundException;
 import com.multi.vidulum.cashflow.domain.*;
+import com.multi.vidulum.cashflow.domain.InvalidCashChangeIdFormatException;
+import com.multi.vidulum.cashflow.domain.InvalidCashFlowIdFormatException;
 import com.multi.vidulum.common.InvalidUserIdFormatException;
 import com.multi.vidulum.cashflow.domain.CashFlowNameAlreadyExistsException;
 import com.multi.vidulum.common.error.ApiError;
@@ -70,6 +72,20 @@ public class ErrorHttpHandler {
     public ResponseEntity<ApiError> handleInvalidUserIdFormat(InvalidUserIdFormatException ex) {
         log.debug("Invalid User ID format: {}", ex.getProvidedId());
         ApiError error = ApiError.of(ErrorCode.INVALID_USER_ID_FORMAT, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(InvalidCashFlowIdFormatException.class)
+    public ResponseEntity<ApiError> handleInvalidCashFlowIdFormat(InvalidCashFlowIdFormatException ex) {
+        log.debug("Invalid CashFlow ID format: {}", ex.getProvidedId());
+        ApiError error = ApiError.of(ErrorCode.INVALID_CASHFLOW_ID_FORMAT, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(InvalidCashChangeIdFormatException.class)
+    public ResponseEntity<ApiError> handleInvalidCashChangeIdFormat(InvalidCashChangeIdFormatException ex) {
+        log.debug("Invalid CashChange ID format: {}", ex.getProvidedId());
+        ApiError error = ApiError.of(ErrorCode.INVALID_CASHCHANGE_ID_FORMAT, ex.getMessage());
         return ResponseEntity.status(error.httpStatus()).body(error);
     }
 

--- a/src/test/java/com/multi/vidulum/CashFlowForecastStatementGenerator.java
+++ b/src/test/java/com/multi/vidulum/CashFlowForecastStatementGenerator.java
@@ -70,7 +70,7 @@ public class CashFlowForecastStatementGenerator extends IntegrationTest {
                 OUTFLOW, List.of(new CategoryName("Uncategorized"), new CategoryName("Category3"))
         );
 
-        CashChangeId lastCashChangeId = CashChangeId.generate();
+        CashChangeId lastCashChangeId = TestIds.nextCashChangeId();
         CashChangeStatus statusOfLastCashChange = CashChangeStatus.PENDING;
         YearMonth processingPeriod = YearMonth.now(clock);
         for (int i = 0; i < 12+NUMBER_OF_ATTESTED_MONTHS; i++) {
@@ -158,7 +158,7 @@ class Actor {
                 new AppendExpectedCashChangeCommand(
                         cashFlowId,
                         category,
-                        new CashChangeId(CashChangeId.generate().id()),
+                        TestIds.nextCashChangeId(),
                         new Name("cash-change name"),
                         new Description("cash-change description"),
                         money,

--- a/src/test/java/com/multi/vidulum/CashflowStatementViaAIGenerator.java
+++ b/src/test/java/com/multi/vidulum/CashflowStatementViaAIGenerator.java
@@ -758,7 +758,7 @@ class HomeBudgetActor {
                 new AppendExpectedCashChangeCommand(
                         cashFlowId,
                         category,
-                        new CashChangeId(CashChangeId.generate().id()),
+                        TestIds.nextCashChangeId(),
                         new Name("Transaction: " + category.name()),
                         new Description("Auto-generated transaction in category " + category.name()),
                         money,

--- a/src/test/java/com/multi/vidulum/DualCashflowStatementGenerator.java
+++ b/src/test/java/com/multi/vidulum/DualCashflowStatementGenerator.java
@@ -1080,7 +1080,7 @@ class DualBudgetActor {
                 new AppendExpectedCashChangeCommand(
                         cashFlowId,
                         category,
-                        new CashChangeId(CashChangeId.generate().id()),
+                        TestIds.nextCashChangeId(),
                         new Name("Transaction: " + category.name()),
                         new Description("Auto-generated transaction in category " + category.name()),
                         money,
@@ -1095,7 +1095,7 @@ class DualBudgetActor {
                 new AppendPaidCashChangeCommand(
                         cashFlowId,
                         category,
-                        new CashChangeId(CashChangeId.generate().id()),
+                        TestIds.nextCashChangeId(),
                         new Name("Paid Transaction: " + category.name()),
                         new Description("Auto-generated paid transaction in category " + category.name()),
                         money,

--- a/src/test/java/com/multi/vidulum/TestIds.java
+++ b/src/test/java/com/multi/vidulum/TestIds.java
@@ -1,5 +1,7 @@
 package com.multi.vidulum;
 
+import com.multi.vidulum.cashflow.domain.CashChangeId;
+import com.multi.vidulum.cashflow.domain.CashFlowId;
 import com.multi.vidulum.common.UserId;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -8,19 +10,32 @@ import java.util.concurrent.atomic.AtomicLong;
  * Helper class for generating test IDs in unit and integration tests.
  * Provides sequential, human-readable IDs that match the production format.
  *
- * Usage:
- * - Use {@link #nextUserId()} to generate unique test user IDs
- * - Use {@link #reset()} in @BeforeEach if tests need predictable IDs
- * - Use {@link #invalidUserId()} for testing validation errors
- * - Use {@link #nonExistentUserId()} for testing "not found" scenarios
+ * <p>ID formats:
+ * <ul>
+ *   <li>UserId: U + 8 digits (e.g., U10000001)</li>
+ *   <li>CashFlowId: CF + 8 digits (e.g., CF10000001)</li>
+ *   <li>CashChangeId: CC + 10 digits (e.g., CC1000000001)</li>
+ * </ul>
+ *
+ * <p>Usage:
+ * <ul>
+ *   <li>Use {@link #nextUserId()}, {@link #nextCashFlowId()}, {@link #nextCashChangeId()} to generate unique test IDs</li>
+ *   <li>Use {@link #reset()} in @BeforeEach if tests need predictable IDs</li>
+ *   <li>Use invalidXxx() methods for testing validation errors</li>
+ *   <li>Use nonExistentXxx() methods for testing "not found" scenarios</li>
+ * </ul>
  */
 public final class TestIds {
 
     private static final AtomicLong userCounter = new AtomicLong(10000000);
+    private static final AtomicLong cashFlowCounter = new AtomicLong(10000000);
+    private static final AtomicLong cashChangeCounter = new AtomicLong(1000000000);
 
     private TestIds() {
         // Utility class - no instantiation
     }
+
+    // ============ UserId methods ============
 
     /**
      * Generates a new unique UserId for tests.
@@ -29,7 +44,7 @@ public final class TestIds {
      * @return new UserId with valid format
      */
     public static UserId nextUserId() {
-        return new UserId(String.format("U%08d", userCounter.incrementAndGet()));
+        return UserId.of(String.format("U%08d", userCounter.incrementAndGet()));
     }
 
     /**
@@ -58,15 +73,7 @@ public final class TestIds {
      * @return valid UserId that doesn't exist
      */
     public static UserId nonExistentUserIdObject() {
-        return new UserId("U99999999");
-    }
-
-    /**
-     * Resets all counters to initial values.
-     * Call this in @BeforeEach if your tests need predictable IDs.
-     */
-    public static void reset() {
-        userCounter.set(10000000);
+        return UserId.of("U99999999");
     }
 
     /**
@@ -80,6 +87,126 @@ public final class TestIds {
         if (suffix < 1 || suffix > 99999999) {
             throw new IllegalArgumentException("Suffix must be between 1 and 99999999");
         }
-        return new UserId(String.format("U%08d", suffix));
+        return UserId.of(String.format("U%08d", suffix));
+    }
+
+    // ============ CashFlowId methods ============
+
+    /**
+     * Generates a new unique CashFlowId for tests.
+     * Thread-safe, IDs are sequential (CF10000001, CF10000002, ...).
+     *
+     * @return new CashFlowId with valid format
+     */
+    public static CashFlowId nextCashFlowId() {
+        return CashFlowId.of(String.format("CF%08d", cashFlowCounter.incrementAndGet()));
+    }
+
+    /**
+     * Returns an invalid CashFlow ID string for testing validation errors.
+     * This will cause InvalidCashFlowIdFormatException when passed to CashFlowId.of().
+     *
+     * @return invalid CashFlow ID string
+     */
+    public static String invalidCashFlowId() {
+        return "invalid-cashflow-id";
+    }
+
+    /**
+     * Returns a valid but non-existent CashFlow ID for testing "not found" scenarios.
+     *
+     * @return valid format CashFlowId that doesn't exist in the database
+     */
+    public static String nonExistentCashFlowId() {
+        return "CF99999999";
+    }
+
+    /**
+     * Returns a valid CashFlowId object that doesn't exist in the database.
+     * Useful for testing "not found" scenarios.
+     *
+     * @return valid CashFlowId that doesn't exist
+     */
+    public static CashFlowId nonExistentCashFlowIdObject() {
+        return CashFlowId.of("CF99999999");
+    }
+
+    /**
+     * Creates a CashFlowId with a specific suffix for debugging.
+     *
+     * @param suffix a number between 1 and 99999999
+     * @return CashFlowId with that specific number
+     */
+    public static CashFlowId cashFlowIdWithSuffix(long suffix) {
+        if (suffix < 1 || suffix > 99999999) {
+            throw new IllegalArgumentException("Suffix must be between 1 and 99999999");
+        }
+        return CashFlowId.of(String.format("CF%08d", suffix));
+    }
+
+    // ============ CashChangeId methods ============
+
+    /**
+     * Generates a new unique CashChangeId for tests.
+     * Thread-safe, IDs are sequential (CC1000000001, CC1000000002, ...).
+     *
+     * @return new CashChangeId with valid format
+     */
+    public static CashChangeId nextCashChangeId() {
+        return CashChangeId.of(String.format("CC%010d", cashChangeCounter.incrementAndGet()));
+    }
+
+    /**
+     * Returns an invalid CashChange ID string for testing validation errors.
+     * This will cause InvalidCashChangeIdFormatException when passed to CashChangeId.of().
+     *
+     * @return invalid CashChange ID string
+     */
+    public static String invalidCashChangeId() {
+        return "invalid-cashchange-id";
+    }
+
+    /**
+     * Returns a valid but non-existent CashChange ID for testing "not found" scenarios.
+     *
+     * @return valid format CashChangeId that doesn't exist in the database
+     */
+    public static String nonExistentCashChangeId() {
+        return "CC9999999999";
+    }
+
+    /**
+     * Returns a valid CashChangeId object that doesn't exist in the database.
+     * Useful for testing "not found" scenarios.
+     *
+     * @return valid CashChangeId that doesn't exist
+     */
+    public static CashChangeId nonExistentCashChangeIdObject() {
+        return CashChangeId.of("CC9999999999");
+    }
+
+    /**
+     * Creates a CashChangeId with a specific suffix for debugging.
+     *
+     * @param suffix a number between 1 and 9999999999
+     * @return CashChangeId with that specific number
+     */
+    public static CashChangeId cashChangeIdWithSuffix(long suffix) {
+        if (suffix < 1 || suffix > 9999999999L) {
+            throw new IllegalArgumentException("Suffix must be between 1 and 9999999999");
+        }
+        return CashChangeId.of(String.format("CC%010d", suffix));
+    }
+
+    // ============ Reset ============
+
+    /**
+     * Resets all counters to initial values.
+     * Call this in @BeforeEach if your tests need predictable IDs.
+     */
+    public static void reset() {
+        userCounter.set(10000000);
+        cashFlowCounter.set(10000000);
+        cashChangeCounter.set(1000000000);
     }
 }

--- a/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionHttpActor.java
+++ b/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionHttpActor.java
@@ -83,7 +83,7 @@ public class BankDataIngestionHttpActor {
      */
     public CashFlowDto.CashFlowSummaryJson getCashFlow(String cashFlowId) {
         ResponseEntity<CashFlowDto.CashFlowSummaryJson> response = restTemplate.getForEntity(
-                baseUrl + "/cash-flow/" + cashFlowId,
+                baseUrl + "/cash-flow/cf=" + cashFlowId,
                 CashFlowDto.CashFlowSummaryJson.class
         );
 
@@ -96,7 +96,7 @@ public class BankDataIngestionHttpActor {
      */
     public Map<String, Object> getCashFlowAsMap(String cashFlowId) {
         ResponseEntity<Map> response = restTemplate.getForEntity(
-                baseUrl + "/cash-flow/" + cashFlowId,
+                baseUrl + "/cash-flow/cf=" + cashFlowId,
                 Map.class
         );
 
@@ -124,7 +124,7 @@ public class BankDataIngestionHttpActor {
 
         // Use isImport=true to allow category creation in SETUP mode
         ResponseEntity<Void> response = restTemplate.exchange(
-                baseUrl + "/cash-flow/" + cashFlowId + "/category?isImport=true",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category?isImport=true",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 Void.class
@@ -148,7 +148,7 @@ public class BankDataIngestionHttpActor {
                 .build();
 
         ResponseEntity<CashFlowDto.AttestHistoricalImportResponseJson> response = restTemplate.exchange(
-                baseUrl + "/cash-flow/" + cashFlowId + "/attest-historical-import",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/attest-historical-import",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 CashFlowDto.AttestHistoricalImportResponseJson.class
@@ -179,7 +179,7 @@ public class BankDataIngestionHttpActor {
                 .build();
 
         ResponseEntity<String> response = restTemplate.exchange(
-                baseUrl + "/cash-flow/" + cashFlowId + "/import-historical",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/import-historical",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 String.class
@@ -205,7 +205,7 @@ public class BankDataIngestionHttpActor {
                 .build();
 
         ResponseEntity<BankDataIngestionDto.ConfigureMappingsResponse> response = restTemplate.exchange(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/mappings",
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/mappings",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 BankDataIngestionDto.ConfigureMappingsResponse.class
@@ -259,7 +259,7 @@ public class BankDataIngestionHttpActor {
      */
     public BankDataIngestionDto.GetMappingsResponse getMappings(String cashFlowId) {
         ResponseEntity<BankDataIngestionDto.GetMappingsResponse> response = restTemplate.getForEntity(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/mappings",
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/mappings",
                 BankDataIngestionDto.GetMappingsResponse.class
         );
 
@@ -273,7 +273,7 @@ public class BankDataIngestionHttpActor {
      */
     public BankDataIngestionDto.ListStagingSessionsResponse listStagingSessions(String cashFlowId) {
         ResponseEntity<BankDataIngestionDto.ListStagingSessionsResponse> response = restTemplate.getForEntity(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/staging",
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/staging",
                 BankDataIngestionDto.ListStagingSessionsResponse.class
         );
 
@@ -296,7 +296,7 @@ public class BankDataIngestionHttpActor {
                 .build();
 
         ResponseEntity<BankDataIngestionDto.StageTransactionsResponse> response = restTemplate.exchange(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/staging",
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/staging",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 BankDataIngestionDto.StageTransactionsResponse.class
@@ -337,7 +337,7 @@ public class BankDataIngestionHttpActor {
                 .build();
 
         ResponseEntity<BankDataIngestionDto.StartImportResponse> response = restTemplate.exchange(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/import",
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/import",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 BankDataIngestionDto.StartImportResponse.class
@@ -355,7 +355,7 @@ public class BankDataIngestionHttpActor {
      */
     public BankDataIngestionDto.GetImportProgressResponse getImportProgress(String cashFlowId, String jobId) {
         ResponseEntity<BankDataIngestionDto.GetImportProgressResponse> response = restTemplate.getForEntity(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/import/" + jobId,
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/import/" + jobId,
                 BankDataIngestionDto.GetImportProgressResponse.class
         );
 
@@ -373,7 +373,7 @@ public class BankDataIngestionHttpActor {
                 .build();
 
         ResponseEntity<BankDataIngestionDto.FinalizeImportResponse> response = restTemplate.exchange(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/import/" + jobId + "/finalize",
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/import/" + jobId + "/finalize",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 BankDataIngestionDto.FinalizeImportResponse.class
@@ -389,7 +389,7 @@ public class BankDataIngestionHttpActor {
      */
     public BankDataIngestionDto.GetStagingPreviewResponse getStagingPreview(String cashFlowId, String stagingSessionId) {
         ResponseEntity<BankDataIngestionDto.GetStagingPreviewResponse> response = restTemplate.getForEntity(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/staging/" + stagingSessionId,
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/staging/" + stagingSessionId,
                 BankDataIngestionDto.GetStagingPreviewResponse.class
         );
 
@@ -402,7 +402,7 @@ public class BankDataIngestionHttpActor {
      */
     public void deleteStagingSession(String cashFlowId, String stagingSessionId) {
         ResponseEntity<Void> response = restTemplate.exchange(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/staging/" + stagingSessionId,
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/staging/" + stagingSessionId,
                 HttpMethod.DELETE,
                 null,
                 Void.class
@@ -418,7 +418,7 @@ public class BankDataIngestionHttpActor {
      */
     public BankDataIngestionDto.RevalidateStagingResponse revalidateStaging(String cashFlowId, String stagingSessionId) {
         ResponseEntity<BankDataIngestionDto.RevalidateStagingResponse> response = restTemplate.exchange(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/staging/" + stagingSessionId + "/revalidate",
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/staging/" + stagingSessionId + "/revalidate",
                 HttpMethod.POST,
                 null,
                 BankDataIngestionDto.RevalidateStagingResponse.class
@@ -465,7 +465,7 @@ public class BankDataIngestionHttpActor {
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
         ResponseEntity<BankDataIngestionDto.UploadCsvResponse> response = restTemplate.exchange(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/upload",
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/upload",
                 HttpMethod.POST,
                 requestEntity,
                 BankDataIngestionDto.UploadCsvResponse.class
@@ -502,7 +502,7 @@ public class BankDataIngestionHttpActor {
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
         ResponseEntity<BankDataIngestionDto.UploadCsvResponse> response = restTemplate.exchange(
-                baseUrl + "/api/v1/bank-data-ingestion/" + cashFlowId + "/upload",
+                baseUrl + "/api/v1/bank-data-ingestion/cf=" + cashFlowId + "/upload",
                 HttpMethod.POST,
                 requestEntity,
                 BankDataIngestionDto.UploadCsvResponse.class

--- a/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionHttpIntegrationTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionHttpIntegrationTest.java
@@ -62,11 +62,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * This test verifies the HTTP REST API contracts that HttpCashFlowServiceClient
  * would use in a microservice architecture:
- * 1. GET /cash-flow/{id} - get CashFlow info
- * 2. POST /cash-flow/{id}/category - create category
- * 3. POST /cash-flow/{id}/import-historical - import transaction
- * 4. POST /api/v1/bank-data-ingestion/{id}/stage - stage transactions
- * 5. POST /api/v1/bank-data-ingestion/{id}/import - start import
+ * 1. GET /cash-flow/cf={id} - get CashFlow info
+ * 2. POST /cash-flow/cf={id}/category - create category
+ * 3. POST /cash-flow/cf={id}/import-historical - import transaction
+ * 4. POST /api/v1/bank-data-ingestion/cf={id}/stage - stage transactions
+ * 5. POST /api/v1/bank-data-ingestion/cf={id}/import - start import
  *
  * Uses BankDataIngestionHttpActor for cleaner test code following the DualBudgetActor pattern.
  */
@@ -174,7 +174,7 @@ public class BankDataIngestionHttpIntegrationTest {
     }
 
     @Test
-    @DisplayName("Should get CashFlow info via REST API - verifies GET /cash-flow/{id}")
+    @DisplayName("Should get CashFlow info via REST API - verifies GET /cash-flow/cf={id}")
     void shouldGetCashFlowInfoViaRestApi() {
         // given
         YearMonth startPeriod = YearMonth.of(2021, 7);
@@ -243,7 +243,7 @@ public class BankDataIngestionHttpIntegrationTest {
     }
 
     @Test
-    @DisplayName("Should create category via REST API - verifies POST /cash-flow/{id}/category")
+    @DisplayName("Should create category via REST API - verifies POST /cash-flow/cf={id}/category")
     void shouldCreateCategoryViaRestApi() {
         // given
         String cashFlowId = actor.createCashFlowWithHistory(

--- a/src/test/java/com/multi/vidulum/bank_data_ingestion/app/HttpTestCashFlowServiceClient.java
+++ b/src/test/java/com/multi/vidulum/bank_data_ingestion/app/HttpTestCashFlowServiceClient.java
@@ -33,7 +33,7 @@ public class HttpTestCashFlowServiceClient implements CashFlowServiceClient {
     @Override
     public CashFlowInfo getCashFlowInfo(String cashFlowId) {
         ResponseEntity<CashFlowDto.CashFlowSummaryJson> response = restTemplate.getForEntity(
-                baseUrl + "/cash-flow/" + cashFlowId,
+                baseUrl + "/cash-flow/cf=" + cashFlowId,
                 CashFlowDto.CashFlowSummaryJson.class
         );
 
@@ -53,7 +53,7 @@ public class HttpTestCashFlowServiceClient implements CashFlowServiceClient {
     public boolean exists(String cashFlowId) {
         try {
             ResponseEntity<Map> response = restTemplate.getForEntity(
-                    baseUrl + "/cash-flow/" + cashFlowId,
+                    baseUrl + "/cash-flow/cf=" + cashFlowId,
                     Map.class
             );
             return response.getStatusCode().is2xxSuccessful();
@@ -74,7 +74,7 @@ public class HttpTestCashFlowServiceClient implements CashFlowServiceClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         ResponseEntity<Void> response = restTemplate.exchange(
-                baseUrl + "/cash-flow/" + cashFlowId + "/category",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category",
                 HttpMethod.POST,
                 new HttpEntity<>(request, headers),
                 Void.class
@@ -108,7 +108,7 @@ public class HttpTestCashFlowServiceClient implements CashFlowServiceClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         ResponseEntity<String> response = restTemplate.exchange(
-                baseUrl + "/cash-flow/" + cashFlowId + "/import-historical",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/import-historical",
                 HttpMethod.POST,
                 new HttpEntity<>(httpRequest, headers),
                 String.class

--- a/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/CashFlowControllerTest.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.cashflow;
 
+import com.multi.vidulum.TestIds;
 import com.multi.vidulum.cashflow.app.CashFlowDto;
 import com.multi.vidulum.cashflow.app.CashFlowRestController;
 import com.multi.vidulum.cashflow.app.commands.archive.CannotArchiveSystemCategoryException;
@@ -56,13 +57,18 @@ public class CashFlowControllerTest extends IntegrationTest {
         return "NormalCF-" + NAME_COUNTER.incrementAndGet();
     }
 
+    private String uniqueUserId() {
+        return TestIds.nextUserId().getId();
+    }
+
     @Test
     void shouldCreateAndGetCashFlow() {
         // given
+        String userId = uniqueUserId();
         String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -84,7 +90,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                 .isEqualTo(
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
-                                .userId("U10000009")
+                                .userId(userId)
                                 .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
@@ -114,10 +120,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldAppendCashChange() {
         // when
+        String userId = uniqueUserId();
         String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -153,7 +160,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                 .isEqualTo(
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
-                                .userId("U10000009")
+                                .userId(userId)
                                 .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
@@ -201,10 +208,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldAppendPaidCashChange() {
         // when
+        String userId = uniqueUserId();
         String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -240,7 +248,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                 .isEqualTo(
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
-                                .userId("U10000009")
+                                .userId(userId)
                                 .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
@@ -287,9 +295,10 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldAppendPaidCashChangeForOutflow() {
         // when
+        String userId = uniqueUserId();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -335,10 +344,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldConfirmCashChange() {
         // when
+        String userId = uniqueUserId();
         String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -379,7 +389,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                 .isEqualTo(
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
-                                .userId("U10000009")
+                                .userId(userId)
                                 .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
@@ -427,10 +437,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldEditCashChange() {
         // when
+        String userId = uniqueUserId();
         String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -476,7 +487,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                 .isEqualTo(
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
-                                .userId("U10000009")
+                                .userId(userId)
                                 .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
@@ -525,10 +536,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldRejectCashChange() {
         // when
+        String userId = uniqueUserId();
         String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -570,7 +582,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                 .isEqualTo(
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
-                                .userId("U10000009")
+                                .userId(userId)
                                 .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
@@ -620,10 +632,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldAppendCashChangeToNewCategory() {
         // when
+        String userId = uniqueUserId();
         String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -665,7 +678,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                 .isEqualTo(
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
-                                .userId("U10000009")
+                                .userId(userId)
                                 .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
@@ -721,10 +734,11 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldAppendCashChangeToSubCategory() {
         // when
+        String userId = uniqueUserId();
         String cashFlowName = uniqueCashFlowName();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(cashFlowName)
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -784,7 +798,7 @@ public class CashFlowControllerTest extends IntegrationTest {
                 .isEqualTo(
                         CashFlowDto.CashFlowSummaryJson.builder()
                                 .cashFlowId(cashFlowId)
-                                .userId("U10000009")
+                                .userId(userId)
                                 .name(cashFlowName)
                                 .description("cash-flow description")
                                 .bankAccount(new BankAccount(
@@ -847,7 +861,7 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldGetCashFlowsDetailsByUserId() {
         // given
-        String userId = "U10000014";
+        String userId = uniqueUserId();
 
         // Create first cash flow for user
         String cashFlowId1 = cashFlowRestController.createCashFlow(
@@ -876,7 +890,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         );
 
         // Create cash flow for different user (should not be returned)
-        String otherUserId = "U10000015";
+        String otherUserId = uniqueUserId();
         String cashFlowId3 = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
                         .userId(otherUserId)
@@ -1010,9 +1024,10 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldSetBudgetingForCategory() {
         // given
+        String userId = uniqueUserId();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1062,9 +1077,10 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldUpdateBudgetingForCategory() {
         // given
+        String userId = uniqueUserId();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1126,9 +1142,10 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldRemoveBudgetingFromCategory() {
         // given
+        String userId = uniqueUserId();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1196,9 +1213,10 @@ public class CashFlowControllerTest extends IntegrationTest {
     @Test
     void shouldSetBudgetingForInflowCategory() {
         // given
+        String userId = uniqueUserId();
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1247,10 +1265,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectPaidCashChangeWhenPaidDateInFuture() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01T00:00:00Z
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1278,10 +1297,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectPaidCashChangeWhenPaidDateNotInActivePeriod() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1309,10 +1329,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAcceptPaidCashChangeInActivePeriod() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1348,10 +1369,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectPaidCashChangeOutflowWhenPaidDateInFuture() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01T00:00:00Z
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1379,10 +1401,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectPaidCashChangeOutflowWhenPaidDateNotInActivePeriod() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1410,10 +1433,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAcceptPaidCashChangeOutflowInActivePeriod() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01, active period is 2022-01
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1453,10 +1477,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectAppendExpectedCashChangeWhenCashFlowInSetupMode() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (starts in SETUP mode)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1486,10 +1511,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectAppendPaidCashChangeWhenCashFlowInSetupMode() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (starts in SETUP mode)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1520,12 +1546,13 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectEditCashChangeWhenCashFlowInSetupMode() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (starts in SETUP mode)
         // Note: In SETUP mode we can't add cash changes via normal flow,
         // so we test with a fake cashChangeId
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1541,7 +1568,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         assertThatThrownBy(() -> cashFlowRestController.edit(
                 CashFlowDto.EditCashChangeJson.builder()
                         .cashFlowId(cashFlowId)
-                        .cashChangeId("fake-cash-change-id")
+                        .cashChangeId(TestIds.nonExistentCashChangeId())
                         .name("Updated name")
                         .description("Updated description")
                         .money(Money.of(200, "USD"))
@@ -1554,12 +1581,13 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectConfirmCashChangeWhenCashFlowInSetupMode() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (starts in SETUP mode)
         // Note: In SETUP mode we can't add cash changes via normal flow,
         // so we test with a fake cashChangeId
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1575,7 +1603,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         assertThatThrownBy(() -> cashFlowRestController.confirm(
                 CashFlowDto.ConfirmCashChangeJson.builder()
                         .cashFlowId(cashFlowId)
-                        .cashChangeId("fake-cash-change-id")
+                        .cashChangeId(TestIds.nonExistentCashChangeId())
                         .build()
         )).isInstanceOf(OperationNotAllowedInSetupModeException.class)
                 .hasMessageContaining("confirmCashChange")
@@ -1584,10 +1612,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectCreateCategoryWhenCashFlowInSetupMode() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (starts in SETUP mode)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1613,10 +1642,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAllowCreateCategoryWhenCashFlowInSetupModeWithImportFlag() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (starts in SETUP mode)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueTestCashFlowName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1650,13 +1680,14 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldCreateCashFlowWithHistoryInSetupStatus() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01, so startPeriod 2021-06 is in the past
         String cashFlowName = uniqueHistoricalName();
 
         // when
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(cashFlowName)
                         .description("Cash flow with historical data support")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1672,7 +1703,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         CashFlowDto.CashFlowSummaryJson result = cashFlowRestController.getCashFlow(cashFlowId);
 
         assertThat(result.getCashFlowId()).isEqualTo(cashFlowId);
-        assertThat(result.getUserId()).isEqualTo("U10000009");
+        assertThat(result.getUserId()).isEqualTo(userId);
         assertThat(result.getName()).isEqualTo(cashFlowName);
         assertThat(result.getStatus()).isEqualTo(CashFlow.CashFlowStatus.SETUP);
         assertThat(result.getBankAccount().balance()).isEqualTo(Money.of(5000, "USD"));
@@ -1689,6 +1720,7 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldCreateMonthlyForecastsWithCorrectStatusesForHistoricalCashFlow() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01
         // startPeriod: 2021-10 (historical)
         // activePeriod: 2022-01 (current)
@@ -1700,7 +1732,7 @@ public class CashFlowControllerTest extends IntegrationTest {
         // when
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1744,13 +1776,14 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectCashFlowWithHistoryWhenStartPeriodIsInFuture() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01
         // Trying to create with startPeriod 2023-01 (future) should fail
 
         // when/then
         assertThatThrownBy(() -> cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name("Future Start Period")
                         .description("This should fail")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1765,12 +1798,13 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldCreateCashFlowWithHistoryStartingFromCurrentMonth() {
+        String userId = uniqueUserId();
         // given - FixedClockConfig sets clock to 2022-01-01
         // startPeriod same as activePeriod (2022-01) - edge case, no historical months
         // when
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name("Current Month Start")
                         .description("No historical data")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1807,10 +1841,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldImportHistoricalCashChangeToSetupPendingMonth() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history starting from 2021-10 (clock is 2022-01-01)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For import testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1858,10 +1893,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectImportToForecastedMonthInOpenMode() {
+        String userId = uniqueUserId();
         // given - create normal CashFlow (OPEN mode, activePeriod = 2022-01)
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueNormalCashFlowName())
                         .description("In OPEN mode")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1889,10 +1925,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectImportWhenPaidDateIsInActiveOrFuturePeriod() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (clock is 2022-01-01, activePeriod = 2022-01)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For import testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1921,10 +1958,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectImportWhenPaidDateIsBeforeStartPeriod() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history starting from 2021-10
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For import testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -1953,10 +1991,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldImportMultipleHistoricalTransactionsToDifferentMonths() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("Multiple imports")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2025,10 +2064,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldUpdateForecastWhenImportingHistoricalInflow() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history starting from 2021-10 (clock is 2022-01-01)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For forecast testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2090,10 +2130,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldUpdateForecastWhenImportingHistoricalOutflow() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history starting from 2021-10 (clock is 2022-01-01)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For outflow forecast testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2155,10 +2196,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldUpdateForecastWithMultipleHistoricalTransactionsInSameMonth() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("Multiple transactions same month")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2270,11 +2312,12 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectImportWhenPaidDateIsInTheFuture() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (clock is 2022-01-01T00:00:00Z)
         // Use startPeriod that includes December 2021 so we can test future dates within that month
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For cutoff testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2308,10 +2351,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectImportWhenPaidDateIsOneHourInTheFuture() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (clock is 2022-01-01T00:00:00Z)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For cutoff testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2341,10 +2385,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAcceptImportWhenPaidDateIsExactlyNow() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (clock is 2022-01-01T00:00:00Z)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For cutoff testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2385,10 +2430,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAcceptImportWhenPaidDateIsOneSecondBeforeNow() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (clock is 2022-01-01T00:00:00Z)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For cutoff testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2424,11 +2470,12 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAcceptImportWhenPaidDateIsEarlierInTheSameDay() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (clock is 2022-01-01T00:00:00Z)
         // Simulating: user starts Vidulum at midnight, imports transaction from morning of Dec 31
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For same-day testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2464,10 +2511,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectImportWhenPaidDateIsTomorrowMorning() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (clock is 2022-01-01T00:00:00Z)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For future date testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2496,10 +2544,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectImportWhenPaidDateIsNextMonth() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (clock is 2022-01-01T00:00:00Z)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For future month testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2528,10 +2577,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAcceptMultipleImportsFromDifferentTimesOnSameHistoricalDay() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("Multiple same-day imports")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2600,11 +2650,12 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAttestHistoricalImportWhenBalancesMatch() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history starting from 2021-10 (clock is 2022-01-01)
         // initialBalance = 1000 USD
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For activation testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2691,10 +2742,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectAttestationWhenBalancesMismatchAndNotForced() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For balance mismatch testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2743,10 +2795,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldForceAttestationWhenBalancesMismatch() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For force activation testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2805,10 +2858,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectAttestationWhenCashFlowNotInSetupMode() {
+        String userId = uniqueUserId();
         // given - create normal CashFlow (OPEN mode, not SETUP)
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueNormalCashFlowName())
                         .description("In OPEN mode")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2830,10 +2884,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAttestHistoricalImportWithNoImportedTransactions() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history but don't import any transactions
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name("Empty Historical Cash Flow")
                         .description("No imports")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2868,10 +2923,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldChangeImportPendingToImportedAfterAttestation() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history (Oct 2021 - Dec 2021 are IMPORT_PENDING)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For status change testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2934,10 +2990,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAttestHistoricalImportWithNegativeBalanceDifference() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For negative difference testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -2989,10 +3046,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldCreateAdjustmentTransactionWhenBalanceDiffersAndCreateAdjustmentIsTrue() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For adjustment testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3058,10 +3116,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldCreateNegativeAdjustmentTransactionWhenConfirmedBalanceIsLower() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For negative adjustment testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3119,10 +3178,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldNotCreateAdjustmentWhenBalancesMatch() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For no-adjustment testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3177,10 +3237,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldSetImportCutoffDateTimeAfterAttestation() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For importCutoffDateTime testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3217,10 +3278,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAddAdjustmentToActiveMonthInForecast() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For forecast adjustment testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3290,10 +3352,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRollbackImportAndClearAllTransactions() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history and import some transactions
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For rollback testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3361,10 +3424,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRollbackImportAndClearCategoriesWhenRequested() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history and add custom categories
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For rollback with categories")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3440,10 +3504,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldRejectRollbackOnNonSetupCashFlow() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history and attest it (making it OPEN)
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("Will be attested")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3485,10 +3550,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldClearForecastTransactionsAfterRollback() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history and import transactions
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For forecast clearing test")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3593,10 +3659,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAllowReImportAfterRollback() {
+        String userId = uniqueUserId();
         // given - create CashFlow with history and import some transactions
         String cashFlowId = cashFlowRestController.createCashFlowWithHistory(
                 CashFlowDto.CreateCashFlowWithHistoryJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueHistoricalName())
                         .description("For re-import testing")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3678,10 +3745,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldArchiveUserCreatedCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow and add a user category
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3738,10 +3806,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldUnarchiveCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow, add a category, and archive it
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3805,10 +3874,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldNotAllowArchivingSystemCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow (has system "Uncategorized" category)
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3830,10 +3900,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldNotAllowArchivingNonExistentCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3855,10 +3926,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void archivedCategoryShouldRemainVisibleInExistingTransactions() {
+        String userId = uniqueUserId();
         // given - create cashflow and add a category with a transaction
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3915,10 +3987,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldPreserveOriginFieldOnSystemCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3949,10 +4022,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldNotAllowAddingExpectedCashChangeToArchivedCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow with a category and archive it
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -3995,10 +4069,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldNotAllowAddingPaidCashChangeToArchivedCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow with a category and archive it
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -4044,10 +4119,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAllowAddingCashChangeToUnarchivedCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow with a category, archive it, then unarchive it
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -4107,10 +4183,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldNotAllowCreatingCategoryWithSameNameAsActiveCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow with a category
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -4141,10 +4218,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldAllowCreatingCategoryWithSameNameAsArchivedCategory() {
+        String userId = uniqueUserId();
         // given - create cashflow with a category and archive it
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -4197,10 +4275,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldNotAllowUnarchivingWhenActiveCategoryWithSameNameExists() {
+        String userId = uniqueUserId();
         // given - create cashflow with a category, archive it, create new one with same name
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -4250,10 +4329,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldArchiveSubcategoriesWhenForceArchiveChildrenIsTrue() {
+        String userId = uniqueUserId();
         // given - create cashflow with parent category and subcategories
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(
@@ -4319,10 +4399,11 @@ public class CashFlowControllerTest extends IntegrationTest {
 
     @Test
     void shouldNotArchiveSubcategoriesWhenForceArchiveChildrenIsFalse() {
+        String userId = uniqueUserId();
         // given - create cashflow with parent category and subcategories
         String cashFlowId = cashFlowRestController.createCashFlow(
                 CashFlowDto.CreateCashFlowJson.builder()
-                        .userId("U10000009")
+                        .userId(userId)
                         .name(uniqueCashFlowName())
                         .description("cash-flow description")
                         .bankAccount(CashFlowDto.BankAccountJson.from(new BankAccount(

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
@@ -210,7 +210,7 @@ class CashFlowErrorHandlingTest {
         @DisplayName("Should return 404 NOT_FOUND with CASHFLOW_NOT_FOUND when CashFlow does not exist")
         void shouldReturn404WhenCashFlowNotFound() {
             // given
-            String nonExistentCashFlowId = UUID.randomUUID().toString();
+            String nonExistentCashFlowId = TestIds.nonExistentCashFlowId();
 
             // when
             ResponseEntity<ApiError> response = actor.getCashFlowExpectingError(nonExistentCashFlowId);
@@ -235,7 +235,7 @@ class CashFlowErrorHandlingTest {
             // given - create CashFlow first
             String userId = TestIds.nextUserId().getId();
             String cashFlowId = actor.createCashFlow(userId, "Test CashFlow", "USD");
-            String nonExistentCashChangeId = UUID.randomUUID().toString();
+            String nonExistentCashChangeId = TestIds.nonExistentCashChangeId();
 
             // when - try to confirm non-existent cash change
             ResponseEntity<ApiError> response = actor.confirmCashChangeExpectingError(cashFlowId, nonExistentCashChangeId);
@@ -553,7 +553,7 @@ class CashFlowErrorHandlingTest {
 
             // when
             ResponseEntity<ApiError> response = actor.editCashChangeExpectingError(
-                    cashFlowId, "fake-id", "New Name", "New Description",
+                    cashFlowId, TestIds.nonExistentCashChangeId(), "New Name", "New Description",
                     Money.of(200, "USD"), "Uncategorized", ZonedDateTime.parse("2022-01-20T00:00:00Z"));
 
             // then
@@ -574,7 +574,7 @@ class CashFlowErrorHandlingTest {
             String cashFlowId = actor.createCashFlowWithHistory(userId, "Setup CashFlow", startPeriod, Money.of(1000, "USD"));
 
             // when
-            ResponseEntity<ApiError> response = actor.confirmCashChangeExpectingError(cashFlowId, "fake-id");
+            ResponseEntity<ApiError> response = actor.confirmCashChangeExpectingError(cashFlowId, TestIds.nonExistentCashChangeId());
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
@@ -99,7 +99,7 @@ public class CashFlowHttpActor {
                 .build();
 
         ResponseEntity<Void> response = restTemplate.exchange(
-                baseUrl + "/cash-flow/" + cashFlowId + "/category?isImport=true",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category?isImport=true",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 Void.class
@@ -127,7 +127,7 @@ public class CashFlowHttpActor {
                 .build();
 
         ResponseEntity<String> response = restTemplate.exchange(
-                baseUrl + "/cash-flow/" + cashFlowId + "/import-historical",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/import-historical",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 String.class
@@ -155,7 +155,7 @@ public class CashFlowHttpActor {
                 .build();
 
         return restTemplate.exchange(
-                baseUrl + "/cash-flow/" + cashFlowId + "/attest-historical-import",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/attest-historical-import",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 CashFlowDto.AttestHistoricalImportResponseJson.class
@@ -180,7 +180,7 @@ public class CashFlowHttpActor {
 
         try {
             ResponseEntity<ApiError> response = rawRestTemplate.exchange(
-                    baseUrl + "/cash-flow/" + cashFlowId + "/attest-historical-import",
+                    baseUrl + "/cash-flow/cf=" + cashFlowId + "/attest-historical-import",
                     HttpMethod.POST,
                     entity,
                     ApiError.class
@@ -197,7 +197,7 @@ public class CashFlowHttpActor {
      */
     public CashFlowDto.CashFlowSummaryJson getCashFlow(String cashFlowId) {
         ResponseEntity<CashFlowDto.CashFlowSummaryJson> response = restTemplate.getForEntity(
-                baseUrl + "/cash-flow/" + cashFlowId,
+                baseUrl + "/cash-flow/cf=" + cashFlowId,
                 CashFlowDto.CashFlowSummaryJson.class
         );
 
@@ -210,7 +210,7 @@ public class CashFlowHttpActor {
      */
     public ResponseEntity<ApiError> getCashFlowExpectingError(String cashFlowId) {
         return executeExpectingError(
-                baseUrl + "/cash-flow/" + cashFlowId,
+                baseUrl + "/cash-flow/cf=" + cashFlowId,
                 HttpMethod.GET,
                 null
         );
@@ -393,7 +393,7 @@ public class CashFlowHttpActor {
                 .build();
 
         return executeExpectingError(
-                baseUrl + "/cash-flow/" + cashFlowId + "/category?isImport=" + isImport,
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category?isImport=" + isImport,
                 HttpMethod.POST,
                 request
         );
@@ -411,7 +411,7 @@ public class CashFlowHttpActor {
                 .build();
 
         return executeExpectingError(
-                baseUrl + "/cash-flow/" + cashFlowId + "/category/archive",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category/archive",
                 HttpMethod.POST,
                 request
         );
@@ -428,7 +428,7 @@ public class CashFlowHttpActor {
                 .build();
 
         return executeExpectingError(
-                baseUrl + "/cash-flow/" + cashFlowId + "/category/unarchive",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category/unarchive",
                 HttpMethod.POST,
                 request
         );
@@ -508,7 +508,7 @@ public class CashFlowHttpActor {
                 .build();
 
         return executeExpectingError(
-                baseUrl + "/cash-flow/" + cashFlowId + "/import-historical",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/import-historical",
                 HttpMethod.POST,
                 request
         );
@@ -520,7 +520,7 @@ public class CashFlowHttpActor {
      */
     public ResponseEntity<ApiError> rollbackImportExpectingError(String cashFlowId) {
         return executeExpectingError(
-                baseUrl + "/cash-flow/" + cashFlowId + "/import",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/import",
                 HttpMethod.DELETE,
                 null
         );
@@ -639,7 +639,7 @@ public class CashFlowHttpActor {
                 .build();
 
         ResponseEntity<Void> response = restTemplate.exchange(
-                baseUrl + "/cash-flow/" + cashFlowId + "/category/archive",
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category/archive",
                 HttpMethod.POST,
                 new HttpEntity<>(request, jsonHeaders()),
                 Void.class

--- a/src/test/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateTest.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.cashflow.domain;
 
+import com.multi.vidulum.TestIds;
 import com.multi.vidulum.cashflow.domain.snapshots.CashChangeSnapshot;
 import com.multi.vidulum.cashflow.domain.snapshots.CashFlowSnapshot;
 import com.multi.vidulum.common.*;
@@ -39,8 +40,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldSaveNewlyCreatedCashChange() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
         CashFlowEvent.CashFlowCreatedEvent createdEvent = new CashFlowEvent.CashFlowCreatedEvent(
                 cashFlowId,
@@ -133,8 +134,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldSavePaidCashChangeWithConfirmedStatus() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
         CashFlowEvent.CashFlowCreatedEvent createdEvent = new CashFlowEvent.CashFlowCreatedEvent(
                 cashFlowId,
@@ -235,8 +236,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldSavePaidCashChangeOutflowAndDecreaseBalance() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
         CashFlowEvent.CashFlowCreatedEvent createdEvent = new CashFlowEvent.CashFlowCreatedEvent(
                 cashFlowId,
@@ -290,10 +291,10 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldHandleMultiplePaidCashChanges() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId inflowId = CashChangeId.generate();
-        CashChangeId outflow1Id = CashChangeId.generate();
-        CashChangeId outflow2Id = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId inflowId = TestIds.nextCashChangeId();
+        CashChangeId outflow1Id = TestIds.nextCashChangeId();
+        CashChangeId outflow2Id = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
 
         cashFlow.apply(new CashFlowEvent.CashFlowCreatedEvent(
@@ -379,9 +380,9 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldConfirmCashChange() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId firstCashChangeId = CashChangeId.generate();
-        CashChangeId secondCashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId firstCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId secondCashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
 
         cashFlow.apply(new CashFlowEvent.CashFlowCreatedEvent(
@@ -547,7 +548,7 @@ class CashFlowAggregateTest extends IntegrationTest {
 //    @Test
 //    void doubleConfirmation_exceptionIsExpected() {
 //        // given
-//        CashChangeId cashChangeId = CashChangeId.generate();
+//        CashChangeId cashChangeId = TestIds.nextCashChangeId();
 //        CashChange cashChange = cashChangeFactory.empty(
 //                cashChangeId,
 //                new UserId("U10000001"),
@@ -569,8 +570,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldEditCashChangeTest() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
         cashFlow.apply(new CashFlowEvent.CashFlowCreatedEvent(
                 cashFlowId,
@@ -698,7 +699,7 @@ class CashFlowAggregateTest extends IntegrationTest {
 //    @Test
 //    void modificationOnConfirmedCashChange_exceptionIsExpected() {
 //        // given
-//        CashChangeId cashChangeId = CashChangeId.generate();
+//        CashChangeId cashChangeId = TestIds.nextCashChangeId();
 //        CashChange cashChange = cashChangeFactory.empty(
 //                cashChangeId,
 //                new UserId("U10000001"),
@@ -724,8 +725,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldRejectCashChangeTest() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
 
         CashFlow cashFlow = new CashFlow();
         cashFlow.apply(new CashFlowEvent.CashFlowCreatedEvent(
@@ -845,7 +846,7 @@ class CashFlowAggregateTest extends IntegrationTest {
 //    @Test
 //    void rejectionOnAlreadyRejectedCashChange_exceptionExpected() {
 //        // given
-//        CashChangeId cashChangeId = CashChangeId.generate();
+//        CashChangeId cashChangeId = TestIds.nextCashChangeId();
 //        CashChange cashChange = cashChangeFactory.empty(
 //                cashChangeId,
 //                new UserId("U10000001"),
@@ -867,7 +868,7 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldAttestMonth() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         CashFlow cashFlow = new CashFlow();
         cashFlow.apply(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -953,7 +954,7 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldSetBudgetingAndTrackUncommittedEvents() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         CashFlow cashFlow = new CashFlow();
         cashFlow.apply(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -1013,7 +1014,7 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldUpdateBudgetingAndTrackUncommittedEvents() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         CashFlow cashFlow = new CashFlow();
         cashFlow.apply(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -1083,7 +1084,7 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldRemoveBudgetingAndTrackUncommittedEvents() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         CashFlow cashFlow = new CashFlow();
         cashFlow.apply(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -1151,7 +1152,7 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldProjectBudgetingEventsCorrectly() {
         // given
-        CashFlowId cashFlowId = CashFlowId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         CashFlow cashFlow = new CashFlow();
         cashFlow.apply(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -1221,8 +1222,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldRejectPaidCashChangeWhenPaidDateNotInActivePeriod() {
         // given - CashFlow created in June 2021, so active period is 2021-06
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
 
         cashFlow.apply(new CashFlowEvent.CashFlowCreatedEvent(
@@ -1261,8 +1262,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldRejectPaidCashChangeWhenPaidDateInPastAttestedPeriod() {
         // given - CashFlow created in June, then attested to July
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
 
         cashFlow.apply(new CashFlowEvent.CashFlowCreatedEvent(
@@ -1309,8 +1310,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldAcceptPaidCashChangeWhenPaidDateInActivePeriod() {
         // given - CashFlow created in June 2021, active period is 2021-06
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
 
         cashFlow.apply(new CashFlowEvent.CashFlowCreatedEvent(
@@ -1355,8 +1356,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldRejectPaidCashChangeOutflowWhenPaidDateNotInActivePeriod() {
         // given - CashFlow created in June 2021, so active period is 2021-06
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
 
         cashFlow.apply(new CashFlowEvent.CashFlowCreatedEvent(
@@ -1395,8 +1396,8 @@ class CashFlowAggregateTest extends IntegrationTest {
     @Test
     void shouldAcceptPaidCashChangeOutflowWhenPaidDateInActivePeriod() {
         // given - CashFlow created in June 2021, active period is 2021-06
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId cashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         CashFlow cashFlow = new CashFlow();
 
         cashFlow.apply(new CashFlowEvent.CashFlowCreatedEvent(

--- a/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastMapperTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastMapperTest.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.cashflow_forecast_processor.app;
 
+import com.multi.vidulum.TestIds;
 import com.multi.vidulum.cashflow.domain.BankAccountNumber;
 import com.multi.vidulum.cashflow.domain.CashChangeId;
 import com.multi.vidulum.cashflow.domain.CashFlowId;
@@ -31,7 +32,7 @@ class CashFlowForecastMapperTest {
     @Test
     void shouldMapCashFlowForecastStatement() {
         // given
-        CashFlowId cashFlowId = new CashFlowId("test-cash-flow-id");
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         YearMonth period = YearMonth.of(2022, 1);
         ZonedDateTime now = ZonedDateTime.parse("2022-01-15T10:00:00Z");
         Checksum checksum = new Checksum("abc123checksum");
@@ -95,7 +96,7 @@ class CashFlowForecastMapperTest {
         CashFlowForecastDto.CashFlowForecastStatementJson result = mapper.map(statement);
 
         // then
-        assertThat(result.getCashFlowId()).isEqualTo("test-cash-flow-id");
+        assertThat(result.getCashFlowId()).isEqualTo(cashFlowId.id());
         assertThat(result.getBankAccountNumber().account()).isEqualTo("US123456789");
         assertThat(result.getBankAccountNumber().denomination()).isEqualTo(Currency.of("USD"));
         assertThat(result.getLastModification()).isEqualTo(now);
@@ -126,7 +127,7 @@ class CashFlowForecastMapperTest {
     @Test
     void shouldMapCashFlowStatsCorrectly() {
         // given
-        CashFlowId cashFlowId = new CashFlowId("test-id");
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         YearMonth period = YearMonth.of(2022, 3);
         ZonedDateTime now = ZonedDateTime.parse("2022-03-01T00:00:00Z");
 
@@ -205,8 +206,8 @@ class CashFlowForecastMapperTest {
     @Test
     void shouldMapTransactionDetailsCorrectly() {
         // given
-        CashFlowId cashFlowId = new CashFlowId("test-id");
-        CashChangeId cashChangeId = new CashChangeId("change-123");
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId cashChangeId = TestIds.nextCashChangeId();
         YearMonth period = YearMonth.of(2022, 2);
         ZonedDateTime now = ZonedDateTime.parse("2022-02-15T10:00:00Z");
         ZonedDateTime dueDate = ZonedDateTime.parse("2022-02-20T00:00:00Z");
@@ -274,7 +275,7 @@ class CashFlowForecastMapperTest {
         assertThat(expectedTransactions).hasSize(1);
 
         CashFlowForecastDto.TransactionDetailsJson transactionJson = expectedTransactions.get(0);
-        assertThat(transactionJson.getCashChangeId()).isEqualTo("change-123");
+        assertThat(transactionJson.getCashChangeId()).isEqualTo(cashChangeId.id());
         assertThat(transactionJson.getName()).isEqualTo("Monthly Salary");
         assertThat(transactionJson.getMoney()).isEqualTo(Money.of(5000, "USD"));
         assertThat(transactionJson.getCreated()).isEqualTo(now);
@@ -285,7 +286,7 @@ class CashFlowForecastMapperTest {
     @Test
     void shouldMapBudgetingCorrectly() {
         // given
-        CashFlowId cashFlowId = new CashFlowId("test-id");
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         YearMonth period = YearMonth.of(2022, 4);
         ZonedDateTime now = ZonedDateTime.parse("2022-04-01T00:00:00Z");
         ZonedDateTime budgetCreated = ZonedDateTime.parse("2022-03-15T10:00:00Z");
@@ -360,7 +361,7 @@ class CashFlowForecastMapperTest {
     @Test
     void shouldMapAttestationCorrectly() {
         // given
-        CashFlowId cashFlowId = new CashFlowId("test-id");
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         YearMonth period = YearMonth.of(2022, 1);
         ZonedDateTime now = ZonedDateTime.parse("2022-02-01T00:00:00Z");
         ZonedDateTime attestationDateTime = ZonedDateTime.parse("2022-01-31T23:59:59Z");
@@ -425,7 +426,7 @@ class CashFlowForecastMapperTest {
     @Test
     void shouldMapSubCategoriesCorrectly() {
         // given
-        CashFlowId cashFlowId = new CashFlowId("test-id");
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         YearMonth period = YearMonth.of(2022, 5);
         ZonedDateTime now = ZonedDateTime.parse("2022-05-01T00:00:00Z");
 
@@ -502,7 +503,7 @@ class CashFlowForecastMapperTest {
     @Test
     void shouldHandleNullChecksumGracefully() {
         // given
-        CashFlowId cashFlowId = new CashFlowId("test-id");
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
         YearMonth period = YearMonth.of(2022, 1);
         ZonedDateTime now = ZonedDateTime.parse("2022-01-01T00:00:00Z");
 

--- a/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastProcessorTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastProcessorTest.java
@@ -1,6 +1,7 @@
 package com.multi.vidulum.cashflow_forecast_processor.app;
 
 import com.multi.vidulum.ContentReader;
+import com.multi.vidulum.TestIds;
 import com.multi.vidulum.cashflow.domain.*;
 import com.multi.vidulum.cashflow.domain.CategoryOrigin;
 import com.multi.vidulum.common.*;
@@ -23,9 +24,9 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void processInflows() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId firstCashChangeId = CashChangeId.generate();
-        CashChangeId secondCashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId firstCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId secondCashChangeId = TestIds.nextCashChangeId();
 
         emit(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -109,9 +110,9 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void processOutflows() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId firstCashChangeId = CashChangeId.generate();
-        CashChangeId secondCashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId firstCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId secondCashChangeId = TestIds.nextCashChangeId();
 
         emit(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -195,12 +196,12 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void shouldAttestMonth() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId firstCashChangeId = CashChangeId.generate();
-        CashChangeId secondCashChangeId = CashChangeId.generate();
-        CashChangeId thirdCashChangeId = CashChangeId.generate();
-        CashChangeId forthCashChangeId = CashChangeId.generate();
-        CashChangeId fifthCashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId firstCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId secondCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId thirdCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId forthCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId fifthCashChangeId = TestIds.nextCashChangeId();
 
         emit(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -349,9 +350,9 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void shouldCreateNewCategory() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId firstCashChangeId = CashChangeId.generate();
-        CashChangeId secondCashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId firstCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId secondCashChangeId = TestIds.nextCashChangeId();
 
         emit(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -442,10 +443,10 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void shouldAppendCashChangeToSubCategory() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId firstCashChangeId = CashChangeId.generate();
-        CashChangeId secondCashChangeId = CashChangeId.generate();
-        CashChangeId thirdCashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId firstCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId secondCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId thirdCashChangeId = TestIds.nextCashChangeId();
 
         emit(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -577,9 +578,9 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void processPaidInflows() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId paidCashChangeId1 = CashChangeId.generate();
-        CashChangeId paidCashChangeId2 = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId paidCashChangeId1 = TestIds.nextCashChangeId();
+        CashChangeId paidCashChangeId2 = TestIds.nextCashChangeId();
 
         emit(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -645,9 +646,9 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void processPaidOutflows() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId paidCashChangeId1 = CashChangeId.generate();
-        CashChangeId paidCashChangeId2 = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId paidCashChangeId1 = TestIds.nextCashChangeId();
+        CashChangeId paidCashChangeId2 = TestIds.nextCashChangeId();
 
         emit(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -713,9 +714,9 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void processMixedExpectedAndPaidCashChanges() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId expectedCashChangeId = CashChangeId.generate();
-        CashChangeId paidCashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId expectedCashChangeId = TestIds.nextCashChangeId();
+        CashChangeId paidCashChangeId = TestIds.nextCashChangeId();
 
         emit(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -785,8 +786,8 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void processPaidCashChangeWithCustomCategory() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId paidCashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId paidCashChangeId = TestIds.nextCashChangeId();
 
         emit(
                 new CashFlowEvent.CashFlowCreatedEvent(
@@ -848,9 +849,9 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void shouldRollbackImportAndClearTransactionsFromImportPendingMonths() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId historicalCashChangeId1 = CashChangeId.generate();
-        CashChangeId historicalCashChangeId2 = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId historicalCashChangeId1 = TestIds.nextCashChangeId();
+        CashChangeId historicalCashChangeId2 = TestIds.nextCashChangeId();
 
         // Create CashFlow with history (SETUP mode)
         emit(
@@ -940,8 +941,8 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void shouldRollbackImportAndClearCategoriesWhenRequested() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId historicalCashChangeId = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId historicalCashChangeId = TestIds.nextCashChangeId();
 
         // Create CashFlow with history
         emit(
@@ -1033,9 +1034,9 @@ class CashFlowForecastProcessorTest extends IntegrationTest {
 
     @Test
     public void shouldAllowReImportAfterRollback() {
-        CashFlowId cashFlowId = CashFlowId.generate();
-        CashChangeId historicalCashChangeId1 = CashChangeId.generate();
-        CashChangeId historicalCashChangeId2 = CashChangeId.generate();
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
+        CashChangeId historicalCashChangeId1 = TestIds.nextCashChangeId();
+        CashChangeId historicalCashChangeId2 = TestIds.nextCashChangeId();
 
         // Create CashFlow with history
         emit(

--- a/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastStatementTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowForecastStatementTest.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.cashflow_forecast_processor.app;
 
+import com.multi.vidulum.TestIds;
 import com.multi.vidulum.cashflow.domain.BankAccountNumber;
 import com.multi.vidulum.cashflow.domain.CashChangeId;
 import com.multi.vidulum.cashflow.domain.CashFlowId;
@@ -149,7 +150,7 @@ class CashFlowForecastStatementTest {
 
     private CashFlowForecastStatement createStatement(Map<YearMonth, CashFlowMonthlyForecast> forecasts) {
         return new CashFlowForecastStatement(
-                new CashFlowId("test-cashflow-id"),
+                TestIds.nextCashFlowId(),
                 forecasts,
                 new BankAccountNumber("test-account", Currency.of("USD")),
                 new CurrentCategoryStructure(new ArrayList<>(), new ArrayList<>(), ZonedDateTime.now()),
@@ -191,7 +192,7 @@ class CashFlowForecastStatementTest {
         GroupedTransactions groupedTransactions = createGroupedTransactions();
         if (amount > 0) {
             TransactionDetails transaction = TransactionDetails.builder()
-                    .cashChangeId(new CashChangeId(CashChangeId.generate().id()))
+                    .cashChangeId(TestIds.nextCashChangeId())
                     .name(new Name("Transaction"))
                     .money(Money.of(amount, "USD"))
                     .created(ZonedDateTime.now())

--- a/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowMonthlyForecastTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowMonthlyForecastTest.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.cashflow_forecast_processor.app;
 
+import com.multi.vidulum.TestIds;
 import com.multi.vidulum.cashflow.domain.CashChangeId;
 import com.multi.vidulum.cashflow.domain.CategoryName;
 import com.multi.vidulum.cashflow.domain.Name;
@@ -158,7 +159,7 @@ class CashFlowMonthlyForecastTest {
         GroupedTransactions groupedTransactions = createGroupedTransactions();
         for (double amount : amounts) {
             TransactionDetails transaction = TransactionDetails.builder()
-                    .cashChangeId(new CashChangeId(CashChangeId.generate().id()))
+                    .cashChangeId(TestIds.nextCashChangeId())
                     .name(new Name("Transaction"))
                     .money(Money.of(amount, "USD"))
                     .created(ZonedDateTime.now())
@@ -193,7 +194,7 @@ class CashFlowMonthlyForecastTest {
         GroupedTransactions groupedTransactions = createGroupedTransactions();
         for (double amount : amounts) {
             TransactionDetails transaction = TransactionDetails.builder()
-                    .cashChangeId(new CashChangeId(CashChangeId.generate().id()))
+                    .cashChangeId(TestIds.nextCashChangeId())
                     .name(new Name("Transaction"))
                     .money(Money.of(amount, "USD"))
                     .created(ZonedDateTime.now())

--- a/src/test/java/com/multi/vidulum/cashflow_forecast_processor/infrastructure/CashFlowForecastStatementRepositoryImplTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow_forecast_processor/infrastructure/CashFlowForecastStatementRepositoryImplTest.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.cashflow_forecast_processor.infrastructure;
 
+import com.multi.vidulum.TestIds;
 import com.multi.vidulum.cashflow.domain.BankAccountNumber;
 import com.multi.vidulum.cashflow.domain.CashChangeId;
 import com.multi.vidulum.cashflow.domain.CashFlowId;
@@ -45,7 +46,7 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
     @Test
     void shouldSaveAndRetrieveSimpleForecastStatement() {
         // given
-        CashFlowId cashFlowId = new CashFlowId(UUID.randomUUID().toString());
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
 
         CashFlowForecastStatement statement = createSimpleForecastStatement(cashFlowId);
 
@@ -68,7 +69,7 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
     @Test
     void shouldSaveAndRetrieveForecastStatementWithNestedCategories() {
         // given
-        CashFlowId cashFlowId = new CashFlowId(UUID.randomUUID().toString());
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
 
         CashFlowForecastStatement statement = createForecastStatementWithNestedCategories(cashFlowId);
 
@@ -116,7 +117,7 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
     @Test
     void shouldSaveAndRetrieveForecastStatementWithTransactions() {
         // given
-        CashFlowId cashFlowId = new CashFlowId(UUID.randomUUID().toString());
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
 
         CashFlowForecastStatement statement = createForecastStatementWithTransactions(cashFlowId);
 
@@ -150,7 +151,7 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
     @Test
     void shouldSaveAndRetrieveForecastStatementWithCategoryStructure() {
         // given
-        CashFlowId cashFlowId = new CashFlowId(UUID.randomUUID().toString());
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
 
         CashFlowForecastStatement statement = createForecastStatementWithCategoryStructure(cashFlowId);
 
@@ -183,7 +184,7 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
     @Test
     void shouldUpdateExistingForecastStatement() {
         // given
-        CashFlowId cashFlowId = new CashFlowId(UUID.randomUUID().toString());
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
 
         CashFlowForecastStatement statement = createSimpleForecastStatement(cashFlowId);
         repository.save(statement);
@@ -213,7 +214,7 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
     @Test
     void shouldReturnEmptyForNonExistentCashFlowId() {
         // given
-        CashFlowId nonExistentId = new CashFlowId(UUID.randomUUID().toString());
+        CashFlowId nonExistentId = TestIds.nextCashFlowId();
 
         // when
         Optional<CashFlowForecastStatement> result = repository.findByCashFlowId(nonExistentId);
@@ -225,7 +226,7 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
     @Test
     void shouldPersistAttestation() {
         // given
-        CashFlowId cashFlowId = new CashFlowId(UUID.randomUUID().toString());
+        CashFlowId cashFlowId = TestIds.nextCashFlowId();
 
         CashFlowForecastStatement statement = createForecastStatementWithAttestation(cashFlowId);
 
@@ -248,8 +249,8 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
     @Test
     void shouldPersistMultipleForecastStatements() {
         // given
-        CashFlowId cashFlowId1 = new CashFlowId(UUID.randomUUID().toString());
-        CashFlowId cashFlowId2 = new CashFlowId(UUID.randomUUID().toString());
+        CashFlowId cashFlowId1 = TestIds.nextCashFlowId();
+        CashFlowId cashFlowId2 = TestIds.nextCashFlowId();
 
         CashFlowForecastStatement statement1 = createSimpleForecastStatement(cashFlowId1);
         CashFlowForecastStatement statement2 = createSimpleForecastStatement(cashFlowId2);
@@ -383,7 +384,7 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
 
         // Create transactions
         TransactionDetails paidTransaction = TransactionDetails.builder()
-                .cashChangeId(new CashChangeId(UUID.randomUUID().toString()))
+                .cashChangeId(TestIds.nextCashChangeId())
                 .name(new Name("January Salary"))
                 .money(Money.of(15000, TEST_CURRENCY))
                 .created(FIXED_NOW)
@@ -391,7 +392,7 @@ public class CashFlowForecastStatementRepositoryImplTest extends IntegrationTest
                 .build();
 
         TransactionDetails expectedTransaction = TransactionDetails.builder()
-                .cashChangeId(new CashChangeId(UUID.randomUUID().toString()))
+                .cashChangeId(TestIds.nextCashChangeId())
                 .name(new Name("February Salary"))
                 .money(Money.of(15000, TEST_CURRENCY))
                 .created(FIXED_NOW)

--- a/src/test/resources/cashflow_forecast_processor/append-cash-change-to-subcategory.json
+++ b/src/test/resources/cashflow_forecast_processor/append-cash-change-to-subcategory.json
@@ -1,6 +1,6 @@
 {
   "cashFlowId": {
-    "id": "4015b06b-21e1-4037-ab5a-3ca9e4bde75a"
+    "id": "CF10000001"
   },
   "forecasts": {
     "2021-06": {
@@ -89,7 +89,7 @@
                   "PAID": [
                     {
                       "cashChangeId": {
-                        "id": "cbf35c45-de07-48d4-bf51-f5c3f27c8320"
+                    "id": "CC1000000001"
                       },
                       "name": {
                         "name": "Main product purchase"
@@ -118,7 +118,7 @@
               "PAID": [
                 {
                   "cashChangeId": {
-                    "id": "bd3bb5a4-3db8-487b-92f5-c4d9066b7cd3"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "Sales purchase"
@@ -184,7 +184,7 @@
                   "PAID": [
                     {
                       "cashChangeId": {
-                        "id": "053a98a4-c9ce-4cec-bf4a-36f90ed5e629"
+                    "id": "CC1000000001"
                       },
                       "name": {
                         "name": "Morgan Stanley fee"

--- a/src/test/resources/cashflow_forecast_processor/attestation_processing.json
+++ b/src/test/resources/cashflow_forecast_processor/attestation_processing.json
@@ -1,6 +1,6 @@
 {
   "cashFlowId": {
-    "id": "63508c15-94ac-4cc7-bc87-845546ec97fc"
+    "id": "CF10000001"
   },
   "forecasts": {
     "2021-06": {
@@ -63,7 +63,7 @@
               "PAID": [
                 {
                   "cashChangeId": {
-                    "id": "a377fc71-6ea6-4fe7-b1f7-9e7a1b3ea56c"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change name"
@@ -141,7 +141,7 @@
               "PAID": [
                 {
                   "cashChangeId": {
-                    "id": "fa4e10db-0166-4e6f-9872-048a934fefc9"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "Cost 1"
@@ -252,7 +252,7 @@
               "EXPECTED": [
                 {
                   "cashChangeId": {
-                    "id": "e808db0a-bf16-466c-b52c-ac0d8f403f05"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change for new category 1"
@@ -290,7 +290,7 @@
               "EXPECTED": [
                 {
                   "cashChangeId": {
-                    "id": "58de21f7-0bb0-45d1-a8f9-f4d4ea39d219"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change name 2"
@@ -395,7 +395,7 @@
               "EXPECTED": [
                 {
                   "cashChangeId": {
-                    "id": "42e63a73-ef81-4811-bdeb-e87d3f21da33"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change name 3 edited"

--- a/src/test/resources/cashflow_forecast_processor/expected_inflow_processing.json
+++ b/src/test/resources/cashflow_forecast_processor/expected_inflow_processing.json
@@ -1,6 +1,6 @@
 {
   "cashFlowId": {
-    "id": "e523e0ec-6d40-4565-a52b-ab64c9f8f302"
+    "id": "CF10000001"
   },
   "forecasts": {
     "2021-06": {
@@ -62,7 +62,7 @@
               "PAID": [
                 {
                   "cashChangeId": {
-                    "id": "16ede051-d461-404c-ba1c-50aa12e163a9"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change name"
@@ -260,7 +260,7 @@
               "PAID": [
                 {
                   "cashChangeId": {
-                    "id": "98b58859-a176-4892-b767-cfbef58aef61"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change name 2 edited"

--- a/src/test/resources/cashflow_forecast_processor/expected_outflow_processing.json
+++ b/src/test/resources/cashflow_forecast_processor/expected_outflow_processing.json
@@ -1,6 +1,6 @@
 {
   "cashFlowId": {
-    "id": "74159100-6284-47e6-9f6e-b52d42318801"
+    "id": "CF10000001"
   },
   "forecasts": {
     "2021-06": {
@@ -83,7 +83,7 @@
               "PAID": [
                 {
                   "cashChangeId": {
-                    "id": "96200c47-f92e-4c1e-8eb8-da9cb98f44fc"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change name"
@@ -281,7 +281,7 @@
               "PAID": [
                 {
                   "cashChangeId": {
-                    "id": "f58dccc4-9eaf-429b-ace3-11be3afc10bb"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change name 2 edited"

--- a/src/test/resources/cashflow_forecast_processor/new_category.json
+++ b/src/test/resources/cashflow_forecast_processor/new_category.json
@@ -1,6 +1,6 @@
 {
   "cashFlowId": {
-    "id": "c1a293ee-903b-46cc-9deb-7816b0d091a2"
+    "id": "CF10000001"
   },
   "forecasts": {
     "2021-06": {
@@ -83,7 +83,7 @@
               "PAID": [
                 {
                   "cashChangeId": {
-                    "id": "9bfaf08a-c137-4806-912b-f053678dfaf7"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change name"
@@ -141,7 +141,7 @@
               "PAID": [
                 {
                   "cashChangeId": {
-                    "id": "563dd286-f0bb-4cef-9eeb-5171c3ef72a8"
+                    "id": "CC1000000001"
                   },
                   "name": {
                     "name": "cash change name outflow"


### PR DESCRIPTION
  ## Summary

  - Migrate CashFlowId and CashChangeId from UUID to human-readable format
  - Update REST API URL format to use `cf=` prefix for cashFlowId path variables
  - Fix Docker image naming inconsistency

  ## Changes

  ### Human-Readable ID Format
  - **CashFlowId**: Changed from UUID to `CF` + 8 digits (e.g., `CF10000001`)
  - **CashChangeId**: Changed from UUID to `CC` + 10 digits (e.g., `CC1000000001`)
  - Added `BusinessIdGenerator` for sequential ID generation with atomic counters
  - Added validation exceptions: `InvalidCashFlowIdFormatException`, `InvalidCashChangeIdFormatException`
  - Updated error codes: `INVALID_CASHFLOW_ID_FORMAT`, `INVALID_CASHCHANGE_ID_FORMAT`

