### PR TITLE
VID-123: Upgrade Spring Boot to 3.5.2 with dependency updates

### DIFF
--- a/docs/TODO-integration-tests-with-jwt-authentication.md
+++ b/docs/TODO-integration-tests-with-jwt-authentication.md
@@ -1,0 +1,277 @@
+# TODO: Integration Tests with JWT Authentication
+
+## Problem
+
+Current HTTP integration tests **disable security completely** and don't test the full authentication flow. This means tests don't verify:
+
+1. JWT token validation works correctly
+2. Endpoints reject requests without tokens (401 Unauthorized)
+3. Endpoints reject requests with invalid/expired tokens (401 Unauthorized)
+4. Role-based authorization works (403 Forbidden for insufficient permissions)
+5. The `JwtAuthenticationFilter` processes requests correctly
+
+### Evidence
+
+**Bug found during Spring Boot 3.5.2 upgrade** in `JwtService.java`:
+```java
+// BEFORE (BUG) - always returned true for valid token format
+return (extractedUsername.equals(extractedUsername)) && !isTokenExpired(token);
+
+// AFTER (FIXED)
+return (extractedUsername.equals(username)) && !isTokenExpired(token);
+```
+
+This bug would have been caught if tests used JWT authentication.
+
+### Current Test Architecture
+
+| Test Class | Security | JWT Used |
+|------------|----------|----------|
+| `AuthenticationControllerTest` | DISABLED | Only tests generation, not usage |
+| `CashFlowErrorHandlingTest` | DISABLED | No |
+| `BankDataIngestionHttpIntegrationTest` | DISABLED | No |
+| `HttpCashFlowServiceClientIntegrationTest` | DISABLED | No |
+
+Security is disabled via:
+- `AbstractHttpIntegrationTest.TestSecurityConfig` - permits all requests
+- `@ConditionalOnProperty(name = "app.security.enabled")` with `app.security.enabled=false`
+
+---
+
+## Solution: Enable JWT Authentication in Integration Tests
+
+### Step 1: Create `AuthenticatedHttpIntegrationTest` Base Class
+
+Create a new abstract base class that:
+- **Keeps security ENABLED** (no `app.security.enabled=false`)
+- Provides helper method to authenticate and get JWT token
+- Stores token for subsequent requests
+
+```java
+@SpringBootTest(
+    classes = FixedClockConfig.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@Import({PortfolioAppConfig.class, TradingAppConfig.class})
+@ActiveProfiles("test")
+public abstract class AuthenticatedHttpIntegrationTest {
+
+    // Shared Testcontainers (same as current)
+    protected static final MongoDBContainer mongoDBContainer;
+    protected static final KafkaContainer kafka;
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    protected TestRestTemplate restTemplate;
+
+    // JWT token storage
+    protected String accessToken;
+    protected String refreshToken;
+    protected String userId;
+
+    /**
+     * Registers a new user and stores JWT tokens for authenticated requests.
+     */
+    protected void registerAndAuthenticate(String username, String email, String password) {
+        RegisterRequest request = new RegisterRequest(username, email, password);
+        ResponseEntity<AuthenticationResponse> response = restTemplate.postForEntity(
+            "/api/v1/auth/register", request, AuthenticationResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        this.accessToken = response.getBody().getAccessToken();
+        this.refreshToken = response.getBody().getRefreshToken();
+        this.userId = response.getBody().getUserId();
+    }
+
+    /**
+     * Creates HTTP headers with JWT Bearer token.
+     */
+    protected HttpHeaders authenticatedHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(accessToken);  // Authorization: Bearer <token>
+        return headers;
+    }
+
+    /**
+     * Creates HTTP headers without authentication (for testing 401 responses).
+     */
+    protected HttpHeaders unauthenticatedHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+}
+```
+
+### Step 2: Update `*HttpActor` Classes
+
+Modify HTTP Actor classes to accept and use JWT tokens:
+
+```java
+@Slf4j
+public class CashFlowHttpActor {
+
+    private final TestRestTemplate restTemplate;
+    private final String baseUrl;
+    private String jwtToken;  // NEW: Store JWT token
+
+    public CashFlowHttpActor(TestRestTemplate restTemplate, int port) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = "http://localhost:" + port;
+    }
+
+    // NEW: Set JWT token for authenticated requests
+    public void setJwtToken(String token) {
+        this.jwtToken = token;
+    }
+
+    // NEW: Create authenticated headers
+    private HttpHeaders jsonHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (jwtToken != null) {
+            headers.setBearerAuth(jwtToken);
+        }
+        return headers;
+    }
+
+    // Existing methods remain the same, they already use jsonHeaders()
+}
+```
+
+### Step 3: Update Test Classes
+
+Migrate tests to use authentication:
+
+```java
+@Slf4j
+class CashFlowErrorHandlingTest extends AuthenticatedHttpIntegrationTest {
+
+    private CashFlowHttpActor actor;
+
+    @BeforeEach
+    void setUp() {
+        // Register user and get JWT token
+        String username = "testuser_" + UUID.randomUUID().toString().substring(0, 8);
+        registerAndAuthenticate(username, username + "@test.com", "password123");
+
+        // Create actor with JWT token
+        actor = new CashFlowHttpActor(restTemplate, port);
+        actor.setJwtToken(accessToken);
+    }
+
+    // Existing tests remain the same - they now use authenticated requests
+}
+```
+
+### Step 4: Add Security-Specific Tests
+
+Create dedicated tests for authentication/authorization:
+
+```java
+@Slf4j
+class CashFlowSecurityTest extends AuthenticatedHttpIntegrationTest {
+
+    @Test
+    @DisplayName("Should return 401 when accessing protected endpoint without token")
+    void shouldReturn401WithoutToken() {
+        // given - no authentication
+        CashFlowHttpActor unauthenticatedActor = new CashFlowHttpActor(restTemplate, port);
+        // Don't set JWT token
+
+        // when
+        ResponseEntity<ApiError> response = unauthenticatedActor.getCashFlowExpectingError("CF123");
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("Should return 401 with invalid token")
+    void shouldReturn401WithInvalidToken() {
+        // given
+        CashFlowHttpActor actor = new CashFlowHttpActor(restTemplate, port);
+        actor.setJwtToken("invalid.jwt.token");
+
+        // when
+        ResponseEntity<ApiError> response = actor.getCashFlowExpectingError("CF123");
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("Should return 401 with expired token")
+    void shouldReturn401WithExpiredToken() {
+        // given - generate expired token (requires test helper or mocked clock)
+        // ...
+    }
+
+    @Test
+    @DisplayName("Should return 403 when user lacks required role")
+    void shouldReturn403WithoutRequiredRole() {
+        // given - authenticate as MANAGER, try to access ADMIN-only endpoint
+        // ...
+    }
+}
+```
+
+### Step 5: Remove Security Disabling Code
+
+After migration, remove:
+
+1. `AbstractHttpIntegrationTest.TestSecurityConfig` inner class
+2. `app.security.enabled=false` from test properties
+3. `@ConditionalOnProperty` can remain on `SecurityConfiguration` for other use cases
+
+---
+
+## Migration Strategy
+
+### Phase 1: Add New Infrastructure (Non-Breaking)
+- [ ] Create `AuthenticatedHttpIntegrationTest` base class
+- [ ] Add `setJwtToken()` method to all `*HttpActor` classes
+- [ ] Create `CashFlowSecurityTest` with basic 401/403 tests
+
+### Phase 2: Migrate Existing Tests (One by One)
+- [ ] Migrate `CashFlowErrorHandlingTest` to extend `AuthenticatedHttpIntegrationTest`
+- [ ] Migrate `BankDataIngestionHttpIntegrationTest`
+- [ ] Migrate `HttpCashFlowServiceClientIntegrationTest`
+
+### Phase 3: Cleanup
+- [ ] Remove `AbstractHttpIntegrationTest` (old, security-disabled version)
+- [ ] Remove `TestSecurityConfig` from individual test classes
+- [ ] Update CLAUDE.md with new testing guidelines
+
+---
+
+## Benefits
+
+1. **Tests closer to production** - same security filters, same JWT validation
+2. **Catch security bugs early** - like the `isTokenValid()` bug found during upgrade
+3. **Test authorization** - verify role-based access control works
+4. **Confidence in deployments** - security is tested, not assumed
+
+## Risks
+
+1. **Slower tests** - each test needs to register/authenticate first
+2. **More setup code** - tests need to handle authentication
+3. **Token expiration** - long-running tests might face token expiration (mitigated by test configuration)
+
+## Estimated Effort
+
+- Phase 1: 2-3 hours
+- Phase 2: 1-2 hours per test class
+- Phase 3: 30 minutes
+
+---
+
+## References
+
+- Spring Security 6.x Migration Guide
+- `JwtService.java` - JWT generation and validation
+- `SecurityConfiguration.java` - security filter chain configuration
+- `JwtAuthenticationFilter.java` - request authentication filter

--- a/docs/TODO-kafka-dead-letter-queue.md
+++ b/docs/TODO-kafka-dead-letter-queue.md
@@ -1,0 +1,202 @@
+# TODO: Kafka Dead Letter Queue (DLQ) Implementation
+
+## Problem
+
+### Opis
+W `HistoricalCashChangeImportedEventHandler` (oraz potencjalnie innych handlerach Kafka) istnieje problem z obsługą "poison messages" - wiadomości które nie mogą być przetworzone.
+
+### Obecne zachowanie
+1. Handler otrzymuje event `HistoricalCashChangeImportedEvent`
+2. Próbuje znaleźć `CashFlowForecastStatement` w MongoDB
+3. Jeśli nie znajdzie - retry z exponential backoff (10 prób, ~13 sekund łącznie)
+4. Po wyczerpaniu prób - **rzuca wyjątek**
+5. Kafka consumer nie commituje offsetu
+6. Consumer próbuje przetworzyć tę samą wiadomość ponownie
+7. **INFINITE LOOP** - cały consumer jest zablokowany
+
+### Konsekwencje
+- Jeden uszkodzony event blokuje przetwarzanie wszystkich kolejnych eventów
+- Brak widoczności problemu (poza logami WARN)
+- System przestaje reagować na nowe eventy
+
+### Kiedy to może wystąpić
+1. **Testy z shared Testcontainers**: Kafka zachowuje wiadomości między uruchomieniami testów, ale MongoDB może mieć inne dane
+2. **Produkcja - race condition**: Event wysłany zanim CashFlow został w pełni zapisany
+3. **Produkcja - usunięcie danych**: CashFlow usunięty, ale eventy pozostały w Kafka
+4. **Produkcja - błąd replikacji**: MongoDB replica lag
+
+## Tymczasowe rozwiązanie (zaimplementowane)
+
+W `HistoricalCashChangeImportedEventHandler.handleWithRetry()`:
+- Po wyczerpaniu prób dla `CashFlowDoesNotExistsException` - logujemy ERROR i skipujemy wiadomość
+- Consumer może kontynuować przetwarzanie kolejnych wiadomości
+- Błąd jest widoczny w logach
+
+**Wady tego rozwiązania:**
+- Wiadomość jest tracona bezpowrotnie
+- Brak możliwości późniejszego przetworzenia
+- Wymaga ręcznej interwencji na podstawie logów
+
+## Docelowe rozwiązanie: Dead Letter Queue
+
+### Architektura
+
+```
+                                    ┌─────────────────┐
+                                    │   DLQ Topic     │
+                                    │ (cash_flow_dlq) │
+                                    └────────┬────────┘
+                                             │
+                                             ▼
+┌──────────┐    ┌─────────────┐    ┌─────────────────┐    ┌──────────────┐
+│  Kafka   │───▶│  Consumer   │───▶│    Handler      │───▶│   MongoDB    │
+│  Topic   │    │ (group_id7) │    │ (processing)    │    │  (success)   │
+└──────────┘    └─────────────┘    └────────┬────────┘    └──────────────┘
+                                            │
+                                            │ (failure after N retries)
+                                            ▼
+                                   ┌─────────────────┐
+                                   │  DLQ Producer   │
+                                   │ (send to DLQ)   │
+                                   └─────────────────┘
+```
+
+### Implementacja
+
+#### 1. Konfiguracja DLQ topic
+```java
+@Configuration
+public class KafkaTopicConfig {
+
+    @Bean
+    public NewTopic cashFlowDlqTopic() {
+        return TopicBuilder.name("cash_flow_dlq")
+                .partitions(1)
+                .replicas(1)
+                .config(TopicConfig.RETENTION_MS_CONFIG, "604800000") // 7 dni
+                .build();
+    }
+}
+```
+
+#### 2. DLQ Message format
+```java
+public record DlqMessage(
+    String originalTopic,
+    String originalKey,
+    String originalPayload,
+    String errorMessage,
+    String exceptionClass,
+    int retryCount,
+    ZonedDateTime failedAt,
+    Map<String, String> metadata
+) {}
+```
+
+#### 3. Error Handler z DLQ
+```java
+@Component
+@AllArgsConstructor
+public class KafkaDlqErrorHandler {
+
+    private final KafkaTemplate<String, DlqMessage> dlqTemplate;
+
+    public void sendToDlq(ConsumerRecord<?, ?> record, Exception exception, int retryCount) {
+        DlqMessage dlqMessage = new DlqMessage(
+            record.topic(),
+            record.key() != null ? record.key().toString() : null,
+            record.value().toString(),
+            exception.getMessage(),
+            exception.getClass().getName(),
+            retryCount,
+            ZonedDateTime.now(),
+            Map.of(
+                "partition", String.valueOf(record.partition()),
+                "offset", String.valueOf(record.offset())
+            )
+        );
+
+        dlqTemplate.send("cash_flow_dlq", dlqMessage);
+        log.error("Message sent to DLQ: topic={}, offset={}, error={}",
+            record.topic(), record.offset(), exception.getMessage());
+    }
+}
+```
+
+#### 4. Modyfikacja handlera
+```java
+// W HistoricalCashChangeImportedEventHandler
+private final KafkaDlqErrorHandler dlqErrorHandler;
+
+private void handleWithRetry(CashFlowEvent.HistoricalCashChangeImportedEvent event,
+                             ConsumerRecord<?, ?> record) {
+    // ... retry logic ...
+
+    // After retries exhausted:
+    dlqErrorHandler.sendToDlq(record, lastException, MAX_RETRIES);
+    // Don't throw - let consumer commit and move on
+}
+```
+
+### Monitoring i Alerting
+
+#### Metryki do monitorowania
+- `kafka.dlq.messages.total` - liczba wiadomości w DLQ
+- `kafka.dlq.messages.by_error_type` - podział po typie błędu
+- `kafka.consumer.lag` - opóźnienie consumera
+
+#### Alerty
+- **CRITICAL**: DLQ ma więcej niż 10 wiadomości w ciągu godziny
+- **WARNING**: DLQ ma jakiekolwiek wiadomości
+- **INFO**: Consumer lag > 1000
+
+### Narzędzia do obsługi DLQ
+
+#### 1. DLQ Viewer (Admin endpoint)
+```java
+@RestController
+@RequestMapping("/admin/dlq")
+public class DlqAdminController {
+
+    @GetMapping("/messages")
+    public List<DlqMessage> getMessages(@RequestParam(defaultValue = "100") int limit);
+
+    @PostMapping("/replay/{messageId}")
+    public void replayMessage(@PathVariable String messageId);
+
+    @DeleteMapping("/{messageId}")
+    public void deleteMessage(@PathVariable String messageId);
+}
+```
+
+#### 2. Automatyczny replay (opcjonalnie)
+- Scheduled job próbujący przetworzyć wiadomości z DLQ
+- Exponential backoff między próbami
+- Max retry count per message
+
+## Plan wdrożenia
+
+### Faza 1 (zrobione)
+- [x] Tymczasowe rozwiązanie: skip poison messages z ERROR logiem
+
+### Faza 2 (do zrobienia)
+- [ ] Utworzenie DLQ topic
+- [ ] Implementacja `KafkaDlqErrorHandler`
+- [ ] Modyfikacja wszystkich handlerów do używania DLQ
+- [ ] Dodanie metryk Micrometer
+
+### Faza 3 (przyszłość)
+- [ ] Admin UI do przeglądania DLQ
+- [ ] Automatyczny replay z backoff
+- [ ] Integracja z systemem alertingu
+
+## Powiązane pliki
+
+- `src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/HistoricalCashChangeImportedEventHandler.java`
+- `src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowEventListener.java`
+- `src/main/java/com/multi/vidulum/config/KafkaConsumerConfig.java`
+
+## Referencje
+
+- [Spring Kafka Error Handling](https://docs.spring.io/spring-kafka/reference/kafka/annotation-error-handling.html)
+- [Kafka Dead Letter Queue Pattern](https://www.confluent.io/blog/kafka-connect-deep-dive-error-handling-dead-letter-queues/)

--- a/docs/design/2026-02-14-business-analysis-alerts-cashchange-lifecycle.md
+++ b/docs/design/2026-02-14-business-analysis-alerts-cashchange-lifecycle.md
@@ -1,0 +1,1597 @@
+# Business Analysis: Recurring Rules vs Agicap + Alerts & CashChange Lifecycle
+
+**Data utworzenia:** 2026-02-14
+**Status:** Analysis & Design Extension
+**Autor:** Claude Code + User
+
+---
+
+## Spis treści
+
+1. [Porównanie z Agicap](#1-porównanie-z-agicap)
+2. [Porównanie z Float i Pulse](#2-porównanie-z-float-i-pulse)
+3. [Ocena biznesowa designu](#3-ocena-biznesowa-designu)
+4. [Analiza obecnego CashChange](#4-analiza-obecnego-cashchange)
+5. [Rozszerzenie: Statusy CashChange](#5-rozszerzenie-statusy-cashchange)
+6. [Lifecycle CashChange](#6-lifecycle-cashchange)
+7. [Alert System Design](#7-alert-system-design)
+8. [Integracja: Recurring Rules + Alerts](#8-integracja-recurring-rules--alerts)
+9. [Business Value Proposition](#9-business-value-proposition)
+10. [Rekomendacje implementacyjne](#10-rekomendacje-implementacyjne)
+
+---
+
+## 1. Porównanie z Agicap
+
+### 1.1 Agicap - Features Overview
+
+**Źródła:**
+- [Cash flow management software | Agicap](https://agicap.com/en-us/)
+- [Cash flow forecasting software | Agicap](https://agicap.com/en-us/features/cashflow-forecast/)
+- [Cash Flow Forecast Guide 2025 | Agicap](https://agicap.com/en-us/article/cash-flow-forecast/)
+
+**Kluczowe możliwości:**
+
+#### Multi-horizon forecasting
+```
+Short-term (4-13 weeks):
+  - Based on actual data
+  - Integrates AP/AR, payroll, recurring items (rent, wages)
+  - Daily/weekly refresh
+
+Medium-term (6 months):
+  - Combines actuals + budgets + AP/AR cycles
+  - Debt servicing schedules
+  - Recurring transactions (rent, salaries, taxes, debts, investments)
+
+Long-term (year-end):
+  - Strategic planning
+  - M&A scenarios
+```
+
+#### Recurring Transactions Handling
+```
+Data inputs:
+  ✅ Supplier/customer invoices
+  ✅ Open purchase orders
+  ✅ Payment terms
+  ✅ Debt schedules
+  ✅ Recurring/exceptional transactions
+
+Automation:
+  ✅ Real-time bank/ERP/accounting integrations
+  ✅ Auto-capture of AP/AR, payroll, tax
+  ✅ Smart reconciliation (1:1, 1:N, N:1, N:N matching)
+  ✅ DSO-based rules (Days Sales Outstanding)
+```
+
+#### Business Rules
+```
+DSO Rules:
+  - Each customer's actual DSO
+  - Group-wide DSO rules
+  - Payment terms standardization
+  - Local adaptation
+
+Reconciliation Engine:
+  - 1:1 matching (jedna faktura → jedna płatność)
+  - 1:N matching (jedna faktura → wiele rat)
+  - N:1 matching (wiele faktur → jedna płatność)
+  - N:N matching (complex scenarios)
+```
+
+---
+
+### 1.2 Vidulum vs Agicap - Feature Matrix
+
+| Feature | Agicap | Vidulum (current) | Vidulum (with Recurring Rules MVP) |
+|---------|--------|-------------------|-------------------------------------|
+| **Recurring Transactions** |
+| Manual creation | ✅ Yes | ❌ No | ✅ **Yes** |
+| Auto-detection from history | ⚠️ Via ERP | ❌ No | ❌ Phase 4 |
+| Advanced frequencies | ⚠️ Basic | ❌ No | ✅ **Yes** (better) |
+| Seasonal rules | ❌ No | ❌ No | ✅ **Yes** (unique) |
+| Business-specific (max occurrences, etc.) | ⚠️ Partial | ❌ No | ✅ **Yes** |
+| **Forecasting** |
+| Multi-horizon (4-13 weeks, 6 months, year) | ✅ Yes | ⚠️ 12 months | ⚠️ 12 months |
+| DSO-based rules | ✅ Yes | ❌ No | ❌ Phase 5 |
+| Payment terms | ✅ Yes | ❌ No | ❌ Phase 5 |
+| Scenario modeling | ✅ Yes | ❌ No | ❌ Phase 6 |
+| **Integration** |
+| Bank API (real-time) | ✅ Yes | ❌ No | ❌ Phase 5 |
+| ERP integration | ✅ Yes | ❌ No | ❌ Future |
+| AP/AR automation | ✅ Yes | ❌ No | ❌ Phase 5 |
+| **Reconciliation** |
+| Smart matching (1:1, 1:N, N:1, N:N) | ✅ Yes | ❌ No | ❌ Phase 5 |
+| Auto-categorization | ✅ Yes | ⚠️ Partial (CSV) | ⚠️ Partial (CSV) |
+| **Alerts** |
+| Low balance alerts | ✅ Yes | ❌ No | ⚠️ Phase 3 extension |
+| Overdue payments | ✅ Yes | ❌ No | ⚠️ Phase 3 extension |
+| Pattern anomalies | ✅ Yes | ❌ No | ❌ Phase 6 (AI) |
+| **User Experience** |
+| Manual entry reduction | ✅ High | ⚠️ Medium | ✅ **High** |
+| Error-prone spreadsheets replacement | ✅ Yes | ⚠️ Partial | ✅ **Yes** |
+| Multi-user/roles | ✅ Yes | ⚠️ Basic | ⚠️ Basic |
+| **Pricing Tier** |
+| Target market | Mid-market ($200-500/mo) | SMB/Individuals ($0-50/mo) | SMB/Mid-market ($50-200/mo) |
+
+---
+
+### 1.3 Gap Analysis
+
+#### Where Vidulum LOSES to Agicap:
+
+1. **ERP Integration** - Agicap ma real-time sync z Sage, NetSuite, QuickBooks
+2. **AP/AR Automation** - Agicap auto-importuje faktury i terminy płatności
+3. **DSO Rules** - Agicap przewiduje kiedy klient rzeczywiście zapłaci (nie tylko invoice due date)
+4. **Multi-horizon** - Agicap ma 3 horyzonty (4-13 weeks, 6 months, year)
+5. **Scenario modeling** - Agicap ma "what-if" analysis
+6. **Smart reconciliation** - Agicap ma N:N matching (złożone scenariusze)
+
+#### Where Vidulum WINS vs Agicap:
+
+1. **Advanced Frequencies** ✅
+   - Agicap: monthly, quarterly, yearly (basic)
+   - Vidulum: co 2 tygodnie, ostatni piątek miesiąca, każde 14 dni od daty
+
+2. **Seasonal Rules** ✅ (UNIQUE)
+   - Agicap: brak
+   - Vidulum: activeMonths [9,10,11,12,1,2,3,4,5,6] dla przedszkola
+
+3. **Business-Specific Features** ✅
+   - Agicap: limited
+   - Vidulum: maxOccurrences (raty kredytu), excludedDates, notes
+
+4. **Transparency** ✅
+   - Agicap: black box (user nie widzi jak forecast jest obliczany)
+   - Vidulum: full visibility - każda transakcja ma link do RecurringRule
+
+5. **Price** ✅
+   - Agicap: $200-500/mo (mid-market)
+   - Vidulum: $0-50/mo (SMB tier), $50-200/mo (business tier)
+
+6. **Simplicity** ✅
+   - Agicap: complex setup, requires ERP
+   - Vidulum: standalone, works without ERP
+
+---
+
+## 2. Porównanie z Float i Pulse
+
+### 2.1 Float Cash Flow Forecasting
+
+**Źródła:**
+- [Float Cash Flow Forecasting Software](https://floatapp.com/)
+- [Float Features](https://www.floatapp.com/features)
+
+**Kluczowe features:**
+
+```
+Automation:
+  ✅ Auto-sync with Xero/QuickBooks/FreeAgent (every 24h)
+  ✅ Real-time financial data
+  ✅ Recurring payment tracking
+  ✅ What-if scenarios (toggle on/off)
+
+Recurring Payments:
+  ⚠️ Basic - tracks from accounting platform
+  ❌ No manual creation
+  ❌ No advanced frequencies
+  ❌ No seasonal rules
+
+Alerts:
+  ⚠️ Limited - highlights cash flow issues
+  ❌ No custom alert rules
+```
+
+**Vidulum vs Float:**
+
+| Feature | Float | Vidulum MVP |
+|---------|-------|-------------|
+| Manual recurring rules | ❌ | ✅ **Better** |
+| Advanced frequencies | ❌ | ✅ **Better** |
+| Seasonal rules | ❌ | ✅ **Unique** |
+| Accounting integration | ✅ Better | ⚠️ CSV only |
+| What-if scenarios | ✅ | ❌ Phase 6 |
+| Price | $49-99/mo | $0-50/mo |
+
+---
+
+### 2.2 Pulse Cash Flow Management
+
+**Źródła:**
+- [Pulse Features](https://pulseapp.com/features)
+- [Pulse (mypulse.io)](https://mypulse.io/)
+
+**Kluczowe features:**
+
+```
+Recurring Logic:
+  ✅ Daily, weekly, monthly, yearly
+  ✅ Powerful recurring income/expense logic
+  ✅ Monitor cash flow by week/month/custom range
+
+Alerts (mypulse.io):
+  ✅ Automated alerts for critical updates
+  ✅ Cash flow pattern shift detection
+  ✅ AI model identifies key event triggers
+  ❌ No custom alert rules visible to user
+
+Forecasting:
+  ✅ Projects future cash flow
+  ✅ Takes into account recurring revenue, expenses, past-due payments
+  ⚠️ AI-based but not transparent
+```
+
+**Vidulum vs Pulse:**
+
+| Feature | Pulse | Vidulum MVP |
+|---------|-------|-------------|
+| Recurring frequencies | ⚠️ Basic | ✅ **Advanced** |
+| Seasonal rules | ❌ | ✅ **Unique** |
+| Alert system | ✅ Better | ⚠️ Phase 3 extension |
+| AI forecasting | ✅ | ❌ Phase 6 |
+| Transparency | ❌ Black box | ✅ **Full visibility** |
+| Price | $29/mo | $0-50/mo |
+
+---
+
+## 3. Ocena biznesowa designu
+
+### 3.1 Mocne strony (Strengths)
+
+#### 1. **Advanced Frequencies** - przewaga konkurencyjna
+
+```yaml
+Agicap: monthly, quarterly, yearly (3 opcje)
+Float: daily, weekly, monthly, yearly (4 opcje)
+Pulse: daily, weekly, monthly, yearly (4 opcje)
+
+Vidulum: 6 opcji + warianty:
+  - MONTHLY (+ interval, + last day)
+  - WEEKLY (+ interval)
+  - YEARLY
+  - QUARTERLY (+ which month of quarter)
+  - EVERY_N_DAYS (+ day of week constraint)
+  - ONCE
+
+Examples:
+  ✅ "Co 2 tygodnie w piątki" (wypłata)
+  ✅ "Ostatni dzień miesiąca" (telefon)
+  ✅ "Każde 14 dni od 7 marca" (rata)
+  ✅ "Pierwszy piątek miesiąca" (team lunch)
+```
+
+**Business value:** Obsługa nietypowych cykli biznesowych (construction, freelance, agencies)
+
+---
+
+#### 2. **Seasonal Rules** - UNIQUE feature
+
+```yaml
+Use cases:
+  - Przedszkole: 10 miesięcy (IX-VI)
+  - Ogrzewanie: 7 miesięcy (X-IV)
+  - Seasonal business: tourism (V-IX), ski resort (XII-III)
+  - Academic: university payments (IX-VI)
+  - Construction: weather-dependent costs
+
+Implementation:
+  activeMonths: [9,10,11,12,1,2,3,4,5,6]
+
+Competitors: NONE has this feature
+```
+
+**Business value:** Obsługa sezonowych biznesów (turystyka, budownictwo, edukacja)
+
+---
+
+#### 3. **Business-Specific Features**
+
+```yaml
+maxOccurrences:
+  - Loan installments: 24 raty
+  - Leasing: 36 miesięcy + balon
+  - Fixed-term contracts
+
+excludedDates:
+  - Holidays: skip Dec 25
+  - Vacation: skip August
+  - Special events
+
+notes:
+  - Business context
+  - Justification
+  - Approvals
+```
+
+**Business value:** Professional use cases (finance, accounting, compliance)
+
+---
+
+#### 4. **Full Transparency**
+
+```yaml
+Agicap: Black box - user nie widzi szczegółów
+Float: Integration-driven - depends on accounting platform
+Pulse: AI-driven - opaque
+
+Vidulum:
+  ✅ Każda transakcja ma link do RecurringRule
+  ✅ User widzi occurrence number (12/24)
+  ✅ Full audit trail
+  ✅ Can pause/resume/edit rules
+```
+
+**Business value:** Trust, compliance, auditability
+
+---
+
+### 3.2 Słabości (Weaknesses)
+
+#### 1. **Brak ERP Integration**
+
+```
+Problem: SMB/mid-market businesses use Xero, QuickBooks, Sage
+Agicap: Real-time sync with all major ERPs
+Vidulum: CSV import only
+
+Impact: Manual work, data staleness, errors
+```
+
+**Mitigation:**
+- Phase 5: Add Xero/QuickBooks integrations
+- Phase 6: Add Sage, NetSuite (enterprise)
+
+---
+
+#### 2. **Brak DSO Rules**
+
+```
+Problem: Invoice due date ≠ actual payment date
+Example:
+  Invoice due: 30 days
+  Customer actually pays: 45 days (DSO = 45)
+
+Agicap: Uses historical DSO to predict actual payment date
+Vidulum: Uses dueDate only (naïve forecast)
+
+Impact: Forecast inaccuracy for B2B businesses
+```
+
+**Mitigation:**
+- Phase 6: Add customer payment behavior tracking
+- Phase 7: Add DSO-based forecasting
+
+---
+
+#### 3. **Brak Smart Reconciliation (N:N matching)**
+
+```
+Problem: Complex payment scenarios
+Examples:
+  - 1 invoice → 3 partial payments
+  - 5 invoices → 1 bulk payment
+  - Split payments across months
+
+Agicap: N:N matching engine
+Vidulum: 1:1 matching only (Phase 5)
+
+Impact: Manual reconciliation for complex B2B scenarios
+```
+
+**Mitigation:**
+- Phase 5: 1:1 matching (MVP)
+- Phase 6: 1:N, N:1 matching
+- Phase 7: N:N matching (enterprise)
+
+---
+
+#### 4. **Brak Scenario Modeling**
+
+```
+Problem: "What if" analysis
+Examples:
+  - What if customer delays payment by 2 weeks?
+  - What if we get new $50k contract?
+  - What if we hire 3 more people?
+
+Agicap: Toggle scenarios on/off
+Float: Toggle scenarios on/off
+Vidulum: None
+
+Impact: Limited strategic planning capability
+```
+
+**Mitigation:**
+- Phase 6: Scenario modeling
+- Phase 7: Monte Carlo simulation (probabilistic forecasting)
+
+---
+
+### 3.3 Market Positioning
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│  High Complexity / Enterprise                           │
+│                                                         │
+│      Agicap ($200-500/mo)                              │
+│      • ERP integration                                  │
+│      • DSO rules                                        │
+│      • N:N reconciliation                              │
+│      • Multi-entity consolidation                      │
+│                                                         │
+│  ─────────────────────────────────────────────────     │
+│                                                         │
+│  Mid-Market / SMB                                       │
+│                                                         │
+│      Vidulum ($50-200/mo) ← OUR TARGET                 │
+│      • Advanced recurring rules ✅                     │
+│      • Seasonal features ✅                            │
+│      • Business-specific ✅                            │
+│      • Manual + semi-automated                          │
+│                                                         │
+│  ─────────────────────────────────────────────────     │
+│                                                         │
+│  Low Complexity / Individuals                           │
+│                                                         │
+│      Pulse ($29/mo), Float ($49/mo)                    │
+│      • Basic recurring                                  │
+│      • Accounting integration                           │
+│      • Limited customization                            │
+│                                                         │
+│      Vidulum FREE ($0/mo)                              │
+│      • Manual recurring rules                           │
+│      • CSV import                                       │
+│      • Self-service                                     │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Positioning statement:**
+```
+Vidulum = "Advanced recurring rules for SMB/mid-market"
+
+Too simple for enterprise (no ERP)
+Too advanced for individuals (overkill features)
+PERFECT for SMB/mid-market (sweet spot)
+```
+
+---
+
+## 4. Analiza obecnego CashChange
+
+### 4.1 Obecny stan (as-is)
+
+```java
+// File: CashChange.java (current implementation)
+
+public class CashChange {
+    private CashChangeId cashChangeId;
+    private Name name;
+    private Description description;
+    private Money money;
+    private Type type;  // INFLOW / OUTFLOW
+    private CategoryName categoryName;
+    private CashChangeStatus status;  // PENDING, CONFIRMED, REJECTED, ARCHIVED
+    private ZonedDateTime created;
+    private ZonedDateTime dueDate;
+    private ZonedDateTime endDate;  // when confirmed
+}
+
+// Current statuses
+public enum CashChangeStatus {
+    PENDING,     // Oczekuje na potwierdzenie
+    CONFIRMED,   // Potwierdzone (paid)
+    REJECTED,    // Odrzucone
+    ARCHIVED     // Zarchiwizowane
+}
+```
+
+**Aktualny lifecycle:**
+
+```
+User action: appendExpectedCashChange
+  → status = PENDING
+
+User action: confirmCashChange
+  → status = CONFIRMED
+  → endDate = now()
+  → balance updated
+
+User action: rejectCashChange
+  → status = REJECTED
+
+(later: archive old transactions)
+  → status = ARCHIVED
+```
+
+**Problemy z obecnym modelem:**
+
+1. **Brak rozróżnienia EXPECTED vs PAID**
+   ```
+   PENDING może być:
+     - Ręcznie utworzone (expected)
+     - Wygenerowane z RecurringRule (forecasted)
+     - Imported z banku (uncategorized)
+
+   → Nie wiadomo skąd pochodzi transakcja
+   ```
+
+2. **Brak paidDate**
+   ```
+   endDate jest używane dla:
+     - Actual payment date (when confirmed)
+     - Rejection date (when rejected)
+
+   → Nie można rozróżnić kiedy faktycznie zapłacono
+   ```
+
+3. **Brak link do RecurringRule**
+   ```
+   Nie wiadomo która transakcja pochodzi z której reguły
+
+   → Nie można:
+     - Edytować wszystkich z reguły
+     - Usunąć wszystkich z reguły
+     - Policzyć ile już wygenerowano (12/24)
+   ```
+
+4. **Brak statusu OVERDUE**
+   ```
+   PENDING po dueDate = ?
+
+   → System nie wie że transakcja jest przeterminowana
+   → Brak alertów o overdue
+   ```
+
+5. **Brak statusu UNMATCHED**
+   ```
+   Koniec miesiąca, PENDING nie dopasowane do bank transaction = ?
+
+   → Wymaga manualnej decyzji (match, defer, cancel)
+   → Obecnie: wisi w PENDING w nieskończoność
+   ```
+
+---
+
+## 5. Rozszerzenie: Statusy CashChange
+
+### 5.1 Proponowane nowe statusy
+
+```java
+public enum CashChangeStatus {
+    // ========================================
+    // EXPECTED (planowane transakcje)
+    // ========================================
+
+    PENDING,        // Ręcznie utworzone przez usera
+                    // Oczekuje na confirm/reject
+
+    FORECASTED,     // Wygenerowane automatycznie z RecurringRule
+                    // Oczekuje na dopasowanie z bankiem lub manual confirm
+
+    // ========================================
+    // CONFIRMED (potwierdzone transakcje)
+    // ========================================
+
+    CONFIRMED,      // Potwierdzone transakcje
+                    // - Manual: user kliknął "confirm"
+                    // - Auto: dopasowane do bank transaction
+
+    // ========================================
+    // PROBLEM STATES (wymagają akcji)
+    // ========================================
+
+    OVERDUE,        // PENDING/FORECASTED po dueDate
+                    // Alert: "Transaction overdue"
+                    // Actions: confirm late, defer, cancel
+
+    UNMATCHED,      // Koniec miesiąca, brak dopasowania do bank transaction
+                    // Alert: "Unmatched transaction"
+                    // Actions: match manually, mark as unpaid, cancel
+
+    // ========================================
+    // TERMINAL STATES (zakończone)
+    // ========================================
+
+    REJECTED,       // Odrzucone przez usera
+
+    CANCELLED,      // Anulowane (np. recurring rule zakończone)
+
+    DEFERRED,       // Przesunięte na inny termin
+                    // System tworzy nową transakcję w nowym miesiącu
+
+    ARCHIVED        // Zarchiwizowane (stare transakcje)
+}
+```
+
+---
+
+### 5.2 Rozszerzenie CashChange Model
+
+```java
+public class CashChange {
+    // ===== Existing fields =====
+    private CashChangeId cashChangeId;
+    private Name name;
+    private Description description;
+    private Money money;
+    private Type type;
+    private CategoryName categoryName;
+    private CashChangeStatus status;  // ROZSZERZONY ENUM
+    private ZonedDateTime created;
+    private ZonedDateTime dueDate;
+    private ZonedDateTime endDate;
+
+    // ===== NEW fields for Recurring Rules =====
+
+    private RecurringRuleId recurringRuleId;  // null = manual, not-null = from rule
+    private Boolean generatedFromRule;        // true = FORECASTED, false = PENDING
+    private Integer occurrenceNumber;         // 12 (dla maxOccurrences)
+    private Integer totalOccurrences;         // 24 (dla maxOccurrences)
+
+    // ===== NEW fields for Bank Reconciliation (Phase 5) =====
+
+    private ZonedDateTime paidDate;           // kiedy faktycznie zapłacono (z banku)
+    private BankTransactionId bankTransactionId;  // link do bank transaction
+    private Integer matchingScore;            // 0-100 (confidence)
+
+    // ===== NEW fields for Alerts =====
+
+    private ZonedDateTime becameOverdueAt;    // kiedy status → OVERDUE
+    private ZonedDateTime becameUnmatchedAt;  // kiedy status → UNMATCHED
+    private Boolean alertSent;                // czy wysłano alert
+    private ZonedDateTime alertSentAt;        // kiedy wysłano alert
+}
+```
+
+---
+
+## 6. Lifecycle CashChange
+
+### 6.1 Scenario 1: Manual EXPECTED → CONFIRMED
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING: User creates manual transaction
+    PENDING --> CONFIRMED: User confirms (click "Paid")
+    PENDING --> OVERDUE: dueDate passed, not confirmed
+    OVERDUE --> CONFIRMED: User confirms late
+    OVERDUE --> CANCELLED: User cancels
+    CONFIRMED --> ARCHIVED: Auto-archive after 12 months
+    CANCELLED --> ARCHIVED: Auto-archive after 12 months
+    ARCHIVED --> [*]
+```
+
+**Timeline:**
+```
+Day 0:  User: appendExpectedCashChange
+        → status = PENDING
+        → dueDate = Feb 10
+
+Day 10: System: check if dueDate passed
+        → dueDate = Feb 10 (today)
+        → status = PENDING (still ok)
+
+Day 11: System: check if dueDate passed
+        → dueDate = Feb 10 (yesterday)
+        → status → OVERDUE
+        → Alert: "Czynsz overdue (1 day)"
+
+Day 12: User: confirmCashChange
+        → status → CONFIRMED
+        → endDate = Feb 12
+        → paidDate = Feb 12
+```
+
+---
+
+### 6.2 Scenario 2: FORECASTED (from RecurringRule) → CONFIRMED
+
+```mermaid
+stateDiagram-v2
+    [*] --> FORECASTED: RecurringRule generates
+    FORECASTED --> CONFIRMED: Auto-match with bank OR manual confirm
+    FORECASTED --> OVERDUE: dueDate passed, not matched
+    OVERDUE --> CONFIRMED: Late match or manual confirm
+    OVERDUE --> UNMATCHED: End of month, no match
+    UNMATCHED --> CONFIRMED: Manual match
+    UNMATCHED --> DEFERRED: Defer to next month
+    UNMATCHED --> CANCELLED: Cancel (won't happen)
+    CONFIRMED --> ARCHIVED: Auto-archive after 12 months
+    DEFERRED --> FORECASTED: Create new in next month
+    CANCELLED --> ARCHIVED: Auto-archive after 12 months
+    ARCHIVED --> [*]
+```
+
+**Timeline:**
+```
+Feb 1:  System: MonthlyRolloverScheduler
+        → RecurringRule: "Czynsz" generates
+        → status = FORECASTED
+        → dueDate = Feb 10
+        → recurringRuleId = RR10000001
+        → occurrenceNumber = 12
+        → totalOccurrences = null (no maxOccurrences)
+
+Feb 10: System: check if dueDate passed
+        → dueDate = Feb 10 (today)
+        → status = FORECASTED (still ok)
+
+Feb 11: System: check if dueDate passed
+        → dueDate = Feb 10 (yesterday)
+        → status → OVERDUE
+        → Alert: "Czynsz overdue (1 day)"
+
+Feb 12: Bank API: import transaction
+        → 2050 PLN, "ZARZĄDCA NIERUCH"
+        → Reconciliation engine:
+            - Find EXPECTED/FORECASTED/OVERDUE with category "Mieszkanie"
+            - Match by counterpartyAccount
+            - Score = 95 (high confidence)
+        → Auto-match:
+            - status → CONFIRMED
+            - paidDate = Feb 12
+            - bankTransactionId = BT10000123
+            - matchingScore = 95
+        → Alert: "Czynsz matched automatically (2 days late, +50 PLN)"
+
+Feb 28: System: End of month check
+        → All FORECASTED/OVERDUE in February → UNMATCHED?
+        → Czynsz już CONFIRMED, skip
+```
+
+---
+
+### 6.3 Scenario 3: FORECASTED → UNMATCHED (not paid)
+
+```
+Feb 1:  RecurringRule generates
+        → status = FORECASTED
+        → dueDate = Feb 10
+        → name = "Gym Membership"
+
+Feb 11: System: dueDate passed
+        → status → OVERDUE
+
+Feb 28: System: End of month
+        → status still OVERDUE
+        → No bank match found
+        → status → UNMATCHED
+        → Alert: "Gym Membership unmatched - action required"
+
+User sees dashboard:
+  ⚠️ Unmatched Transactions (1)
+
+  Gym Membership, 150 PLN, due Feb 10
+
+  Options:
+    [Match manually] [Mark as unpaid] [Cancel] [Defer to March]
+
+User clicks: "Mark as unpaid"
+  → status → CANCELLED
+  → reason = "Cancelled membership, not renewed"
+```
+
+---
+
+### 6.4 Scenario 4: FORECASTED → DEFERRED (postponed)
+
+```
+Feb 1:  RecurringRule generates
+        → status = FORECASTED
+        → dueDate = Feb 10
+        → name = "Czynsz"
+
+Feb 5:  User: "Landlord said pay on Feb 20 this time"
+        → User: deferCashChange(to = Feb 20)
+        → status → DEFERRED
+        → Original transaction cancelled
+        → New transaction created:
+            - status = PENDING (manual override)
+            - dueDate = Feb 20
+            - recurringRuleId = null (detached from rule)
+            - notes = "Deferred from Feb 10 by user request"
+
+Feb 20: User confirms
+        → status → CONFIRMED
+```
+
+---
+
+### 6.5 Scenario 5: Loan installment (12/24)
+
+```
+Mar 1:  RecurringRule: "Loan - Car"
+        → maxOccurrences = 24
+        → generatedCount = 11
+        → Generate occurrence #12:
+            - status = FORECASTED
+            - dueDate = Mar 20
+            - recurringRuleId = RR10000005
+            - occurrenceNumber = 12
+            - totalOccurrences = 24
+
+Mar 20: Bank import
+        → 500 PLN, "BANK CREDIT"
+        → Auto-match
+        → status → CONFIRMED
+        → UI shows: "Loan 12/24 paid ✓"
+
+... (repeat 12 more times)
+
+Feb 20, 2027: Occurrence #24 confirmed
+        → RecurringRule check:
+            - generatedCount = 24
+            - maxOccurrences = 24
+            - generatedCount >= maxOccurrences
+        → RecurringRule: status → ENDED
+        → No more occurrences generated
+```
+
+---
+
+## 7. Alert System Design
+
+### 7.1 Alert Types
+
+```java
+public enum AlertType {
+    // ===== Cash Flow Alerts =====
+    OVERDUE_TRANSACTION,          // Transaction past due date
+    UNMATCHED_TRANSACTION,        // End of month, no match found
+    LOW_BALANCE_WARNING,          // Balance < threshold
+    NEGATIVE_BALANCE_FORECAST,    // Forecast shows negative balance
+
+    // ===== Recurring Rule Alerts =====
+    RULE_AUTO_MATCHED,            // Transaction auto-matched (FYI)
+    RULE_MATCH_SUGGESTION,        // Low confidence match (60-84)
+    RULE_ENDED_AUTO,              // Rule ended (maxOccurrences reached)
+
+    // ===== Anomaly Alerts =====
+    AMOUNT_ANOMALY,               // Amount differs significantly from rule
+    DATE_ANOMALY,                 // Payment date unusual (e.g., 20 days late)
+    MISSING_EXPECTED,             // Expected transaction never happened
+
+    // ===== Business Alerts =====
+    CASH_RUNWAY_LOW,              // < 3 months runway
+    CATEGORY_BUDGET_EXCEEDED,     // Category spending > budget
+    LARGE_TRANSACTION,            // Transaction > threshold (e.g., 10k)
+}
+```
+
+---
+
+### 7.2 Alert Configuration
+
+```java
+public class AlertConfig {
+    private UserId userId;
+    private CashFlowId cashFlowId;
+
+    // Alert settings per type
+    private Map<AlertType, AlertSettings> settings;
+
+    // Global settings
+    private boolean emailEnabled;
+    private boolean pushEnabled;
+    private boolean smsEnabled;
+    private boolean inAppOnly;
+
+    // Thresholds
+    private Money lowBalanceThreshold;      // e.g., 5000 PLN
+    private Integer overdueGracePeriodDays;  // e.g., 3 days
+    private Money largeTransactionThreshold; // e.g., 10000 PLN
+}
+
+public class AlertSettings {
+    private boolean enabled;
+    private AlertPriority priority;  // LOW, MEDIUM, HIGH, CRITICAL
+    private AlertChannel channel;    // EMAIL, PUSH, SMS, IN_APP
+    private boolean digestMode;      // true = daily digest, false = instant
+}
+```
+
+---
+
+### 7.3 Alert Generation - Examples
+
+#### Alert 1: OVERDUE_TRANSACTION
+
+```java
+// Trigger: Daily scheduler (02:00 UTC)
+@Scheduled(cron = "0 0 2 * * *")
+public void checkOverdueTransactions() {
+    LocalDate today = LocalDate.now(clock);
+
+    // Find all PENDING/FORECASTED with dueDate < today
+    List<CashChange> overdueTransactions = cashChangeRepository
+        .findByStatusIn(List.of(PENDING, FORECASTED))
+        .stream()
+        .filter(cc -> LocalDate.from(cc.getDueDate()).isBefore(today))
+        .toList();
+
+    for (CashChange cc : overdueTransactions) {
+        // Check grace period
+        AlertConfig config = alertConfigRepository.findByUserId(cc.getUserId());
+        int gracePeriod = config.getOverdueGracePeriodDays(); // e.g., 3 days
+
+        long daysOverdue = ChronoUnit.DAYS.between(
+            LocalDate.from(cc.getDueDate()),
+            today
+        );
+
+        if (daysOverdue >= gracePeriod) {
+            // Update status
+            cc.setStatus(OVERDUE);
+            cc.setBecameOverdueAt(ZonedDateTime.now(clock));
+            cashChangeRepository.save(cc);
+
+            // Send alert
+            Alert alert = Alert.builder()
+                .type(AlertType.OVERDUE_TRANSACTION)
+                .priority(AlertPriority.HIGH)
+                .title("Transaction Overdue")
+                .message(String.format(
+                    "%s (%s) is %d days overdue",
+                    cc.getName(),
+                    cc.getMoney(),
+                    daysOverdue
+                ))
+                .relatedCashChangeId(cc.getCashChangeId())
+                .build();
+
+            alertService.send(alert);
+
+            cc.setAlertSent(true);
+            cc.setAlertSentAt(ZonedDateTime.now(clock));
+            cashChangeRepository.save(cc);
+        }
+    }
+}
+```
+
+**Email template:**
+```
+Subject: ⚠️ Transaction Overdue: Czynsz
+
+Hi User,
+
+Your transaction "Czynsz" (2000 PLN) was due on Feb 10, 2026.
+It is now 3 days overdue.
+
+Actions you can take:
+  - Mark as paid (if you already paid it)
+  - Defer to a later date
+  - Cancel this transaction
+
+[View Details] [Mark as Paid]
+
+Best regards,
+Vidulum
+```
+
+---
+
+#### Alert 2: UNMATCHED_TRANSACTION
+
+```java
+// Trigger: End of month (last day at 23:00 UTC)
+@Scheduled(cron = "0 0 23 L * *")  // Last day of month
+public void checkUnmatchedTransactions() {
+    YearMonth currentMonth = YearMonth.now(clock);
+
+    // Find all FORECASTED/OVERDUE in current month
+    List<CashChange> unmatchedTransactions = cashChangeRepository
+        .findByStatusIn(List.of(FORECASTED, OVERDUE))
+        .stream()
+        .filter(cc -> YearMonth.from(cc.getDueDate()).equals(currentMonth))
+        .toList();
+
+    for (CashChange cc : unmatchedTransactions) {
+        // Update status
+        cc.setStatus(UNMATCHED);
+        cc.setBecameUnmatchedAt(ZonedDateTime.now(clock));
+        cashChangeRepository.save(cc);
+
+        // Send alert
+        Alert alert = Alert.builder()
+            .type(AlertType.UNMATCHED_TRANSACTION)
+            .priority(AlertPriority.MEDIUM)
+            .title("Unmatched Transaction - Action Required")
+            .message(String.format(
+                "%s (%s) was not matched to any bank transaction this month",
+                cc.getName(),
+                cc.getMoney()
+            ))
+            .relatedCashChangeId(cc.getCashChangeId())
+            .build();
+
+        alertService.send(alert);
+    }
+}
+```
+
+**UI Dashboard:**
+```
+⚠️ Unmatched Transactions (3)
+
+┌────────────────────────────────────────────────────────┐
+│ Czynsz                                    2000 PLN     │
+│ Expected: Feb 10 · No bank match found                │
+│                                                        │
+│ Possible actions:                                     │
+│  ○ Match to bank transaction manually                 │
+│  ○ Mark as "Not paid this month"                      │
+│  ○ Defer to next month                                │
+│  ○ Cancel (won't happen again)                        │
+│                                            [Resolve]  │
+└────────────────────────────────────────────────────────┘
+```
+
+---
+
+#### Alert 3: RULE_AUTO_MATCHED
+
+```java
+// Trigger: After auto-matching (Reconciliation Engine)
+public void onAutoMatch(CashChange expected, BankTransaction bank, int score) {
+    // Alert only if user wants to be notified
+    AlertConfig config = alertConfigRepository.findByUserId(expected.getUserId());
+
+    if (config.getSettings().get(AlertType.RULE_AUTO_MATCHED).isEnabled()) {
+        // Check for anomalies
+        Money amountDiff = expected.getMoney().minus(bank.getAmount()).abs();
+        long daysDiff = ChronoUnit.DAYS.between(
+            LocalDate.from(expected.getDueDate()),
+            bank.getTransactionDate()
+        );
+
+        String anomalies = "";
+        if (amountDiff.getAmount() > 50) {
+            anomalies += String.format("Amount diff: %s. ", amountDiff);
+        }
+        if (daysDiff > 5) {
+            anomalies += String.format("%d days late. ", daysDiff);
+        }
+
+        Alert alert = Alert.builder()
+            .type(AlertType.RULE_AUTO_MATCHED)
+            .priority(anomalies.isEmpty() ? AlertPriority.LOW : AlertPriority.MEDIUM)
+            .title("Transaction Auto-Matched")
+            .message(String.format(
+                "%s matched automatically (score: %d). %s",
+                expected.getName(),
+                score,
+                anomalies.isEmpty() ? "All good!" : anomalies
+            ))
+            .relatedCashChangeId(expected.getCashChangeId())
+            .build();
+
+        alertService.send(alert);
+    }
+}
+```
+
+**Email template (digest mode):**
+```
+Subject: ✅ 5 Transactions Auto-Matched Today
+
+Hi User,
+
+Vidulum automatically matched these transactions today:
+
+  ✅ Czynsz (2000 PLN) - Matched (score: 95)
+     Expected: Feb 10 | Paid: Feb 12 (2 days late)
+
+  ✅ Netflix (29 PLN) - Matched (score: 100)
+     Expected: Feb 15 | Paid: Feb 15 (on time)
+
+  ⚠️ Gym (150 PLN) - Matched (score: 75)
+     Expected: Feb 1 | Paid: Feb 8 (7 days late, +10 PLN)
+     [Review Match]
+
+[View All Transactions]
+
+Best regards,
+Vidulum
+```
+
+---
+
+#### Alert 4: LOW_BALANCE_WARNING
+
+```java
+// Trigger: After any transaction confirmed
+public void onTransactionConfirmed(CashChange cc) {
+    CashFlow cashFlow = cashFlowRepository.findById(cc.getCashFlowId());
+    Money currentBalance = cashFlow.getBankAccount().getBalance();
+
+    AlertConfig config = alertConfigRepository.findByUserId(cashFlow.getUserId());
+    Money threshold = config.getLowBalanceThreshold(); // e.g., 5000 PLN
+
+    if (currentBalance.isLessThan(threshold)) {
+        Alert alert = Alert.builder()
+            .type(AlertType.LOW_BALANCE_WARNING)
+            .priority(AlertPriority.HIGH)
+            .title("Low Balance Warning")
+            .message(String.format(
+                "Your balance (%s) is below threshold (%s)",
+                currentBalance,
+                threshold
+            ))
+            .build();
+
+        alertService.send(alert);
+    }
+}
+```
+
+---
+
+#### Alert 5: NEGATIVE_BALANCE_FORECAST
+
+```java
+// Trigger: Weekly forecast check (every Monday 08:00)
+@Scheduled(cron = "0 0 8 ? * MON")
+public void checkForecastBalance() {
+    List<CashFlow> allCashFlows = cashFlowRepository.findByStatus(CashFlowStatus.OPEN);
+
+    for (CashFlow cashFlow : allCashFlows) {
+        // Calculate forecast for next 4 weeks
+        Money currentBalance = cashFlow.getBankAccount().getBalance();
+        LocalDate today = LocalDate.now(clock);
+        LocalDate fourWeeksLater = today.plusWeeks(4);
+
+        // Get all FORECASTED/PENDING in next 4 weeks
+        List<CashChange> upcoming = cashChangeRepository
+            .findByCashFlowIdAndDueDateBetween(
+                cashFlow.getId(),
+                today.atStartOfDay(),
+                fourWeeksLater.atTime(23, 59, 59)
+            );
+
+        Money projectedBalance = currentBalance;
+        LocalDate negativeDate = null;
+
+        for (CashChange cc : upcoming.stream()
+                .sorted(Comparator.comparing(CashChange::getDueDate))
+                .toList()) {
+
+            if (cc.getType() == Type.INFLOW) {
+                projectedBalance = projectedBalance.plus(cc.getMoney());
+            } else {
+                projectedBalance = projectedBalance.minus(cc.getMoney());
+            }
+
+            if (projectedBalance.isNegative() && negativeDate == null) {
+                negativeDate = LocalDate.from(cc.getDueDate());
+            }
+        }
+
+        if (negativeDate != null) {
+            Alert alert = Alert.builder()
+                .type(AlertType.NEGATIVE_BALANCE_FORECAST)
+                .priority(AlertPriority.CRITICAL)
+                .title("Negative Balance Forecast")
+                .message(String.format(
+                    "Your balance is projected to go negative on %s",
+                    negativeDate
+                ))
+                .build();
+
+            alertService.send(alert);
+        }
+    }
+}
+```
+
+---
+
+### 7.4 Alert Channels
+
+```java
+public interface AlertChannel {
+    void send(Alert alert, User user);
+}
+
+@Component
+public class EmailAlertChannel implements AlertChannel {
+    @Override
+    public void send(Alert alert, User user) {
+        emailService.send(
+            user.getEmail(),
+            alert.getTitle(),
+            renderTemplate(alert)
+        );
+    }
+}
+
+@Component
+public class PushAlertChannel implements AlertChannel {
+    @Override
+    public void send(Alert alert, User user) {
+        pushNotificationService.send(
+            user.getPushToken(),
+            alert.getTitle(),
+            alert.getMessage()
+        );
+    }
+}
+
+@Component
+public class InAppAlertChannel implements AlertChannel {
+    @Override
+    public void send(Alert alert, User user) {
+        alertRepository.save(alert);  // Store for in-app display
+    }
+}
+```
+
+---
+
+## 8. Integracja: Recurring Rules + Alerts
+
+### 8.1 Rozszerz RecurringRule o Alert Settings
+
+```java
+public class RecurringRule {
+    // ... existing fields
+
+    // Alert preferences for this rule
+    private boolean alertOnAutoMatch;        // Notify when auto-matched
+    private boolean alertOnSuggestion;       // Notify when low-confidence match
+    private boolean alertOnOverdue;          // Notify when overdue
+    private boolean alertOnUnmatched;        // Notify when unmatched at month-end
+    private boolean alertOnAmountAnomaly;    // Notify if amount differs > X%
+    private Money amountAnomalyThreshold;    // e.g., ±10%
+}
+```
+
+**UI:**
+```
+┌────────────────────────────────────────────────────────┐
+│ Edit Rule: Czynsz                                [×]   │
+├────────────────────────────────────────────────────────┤
+│                                                        │
+│ Alert Preferences for this rule:                      │
+│                                                        │
+│ ☑ Notify when auto-matched to bank transaction        │
+│ ☑ Notify when match requires confirmation (60-84%)    │
+│ ☑ Notify when overdue (after 3 days)                  │
+│ ☑ Notify when unmatched at end of month               │
+│ ☑ Notify if amount differs by more than ┌──┐ %        │
+│                                           │10│         │
+│                                           └──┘         │
+│                                                        │
+│ [Save] [Cancel]                                        │
+└────────────────────────────────────────────────────────┘
+```
+
+---
+
+### 8.2 Alert Flow Diagram
+
+```
+RecurringRule generates FORECASTED
+        │
+        ▼
+Check dueDate daily ────────┐
+        │                    │
+        │ past dueDate       │
+        ▼                    │
+    OVERDUE ─────────────────┤
+        │                    │
+        │                    │ Alert: OVERDUE_TRANSACTION
+        ▼                    │
+Reconciliation Engine        │
+        │                    │
+  ┌─────┴──────┐            │
+  │            │            │
+High score   Low score      │
+(85-100)     (60-84)        │
+  │            │            │
+  ▼            ▼            │
+AUTO       SUGGEST ─────────┤
+MATCH                       │
+  │                         │ Alert: RULE_MATCH_SUGGESTION
+  │                         │
+  ▼                         ▼
+CONFIRMED ──────────────────┤
+                            │
+                            │ Alert: RULE_AUTO_MATCHED
+                            │ (if anomaly: amount/date diff)
+                            │
+End of month ───────────────┤
+        │                   │
+        │ still OVERDUE     │
+        ▼                   │
+    UNMATCHED ──────────────┘
+                            │
+                            │ Alert: UNMATCHED_TRANSACTION
+                            │
+                            ▼
+```
+
+---
+
+## 9. Business Value Proposition
+
+### 9.1 Dla SMB (małe firmy, freelancerzy)
+
+**Problem:**
+```
+"Spędzam 2-3 godziny tygodniowo na ręcznym wpisywaniu
+powtarzających się transakcji do Excela"
+```
+
+**Rozwiązanie Vidulum:**
+```
+✅ Recurring Rules: raz skonfigurujesz, system generuje automatycznie
+✅ Advanced Frequencies: co 2 tygodnie (wypłaty), ostatni dzień (rachunki)
+✅ Seasonal Rules: przedszkole IX-VI, ogrzewanie X-IV
+✅ Alerts: overdue, unmatched, low balance
+
+Oszczędność czasu: 2-3h/tydzień → 15 min/tydzień (95% redukcja)
+ROI: $50/mo subscription = $200/mo value (4x return)
+```
+
+---
+
+### 9.2 Dla Mid-Market (średnie firmy 10-50 osób)
+
+**Problem:**
+```
+"Używamy Excela do cash flow forecast. Duplikaty,
+błędy, nieaktualne dane. CFO spędza cały tydzień
+na przygotowaniu miesięcznego raportu."
+```
+
+**Rozwiązanie Vidulum:**
+```
+✅ Recurring Rules: wynagrodzenia, ZUS, VAT, leasing
+✅ Business Features: maxOccurrences (raty), excludedDates (święta)
+✅ Alerts: negative balance forecast, large transactions
+✅ Audit Trail: pełna widoczność (12/24), notes, approval history
+
+Oszczędność czasu: 1 dzień/miesiąc → 2h/miesiąc (87% redukcja)
+ROI: $200/mo subscription = $2000/mo value (10x return)
+Compliance: Full audit trail, notes, multi-user access
+```
+
+---
+
+### 9.3 Dla Seasonal Businesses (turystyka, budownictwo)
+
+**Problem:**
+```
+"Nasze koszty są sezonowe. Latem 10 pracowników,
+zimą 2. Excel nie radzi sobie z tym."
+```
+
+**Rozwiązanie Vidulum:**
+```
+✅ Seasonal Rules: activeMonths [5,6,7,8,9] dla seasonal staff
+✅ Seasonal Rules: activeMonths [10,11,12,1,2,3,4] dla heating
+✅ Multiple Rules: different rules for high/low season
+
+UNIQUE FEATURE - nikt inny tego nie ma
+```
+
+---
+
+### 9.4 Dla B2B Services (agencies, consulting)
+
+**Problem:**
+```
+"Klienci płacą z opóźnieniem. Invoice due: 30 dni,
+faktycznie płacą: 45-60 dni. Forecast jest nierealistyczny."
+```
+
+**Rozwiązanie Vidulum (Phase 6):**
+```
+✅ DSO Tracking: system uczy się rzeczywistych terminów płatności
+✅ Customer Profiles: każdy klient ma swój DSO
+✅ Realistic Forecast: forecast uwzględnia historical DSO
+
+Phase 6 feature (not MVP)
+```
+
+---
+
+## 10. Rekomendacje implementacyjne
+
+### 10.1 MVP Priority (Phase 3)
+
+**MUST HAVE:**
+```
+1. Rozszerzenie CashChangeStatus:
+   ✅ FORECASTED (new)
+   ✅ OVERDUE (new)
+
+2. Rozszerzenie CashChange model:
+   ✅ recurringRuleId
+   ✅ generatedFromRule
+   ✅ occurrenceNumber, totalOccurrences
+
+3. Basic Alerts (2 typy):
+   ✅ OVERDUE_TRANSACTION
+   ✅ UNMATCHED_TRANSACTION (end of month)
+
+4. Alert Channel:
+   ✅ In-app only (no email/push yet)
+```
+
+**NICE TO HAVE (can defer):**
+```
+⏸️ UNMATCHED status - defer to Phase 5 (reconciliation)
+⏸️ Email alerts - defer to Phase 4
+⏸️ Push notifications - defer to Phase 4
+⏸️ Alert digest mode - defer to Phase 4
+```
+
+---
+
+### 10.2 Phase Roadmap - Updated
+
+```
+Phase 1: Core Domain (2 weeks) ← DONE (from previous design)
+Phase 2: Persistence (1 week) ← DONE
+Phase 3: Scheduler + Alerts (1 week) ← NEW
+  ├─ MonthlyRolloverScheduler integration
+  ├─ CashChange status extension (FORECASTED, OVERDUE)
+  ├─ Daily overdue checker
+  ├─ End-of-month unmatched checker
+  ├─ In-app alert storage + display
+  └─ Alert REST API (GET /alerts, PATCH /alerts/{id}/mark-read)
+
+Phase 4: REST API (1 week)
+Phase 5: UI Integration (2 weeks)
+Phase 6: Advanced Alerts (1 week) ← NEW
+  ├─ Email channel
+  ├─ Push notification channel
+  ├─ Alert digest mode
+  ├─ Alert configuration UI
+  └─ LOW_BALANCE, NEGATIVE_FORECAST alerts
+```
+
+---
+
+### 10.3 Database Schema - Alert Extension
+
+```javascript
+// Collection: alerts
+{
+  "_id": ObjectId("..."),
+  "alertId": "AL10000001",
+  "userId": "U10000001",
+  "cashFlowId": "CF10000001",
+
+  "type": "OVERDUE_TRANSACTION",  // AlertType enum
+  "priority": "HIGH",  // LOW, MEDIUM, HIGH, CRITICAL
+
+  "title": "Transaction Overdue",
+  "message": "Czynsz (2000 PLN) is 3 days overdue",
+
+  "relatedCashChangeId": "CC10000123",
+  "relatedRecurringRuleId": "RR10000001",  // optional
+
+  "read": false,
+  "readAt": null,
+
+  "dismissed": false,
+  "dismissedAt": null,
+
+  "actionTaken": null,  // "CONFIRMED", "CANCELLED", "DEFERRED", etc.
+  "actionTakenAt": null,
+
+  "createdAt": ISODate("2026-02-13T02:00:00Z"),
+  "expiresAt": ISODate("2026-03-13T02:00:00Z")  // auto-delete after 30 days
+}
+
+// Indexes
+db.alerts.createIndex({ "userId": 1, "read": 1, "createdAt": -1 })
+db.alerts.createIndex({ "cashFlowId": 1, "type": 1 })
+db.alerts.createIndex({ "expiresAt": 1 }, { expireAfterSeconds: 0 })  // TTL index
+```
+
+---
+
+### 10.4 REST API - Alerts
+
+```http
+GET /alerts
+Authorization: Bearer {token}
+
+Query params:
+  ?read=false
+  ?type=OVERDUE_TRANSACTION
+  ?priority=HIGH,CRITICAL
+  ?limit=20
+
+Response 200 OK:
+{
+  "alerts": [
+    {
+      "alertId": "AL10000001",
+      "type": "OVERDUE_TRANSACTION",
+      "priority": "HIGH",
+      "title": "Transaction Overdue",
+      "message": "Czynsz (2000 PLN) is 3 days overdue",
+      "relatedCashChange": {
+        "cashChangeId": "CC10000123",
+        "name": "Czynsz",
+        "amount": { "amount": 2000.00, "currency": "PLN" },
+        "dueDate": "2026-02-10"
+      },
+      "read": false,
+      "createdAt": "2026-02-13T02:00:00Z"
+    }
+  ],
+  "unreadCount": 5
+}
+```
+
+```http
+PATCH /alerts/{alertId}/mark-read
+Authorization: Bearer {token}
+
+Response 200 OK:
+{
+  "alertId": "AL10000001",
+  "read": true,
+  "readAt": "2026-02-14T10:30:00Z"
+}
+```
+
+```http
+DELETE /alerts/{alertId}
+Authorization: Bearer {token}
+
+Response 204 No Content
+```
+
+---
+
+## Źródła
+
+### Agicap:
+- [Cash flow management software | Agicap](https://agicap.com/en-us/)
+- [Cash flow forecasting software | Agicap](https://agicap.com/en-us/features/cashflow-forecast/)
+- [Cash Flow Forecast Guide 2025 | Agicap](https://agicap.com/en-us/article/cash-flow-forecast/)
+
+### Float:
+- [Float Cash Flow Forecasting Software](https://floatapp.com/)
+- [Float Features](https://www.floatapp.com/features)
+
+### Pulse:
+- [Pulse Features](https://pulseapp.com/features)
+- [Pulse (mypulse.io)](https://mypulse.io/)
+
+---
+
+## Podsumowanie
+
+### Kluczowe wnioski:
+
+1. **Vidulum ma unique features** (seasonal rules, advanced frequencies) które przewyższają konkurencję
+2. **Gap vs Agicap**: brak ERP integration, DSO rules, N:N reconciliation
+3. **Market positioning**: SMB/mid-market sweet spot ($50-200/mo)
+4. **CashChange wymaga rozszerzenia**: FORECASTED, OVERDUE, paidDate, recurringRuleId
+5. **Alerts są KLUCZOWE**: Agicap, Float, Pulse - wszyscy mają alerts
+6. **MVP scope realistic**: 1 week for alerts (2 types, in-app only)
+
+### Next steps:
+
+1. Implement Phase 3: Scheduler + Basic Alerts (1 week)
+2. Add FORECASTED, OVERDUE statuses
+3. Add in-app alert system
+4. Defer email/push to Phase 6
+
+**Business value:**
+- 95% time savings for SMB
+- 87% time savings for mid-market
+- Unique seasonal features (no competitor has this)
+- Full transparency (vs black-box competitors)

--- a/docs/design/2026-02-14-recurring-rule-engine-design.md
+++ b/docs/design/2026-02-14-recurring-rule-engine-design.md
@@ -1,0 +1,2074 @@
+# Recurring Rule Engine - Complete Design Document
+
+**Data utworzenia:** 2026-02-14
+**Status:** Design - do implementacji
+**Autor:** Claude Code + User
+**Priorytet:** Phase 3 (po AI Categorization i Month Rollover)
+
+---
+
+## Spis treści
+
+1. [Executive Summary](#1-executive-summary)
+2. [Analiza konkurencji](#2-analiza-konkurencji)
+3. [Problemy z istniejącego designu](#3-problemy-z-istniejącego-designu)
+4. [Scope - co implementujemy teraz](#4-scope---co-implementujemy-teraz)
+5. [Przykłady użycia - User Stories](#5-przykłady-użycia---user-stories)
+6. [Model domenowy](#6-model-domenowy)
+7. [Stany i przejścia](#7-stany-i-przejścia)
+8. [UI Design - od początku do końca](#8-ui-design---od-początku-do-końca)
+9. [REST API](#9-rest-api)
+10. [Baza danych](#10-baza-danych)
+11. [Logika biznesowa](#11-logika-biznesowa)
+12. [Walidacje](#12-walidacje)
+13. [Integracja z istniejącym system](#13-integracja-z-istniejącym-systemem)
+14. [Plan implementacji](#14-plan-implementacji)
+15. [Future Features](#15-future-features)
+
+---
+
+## 1. Executive Summary
+
+### Cel
+
+Stworzyć **Rule Engine** do automatycznego generowania expected CashChanges na podstawie **recurring rules** (reguł powtarzalnych transakcji).
+
+### Kluczowe założenia
+
+- **Manual creation** - user tworzy reguły przez UI
+- **Auto-generation** - system generuje ExpectedCashChange wg reguł
+- **Reconciliation LATER** - dopasowanie bank transactions to osobny komponent (nie teraz)
+- **Simple first** - MVP bez AI, bez pattern detection, bez bank matching
+
+### Co dostaje użytkownik
+
+| Funkcjonalność | MVP (teraz) | Future |
+|----------------|-------------|--------|
+| Tworzenie reguł przez UI | ✅ TAK | - |
+| Auto-generowanie expected transactions | ✅ TAK | - |
+| Pausowanie/wznawianie reguł | ✅ TAK | - |
+| Edycja przyszłych vs wszystkich | ✅ TAK | - |
+| Wykrywanie duplikatów | ✅ TAK | - |
+| Pattern detection (AI) | ❌ NIE | Phase 4 |
+| Auto-matching z bankiem | ❌ NIE | Phase 5 |
+| Sugestie reguł | ❌ NIE | Phase 4 |
+
+---
+
+## 2. Analiza konkurencji
+
+### 2.1 YNAB (You Need A Budget)
+
+**Scheduled Transactions:**
+- Create recurring transactions with frequency: daily, weekly, monthly, yearly
+- Set amount (fixed or variable estimate)
+- Auto-match imported bank transactions to scheduled ones
+- Bulk approve imported transactions
+- "Enter Now" button to create transaction before due date
+
+**Auto-Assign Automation:**
+- Auto-calculate budget based on upcoming scheduled transactions
+- Suggest assignment order based on targets and priorities
+- Alert when category needs more money for upcoming expense
+
+**Strengths:**
+- Very mature scheduling system
+- Good auto-matching
+- Integration with budget targets
+
+**Weaknesses:**
+- Requires manual approval of all transactions
+- No advanced rule conditions (e.g., "only in summer")
+- No split rules
+- Basic frequency options only
+
+**Źródła:**
+- [Scheduled Transactions in YNAB: A Guide](https://support.ynab.com/en_us/scheduled-transactions-a-guide-BygrAIFA9)
+- [How to Use Auto-Assign in YNAB](https://support.ynab.com/en_us/auto-assign-a-guide-r1gBNbBJo)
+
+---
+
+### 2.2 Monarch Money
+
+**Recurring Transactions:**
+- **Auto-detection** - scans transactions, finds recurring patterns
+- **Recurring Review** - presents detected patterns for approval
+- Manual add if auto-detection missed something
+- Calendar view with color coding:
+  - Green ✓ - paid as expected
+  - Yellow - paid different amount
+- List view alternative
+- Frequency support: weekly, bi-weekly, monthly, yearly
+
+**Transaction Rules (IF-THEN):**
+
+**IF conditions:**
+- Merchant (exactly matches / contains)
+- Amount (equal, greater than, less than, range)
+- Category
+- Account
+
+**THEN actions:**
+- Rename merchant
+- Update category
+- Add tags
+- Hide transaction
+- Review status
+- Link to goal
+- Split by percentage or dollar amount
+
+**Apply to existing transactions** - retroactive rule application
+
+**Strengths:**
+- Auto-detection very good
+- Powerful rule engine with splits
+- Calendar visualization
+- Retroactive rule application
+
+**Weaknesses:**
+- Rules and recurrings are separate features
+- No advanced scheduling (e.g., "every 2nd Friday")
+- No seasonal/conditional rules
+
+**Źródła:**
+- [Tracking Recurring Expenses and Bills](https://help.monarch.com/hc/en-us/articles/4890751141908-Tracking-Recurring-Expenses-and-Bills)
+- [Creating Transaction Rules](https://help.monarch.com/hc/en-us/articles/360048393372-Creating-Transaction-Rules)
+
+---
+
+### 2.3 Copilot Money
+
+**Recurrings:**
+- **Create from existing transaction** - must have base transaction
+- Filter settings: transaction name, amount, date
+- Frequencies: weekly, bi-weekly, monthly, custom
+- AI Categorization with ML learning
+- **Shared recurring expenses** - split with other users
+
+**Limitations:**
+- Cannot view/manage auto-created rules
+- Must contact support to remove/change rule
+- No UI for rule management
+
+**Strengths:**
+- Very simple UX
+- ML learning from user corrections
+- Shared expenses (good for couples/families)
+
+**Weaknesses:**
+- No rule visibility/management
+- Limited customization
+- Business features minimal
+
+**Źródła:**
+- [Creating Recurrings](https://help.copilot.money/en/articles/3760068-creating-recurrings)
+- [Recurrings FAQ](https://help.copilot.money/en/articles/10244751-recurrings-faq)
+- [Separating Business and Personal Spending](https://help.copilot.money/en/articles/10760959-separating-business-and-personal-spending)
+
+---
+
+### 2.4 Porównanie - co wybrać dla Vidulum?
+
+| Feature | YNAB | Monarch | Copilot | **Vidulum (MVP)** |
+|---------|------|---------|---------|-------------------|
+| Manual rule creation | ✅ | ✅ | ⚠️ Limited | ✅ **TAK** |
+| Auto-detection | ❌ | ✅ | ✅ | ❌ Phase 4 |
+| Advanced frequencies | ❌ | ⚠️ Basic | ⚠️ Basic | ✅ **TAK** |
+| Seasonal rules | ❌ | ❌ | ❌ | ✅ **TAK** |
+| IF-THEN conditions | ❌ | ✅ | ❌ | ⚠️ Partial |
+| Split rules | ❌ | ✅ | ❌ | ❌ Phase 5 |
+| Business features | ⚠️ Basic | ⚠️ Basic | ⚠️ Basic | ✅ **TAK** |
+| Rule visibility/edit | ✅ | ✅ | ❌ | ✅ **TAK** |
+
+**Nasze przewagi:**
+1. **Advanced frequencies** - każde 2 tygodnie, ostatni piątek miesiąca, sezonowe
+2. **Seasonal rules** - przedszkole tylko 10 miesięcy, rachunki tylko zimą
+3. **Business-friendly** - exclude dates, max occurrences, notes
+4. **Full visibility** - pełna kontrola nad regułami
+
+---
+
+## 3. Problemy z istniejącego designu
+
+Z dokumentu `2026-02-06-bank-integration-design.md` wynikają następujące problemy:
+
+### Problem 1: Zbyt wiele funkcji naraz
+
+Design miesza:
+- Recurring rules
+- Bank API integration
+- Reconciliation (matching)
+- AI categorization
+- Pattern detection
+
+**Rozwiązanie:** Rozdzielić na fazy, MVP = tylko manual rules + auto-generation
+
+### Problem 2: Pattern matching ma niską skuteczność
+
+```
+"Opisy transakcji są chaotyczne"
+"Różne banki, różne formaty"
+```
+
+**Rozwiązanie:** Nie implementować pattern matching w MVP, skupić się na:
+- Counterparty account (98% skuteczności dla przelewów)
+- Amount + date tolerance
+
+### Problem 3: Podwójne liczenie EXPECTED + PAID
+
+```
+EXPECTED: 2000 PLN
+PAID: 2050 PLN (osobno)
+Suma: 4050 PLN ← BŁĄD!
+```
+
+**Rozwiązanie:**
+- EXPECTED nie liczy się do "actual" (tylko do "expected")
+- Reconciliation wykrywa duplikaty (ale to Phase 5)
+
+### Problem 4: Brak jasnej separacji scheduled vs rules
+
+Design miesza "scheduled transactions" (YNAB) z "rules" (Monarch).
+
+**Rozwiązanie:**
+- **RecurringRule** = template (jak często, ile, kategoria)
+- **ExpectedCashChange** = konkretna instancja wygenerowana z rule
+
+---
+
+## 4. Scope - co implementujemy teraz
+
+### MVP Scope (Phase 3)
+
+✅ **IN SCOPE:**
+1. Manual creation of RecurringRule przez UI
+2. CRUD operations na rules
+3. Auto-generation ExpectedCashChange podczas:
+   - Tworzenia reguły (do końca horyzontu)
+   - Month rollover (kolejny miesiąc)
+4. Stany: ACTIVE, PAUSED, ENDED
+5. Advanced frequencies (co 2 tygodnie, ostatni dzień miesiąca, sezonowe)
+6. Walidacje (no overlapping, no past start dates)
+7. Edit modes: "only future" vs "all unmatched"
+
+❌ **OUT OF SCOPE (later phases):**
+1. Pattern detection z historii
+2. Auto-matching z bank transactions
+3. Sugestie reguł przez AI
+4. Split rules (jedna transakcja → wiele kategorii)
+5. Shared rules (multi-user)
+6. Import rules z CSV/JSON
+
+---
+
+## 5. Przykłady użycia - User Stories
+
+### 5.1 Przykłady BASIC (zwykły user)
+
+#### Story 1: Czynsz co miesiąc
+
+```yaml
+User: "Płacę czynsz 2000 PLN 10-tego każdego miesiąca"
+
+Rule:
+  name: "Czynsz"
+  amount: 2000 PLN
+  category: "Mieszkanie"
+  frequency: MONTHLY
+  dayOfMonth: 10
+  type: OUTFLOW
+
+Generated ExpectedCashChanges:
+  - 2026-03-10: Czynsz, 2000 PLN (EXPECTED)
+  - 2026-04-10: Czynsz, 2000 PLN (EXPECTED)
+  - 2026-05-10: Czynsz, 2000 PLN (EXPECTED)
+  ... (do horyzontu: activePeriod + 11 months)
+```
+
+#### Story 2: Netflix co miesiąc (subskrypcja)
+
+```yaml
+User: "Netflix 29 PLN co miesiąc, 15-tego"
+
+Rule:
+  name: "Netflix"
+  amount: 29 PLN
+  category: "Rozrywka / Streaming"
+  frequency: MONTHLY
+  dayOfMonth: 15
+  type: OUTFLOW
+  counterpartyName: "NETFLIX"  # hint dla future reconciliation
+```
+
+#### Story 3: Wypłata co 2 tygodnie
+
+```yaml
+User: "Wypłata 3500 PLN co 2 tygodnie, w piątki"
+
+Rule:
+  name: "Wypłata"
+  amount: 3500 PLN
+  category: "Wynagrodzenie"
+  frequency: EVERY_N_DAYS
+  interval: 14
+  startDate: 2026-03-07  # pierwszy piątek
+  dayOfWeek: FRIDAY  # constraint
+  type: INFLOW
+
+Generated:
+  - 2026-03-07 (piątek)
+  - 2026-03-21 (piątek)
+  - 2026-04-04 (piątek)
+  - 2026-04-18 (piątek)
+  ...
+```
+
+#### Story 4: Ubezpieczenie raz w roku
+
+```yaml
+User: "Ubezpieczenie samochodu 1200 PLN, 1 stycznia każdego roku"
+
+Rule:
+  name: "Ubezpieczenie auto"
+  amount: 1200 PLN
+  category: "Samochód / Ubezpieczenie"
+  frequency: YEARLY
+  dayOfMonth: 1
+  monthOfYear: 1  # JANUARY
+  type: OUTFLOW
+
+Generated:
+  - 2026-01-01 (już minęło - nie generuj)
+  - 2027-01-01
+  - 2028-01-01
+  ...
+```
+
+#### Story 5: Zakupy spożywcze co tydzień (estimate)
+
+```yaml
+User: "Zakupy ~400 PLN co tydzień w soboty"
+
+Rule:
+  name: "Zakupy spożywcze"
+  amount: 400 PLN
+  amountIsEstimate: true  # nie expect exact amount
+  category: "Żywność"
+  frequency: WEEKLY
+  dayOfWeek: SATURDAY
+  type: OUTFLOW
+
+Note: reconciliation będzie miał większą tolerancję dla estimate
+```
+
+---
+
+### 5.2 Przykłady ADVANCED (power users)
+
+#### Story 6: Przedszkole - sezonowe (9 miesięcy)
+
+```yaml
+User: "Przedszkole 800 PLN 5-tego miesiąca, wrzesień-czerwiec"
+
+Rule:
+  name: "Przedszkole - Jaś"
+  amount: 800 PLN
+  category: "Dzieci / Edukacja"
+  frequency: MONTHLY
+  dayOfMonth: 5
+  activeMonths: [9,10,11,12,1,2,3,4,5,6]  # IX-VI
+  type: OUTFLOW
+
+Generated:
+  - 2025-09-05
+  - 2025-10-05
+  - ...
+  - 2026-06-05
+  (SKIP: lipiec, sierpień)
+  - 2026-09-05
+  - ...
+```
+
+#### Story 7: Ogrzewanie tylko zimą
+
+```yaml
+User: "Ogrzewanie ~350 PLN miesięcznie, październik-kwiecień"
+
+Rule:
+  name: "Ogrzewanie"
+  amount: 350 PLN
+  amountIsEstimate: true
+  category: "Mieszkanie / Media"
+  frequency: MONTHLY
+  dayOfMonth: 10
+  activeMonths: [10,11,12,1,2,3,4]  # X-IV
+  type: OUTFLOW
+```
+
+#### Story 8: Rata kredytu - 24 miesiące
+
+```yaml
+User: "Rata kredytu 500 PLN miesięcznie przez 24 miesiące od marca 2026"
+
+Rule:
+  name: "Rata kredytu - samochód"
+  amount: 500 PLN
+  category: "Kredyty"
+  frequency: MONTHLY
+  dayOfMonth: 20
+  startDate: 2026-03-20
+  maxOccurrences: 24  # po 24 ratach kończymy
+  type: OUTFLOW
+
+Generated:
+  - 2026-03-20 (1/24)
+  - 2026-04-20 (2/24)
+  ...
+  - 2028-02-20 (24/24)
+  (STOP - rule auto-ends)
+```
+
+#### Story 9: Ostatni dzień miesiąca
+
+```yaml
+User: "Rachunek za telefon ostatniego dnia miesiąca"
+
+Rule:
+  name: "Telefon"
+  amount: 79 PLN
+  category: "Media"
+  frequency: MONTHLY
+  dayOfMonth: -1  # special: last day of month
+  type: OUTFLOW
+
+Generated:
+  - 2026-03-31 (marzec ma 31 dni)
+  - 2026-04-30 (kwiecień ma 30 dni)
+  - 2026-05-31 (maj ma 31 dni)
+```
+
+#### Story 10: Exclude specific dates
+
+```yaml
+User: "Spłata karty co 10-tego, ALE w maju 2026 przeniesiona na 15-tego"
+
+Rule:
+  name: "Spłata karty kredytowej"
+  amount: 1500 PLN
+  category: "Karty kredytowe"
+  frequency: MONTHLY
+  dayOfMonth: 10
+  excludedDates: ["2026-05-10"]  # skip this date
+  type: OUTFLOW
+
+Manual fix:
+  - User edytuje lub tworzy jednorazową transakcję na 2026-05-15
+```
+
+---
+
+### 5.3 Przykłady BUSINESS (firmy)
+
+#### Story 11: Wynagrodzenia - 5 pracowników
+
+```yaml
+Firma: "Wypłata pensji 5 pracowników, łącznie 25000 PLN, ostatni dzień miesiąca"
+
+Rule:
+  name: "Wynagrodzenia pracowników"
+  amount: 25000 PLN
+  category: "Koszty osobowe / Wynagrodzenia"
+  frequency: MONTHLY
+  dayOfMonth: -1  # last day
+  type: OUTFLOW
+  notes: "5 osób: A(5k), B(5k), C(6k), D(4.5k), E(4.5k)"
+
+Future: Split rule:
+  - A: 5000 PLN (subcategory: Pracownik A)
+  - B: 5000 PLN (subcategory: Pracownik B)
+  - ...
+```
+
+#### Story 12: VAT kwartalny
+
+```yaml
+Firma: "VAT co kwartał, 25-tego pierwszego miesiąca kwartału"
+
+Rule:
+  name: "VAT - kwartalny"
+  amount: 0 PLN  # estimate unknown
+  amountIsEstimate: true
+  category: "Podatki / VAT"
+  frequency: QUARTERLY
+  quarterMonth: 1  # pierwszy miesiąc kwartału (sty, kwi, lip, paź)
+  dayOfMonth: 25
+  type: OUTFLOW
+
+Generated:
+  - 2026-01-25 (Q1)
+  - 2026-04-25 (Q2)
+  - 2026-07-25 (Q3)
+  - 2026-10-25 (Q4)
+```
+
+#### Story 13: ZUS - różne składki
+
+```yaml
+Firma: "ZUS różne składki co miesiąc 10-tego"
+
+Rules (multiple):
+  1. ZUS - ubezpieczenie społeczne (1200 PLN)
+  2. ZUS - ubezpieczenie zdrowotne (450 PLN)
+  3. ZUS - FP + FGŚP (100 PLN)
+
+All:
+  dayOfMonth: 10
+  frequency: MONTHLY
+  category: "Koszty osobowe / ZUS"
+```
+
+#### Story 14: Leasing - 36 miesięcy z balonem
+
+```yaml
+Firma: "Leasing samochodu 2500 PLN/msc przez 36 msc + balon 50000 PLN na końcu"
+
+Rule 1 (raty):
+  name: "Leasing - Mercedes Sprinter"
+  amount: 2500 PLN
+  frequency: MONTHLY
+  dayOfMonth: 5
+  startDate: 2026-03-05
+  maxOccurrences: 36
+  category: "Środki trwałe / Leasing"
+
+Rule 2 (balon):
+  name: "Wykup - Mercedes Sprinter"
+  amount: 50000 PLN
+  frequency: ONCE  # jednorazowe
+  dueDate: 2029-03-05  # po 36 miesiącach
+  category: "Środki trwałe / Wykup"
+```
+
+#### Story 15: Abonament office365 - rosnąca liczba licencji
+
+```yaml
+Firma: "Office365 - zaczyna 5 licencji (150 PLN), później więcej"
+
+Rule (initial):
+  name: "Office365"
+  amount: 150 PLN
+  frequency: MONTHLY
+  dayOfMonth: 1
+  category: "IT / Oprogramowanie"
+
+User action gdy zmiana:
+  - Edytuj rule → "tylko przyszłe"
+  - Kwota: 150 → 210 PLN (7 licencji)
+  - System generuje nowe ExpectedCashChanges z nową kwotą
+```
+
+---
+
+## 6. Model domenowy
+
+### 6.1 RecurringRule Aggregate
+
+```java
+public class RecurringRule {
+    // Identity
+    private RecurringRuleId id;
+    private CashFlowId cashFlowId;
+    private UserId userId;  // owner
+
+    // Basic info
+    private RuleName name;
+    private Description description;
+    private Money amount;
+    private Boolean amountIsEstimate;  // true = fuzzy matching
+    private Type type;  // INFLOW / OUTFLOW
+    private CategoryName categoryName;
+
+    // Recurrence configuration
+    private RecurrencePattern pattern;
+
+    // Validity period
+    private LocalDate startDate;
+    private LocalDate endDate;  // optional
+    private Integer maxOccurrences;  // optional (e.g., 24 for loan)
+
+    // Seasonal / exclusions
+    private List<Month> activeMonths;  // [1..12], empty = all
+    private List<LocalDate> excludedDates;  // specific dates to skip
+
+    // Matching hints (for future reconciliation)
+    private CounterpartyName counterpartyName;  // optional
+    private CounterpartyAccount counterpartyAccount;  // optional
+    private MoneyTolerance amountTolerance;  // ±50 PLN
+    private Integer dateTolerance;  // ±5 days
+
+    // Metadata
+    private RuleStatus status;  // ACTIVE, PAUSED, ENDED
+    private Integer generatedCount;  // ile już wygenerowano
+    private YearMonth lastGeneratedPeriod;  // do którego miesiąca
+    private ZonedDateTime createdAt;
+    private ZonedDateTime lastModifiedAt;
+    private String notes;  // user notes
+}
+```
+
+### 6.2 RecurrencePattern Value Object
+
+```java
+public sealed interface RecurrencePattern {
+
+    record Monthly(
+        int dayOfMonth,  // 1-28, or -1 for last day
+        Integer interval  // null=every month, 2=every 2 months, etc.
+    ) implements RecurrencePattern {}
+
+    record Weekly(
+        DayOfWeek dayOfWeek,
+        Integer interval  // 1=weekly, 2=bi-weekly, etc.
+    ) implements RecurrencePattern {}
+
+    record Yearly(
+        int dayOfMonth,  // 1-28
+        Month monthOfYear  // JANUARY, FEBRUARY, etc.
+    ) implements RecurrencePattern {}
+
+    record Quarterly(
+        int dayOfMonth,  // 1-28
+        int quarterMonth  // 1, 2, or 3 (first/mid/last month of quarter)
+    ) implements RecurrencePattern {}
+
+    record EveryNDays(
+        int interval,  // 14 for every 2 weeks
+        DayOfWeek constrainToDayOfWeek  // optional: only Fridays
+    ) implements RecurrencePattern {}
+
+    record Once(
+        LocalDate dueDate  // jednorazowa transakcja
+    ) implements RecurrencePattern {}
+}
+```
+
+### 6.3 RecurringRule Events
+
+```java
+public sealed interface RecurringRuleEvent {
+
+    record RecurringRuleCreatedEvent(
+        RecurringRuleId ruleId,
+        CashFlowId cashFlowId,
+        RuleName name,
+        RecurrencePattern pattern,
+        Money amount,
+        CategoryName category,
+        // ... all fields
+        ZonedDateTime createdAt
+    ) implements RecurringRuleEvent {}
+
+    record RecurringRuleUpdatedEvent(
+        RecurringRuleId ruleId,
+        UpdateMode updateMode,  // FUTURE_ONLY, ALL_UNMATCHED
+        // changed fields
+        ZonedDateTime updatedAt
+    ) implements RecurringRuleEvent {}
+
+    record RecurringRulePausedEvent(
+        RecurringRuleId ruleId,
+        ZonedDateTime pausedAt
+    ) implements RecurringRuleEvent {}
+
+    record RecurringRuleResumedEvent(
+        RecurringRuleId ruleId,
+        ZonedDateTime resumedAt
+    ) implements RecurringRuleEvent {}
+
+    record RecurringRuleEndedEvent(
+        RecurringRuleId ruleId,
+        EndReason reason,  // MAX_OCCURRENCES_REACHED, END_DATE_REACHED, MANUAL
+        ZonedDateTime endedAt
+    ) implements RecurringRuleEvent {}
+
+    record ExpectedCashChangesGeneratedEvent(
+        RecurringRuleId ruleId,
+        List<CashChangeId> generatedIds,
+        YearMonth generatedUpTo,
+        ZonedDateTime generatedAt
+    ) implements RecurringRuleEvent {}
+}
+```
+
+---
+
+## 7. Stany i przejścia
+
+### 7.1 Status RecurringRule
+
+```mermaid
+stateDiagram-v2
+    [*] --> ACTIVE: create
+    ACTIVE --> PAUSED: pause
+    PAUSED --> ACTIVE: resume
+    ACTIVE --> ENDED: end (manual/auto)
+    PAUSED --> ENDED: end
+    ENDED --> [*]
+```
+
+| Status | Opis | Generuje ExpectedCashChanges? |
+|--------|------|-------------------------------|
+| `ACTIVE` | Reguła aktywna | ✅ TAK |
+| `PAUSED` | Tymczasowo zatrzymana | ❌ NIE |
+| `ENDED` | Zakończona (max occurrences, end date, manual) | ❌ NIE |
+
+### 7.2 Przejścia stanów
+
+#### ACTIVE → PAUSED
+
+```
+User action: "Pause rule"
+
+Effect:
+  - Status = PAUSED
+  - Nie generuj nowych ExpectedCashChanges podczas month rollover
+  - Istniejące ExpectedCashChanges (EXPECTED) pozostają (user może je usunąć ręcznie)
+
+Use case: "Zawieszona wypłata przez 3 miesiące (urlop bezpłatny)"
+```
+
+#### PAUSED → ACTIVE
+
+```
+User action: "Resume rule"
+
+Effect:
+  - Status = ACTIVE
+  - Wznów generowanie od activePeriod do horyzontu
+  - Pytanie: "Czy wygenerować za minione miesiące od pause?"
+    → NO: generuj od dziś
+    → YES: generuj za cały okres (może być opóźnienie)
+```
+
+#### ACTIVE/PAUSED → ENDED
+
+**Trigger 1: Manual**
+```
+User action: "End rule"
+Status → ENDED
+Reason: MANUAL
+```
+
+**Trigger 2: maxOccurrences reached**
+```
+System detects: generatedCount >= maxOccurrences
+Status → ENDED
+Reason: MAX_OCCURRENCES_REACHED
+
+Example: Loan paid off (24/24 installments)
+```
+
+**Trigger 3: endDate reached**
+```
+System detects: current date > endDate
+Status → ENDED
+Reason: END_DATE_REACHED
+
+Example: Fixed-term subscription expired
+```
+
+---
+
+## 8. UI Design - od początku do końca
+
+### 8.1 List View - Dashboard
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Recurring Rules                                    [+ New Rule]│
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│ 🟢 ACTIVE (5 rules)                                          │
+│                                                               │
+│ ┌────────────────────────────────────────────────┐           │
+│ │ Czynsz                               2000 PLN  │ [Edit] [⋮]│
+│ │ Every month on 10th                            │           │
+│ │ Category: Mieszkanie                           │           │
+│ │ Next: Mar 10, 2026 · Generated: 12 upcoming    │           │
+│ └────────────────────────────────────────────────┘           │
+│                                                               │
+│ ┌────────────────────────────────────────────────┐           │
+│ │ Netflix                                 29 PLN │ [Edit] [⋮]│
+│ │ Every month on 15th                            │           │
+│ │ Category: Rozrywka / Streaming                 │           │
+│ │ Next: Mar 15, 2026 · Generated: 12 upcoming    │           │
+│ └────────────────────────────────────────────────┘           │
+│                                                               │
+│ ⏸️ PAUSED (1 rule)                                           │
+│                                                               │
+│ ┌────────────────────────────────────────────────┐           │
+│ │ Gym Membership                          150 PLN│ [Resume]  │
+│ │ Every month on 1st                             │           │
+│ │ Paused since: Jan 15, 2026                     │           │
+│ └────────────────────────────────────────────────┘           │
+│                                                               │
+│ ✅ ENDED (2 rules) [Show]                                    │
+│                                                               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Actions menu [⋮]:**
+- Edit rule
+- Pause rule
+- View generated transactions
+- Duplicate rule
+- Delete rule
+
+---
+
+### 8.2 Create Rule - Step-by-step Wizard
+
+#### Step 1: Basic Info
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Create Recurring Rule                                  [1/3] │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│ Rule Name *                                                   │
+│ ┌───────────────────────────────────────────────────────┐   │
+│ │ Czynsz                                                 │   │
+│ └───────────────────────────────────────────────────────┘   │
+│                                                               │
+│ Description (optional)                                        │
+│ ┌───────────────────────────────────────────────────────┐   │
+│ │ Opłata za mieszkanie przy ul. Kwiatowej 5             │   │
+│ └───────────────────────────────────────────────────────┘   │
+│                                                               │
+│ Amount *                                                      │
+│ ┌──────────┐ ┌──────────────────────────────────────┐       │
+│ │ 2000     │ │ PLN ▼                                 │       │
+│ └──────────┘ └──────────────────────────────────────┘       │
+│ ☐ This is an estimate (amount may vary)                      │
+│                                                               │
+│ Type *                                                        │
+│ ◉ Outflow (expense)                                           │
+│ ○ Inflow (income)                                             │
+│                                                               │
+│ Category *                                                    │
+│ ┌───────────────────────────────────────────────────────┐   │
+│ │ Mieszkanie                                          ▼ │   │
+│ └───────────────────────────────────────────────────────┘   │
+│                                                               │
+│                                     [Cancel]  [Next: Timing →]│
+└──────────────────────────────────────────────────────────────┘
+```
+
+#### Step 2: Timing & Frequency
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Create Recurring Rule                                  [2/3] │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│ Frequency *                                                   │
+│ ┌───────────────────────────────────────────────────────┐   │
+│ │ ◉ Monthly                                             │   │
+│ │ ○ Weekly                                              │   │
+│ │ ○ Every N days                                        │   │
+│ │ ○ Yearly                                              │   │
+│ │ ○ Quarterly                                           │   │
+│ │ ○ Once (single transaction)                           │   │
+│ └───────────────────────────────────────────────────────┘   │
+│                                                               │
+│ ↓ Monthly Options                                             │
+│                                                               │
+│ Day of month *                                                │
+│ ◉ Specific day: ┌──┐                                         │
+│                  │10│                                         │
+│                  └──┘                                         │
+│ ○ Last day of month                                           │
+│                                                               │
+│ Repeat every:                                                 │
+│ ┌──┐ month(s)    (1 = every month, 2 = every other month)   │
+│ │ 1│                                                          │
+│ └──┘                                                          │
+│                                                               │
+│ Start date *                                                  │
+│ ┌───────────────┐                                            │
+│ │ Mar 10, 2026  │ 📅                                         │
+│ └───────────────┘                                            │
+│                                                               │
+│ End condition                                                 │
+│ ◉ No end date                                                 │
+│ ○ End after ┌──┐ occurrences                                 │
+│             └──┘                                              │
+│ ○ End on specific date ┌───────────────┐                     │
+│                         │               │ 📅                 │
+│                         └───────────────┘                     │
+│                                                               │
+│                                [← Back]  [Next: Advanced →]   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Weekly variant:**
+```
+Day of week: ○ Mon ○ Tue ○ Wed ○ Thu ◉ Fri ○ Sat ○ Sun
+Repeat every: [2] week(s)
+```
+
+**Yearly variant:**
+```
+Month: [January ▼]
+Day: [1]
+```
+
+**Quarterly variant:**
+```
+Day of month: [25]
+Which month: ○ First month (Jan, Apr, Jul, Oct)
+             ◉ Second month (Feb, May, Aug, Nov)
+             ○ Third month (Mar, Jun, Sep, Dec)
+```
+
+#### Step 3: Advanced Options (optional)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Create Recurring Rule                                  [3/3] │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│ Active months (leave empty for all months)                   │
+│ ☐ Jan ☐ Feb ☐ Mar ☐ Apr ☐ May ☐ Jun                        │
+│ ☐ Jul ☐ Aug ☐ Sep ☐ Oct ☐ Nov ☐ Dec                        │
+│                                                               │
+│ Example: Heating only Oct-Apr, Daycare only Sep-Jun          │
+│                                                               │
+│ ─────────────────────────────────────────────────────────────│
+│                                                               │
+│ Exclude specific dates (optional)                            │
+│ ┌───────────────────────────────────────────────────────┐   │
+│ │ [Add date]                                             │   │
+│ │                                                         │   │
+│ │ Mar 10, 2026 [×]  (reason: moved to Mar 15)           │   │
+│ └───────────────────────────────────────────────────────┘   │
+│                                                               │
+│ ─────────────────────────────────────────────────────────────│
+│                                                               │
+│ Matching hints (for future auto-matching with bank)          │
+│                                                               │
+│ Counterparty name (optional)                                 │
+│ ┌───────────────────────────────────────────────────────┐   │
+│ │ ZARZĄDCA NIERUCHOMOŚCI                                 │   │
+│ └───────────────────────────────────────────────────────┘   │
+│                                                               │
+│ Counterparty account (optional)                              │
+│ ┌───────────────────────────────────────────────────────┐   │
+│ │ PL12 3456 7890 1234 5678 9012 3456                    │   │
+│ └───────────────────────────────────────────────────────┘   │
+│                                                               │
+│ Amount tolerance: ± ┌──────┐ PLN                            │
+│                      │  50  │                                │
+│                      └──────┘                                │
+│ Date tolerance: ± ┌──┐ days                                 │
+│                    │ 5│                                      │
+│                    └──┘                                      │
+│                                                               │
+│ ─────────────────────────────────────────────────────────────│
+│                                                               │
+│ Notes (optional)                                              │
+│ ┌───────────────────────────────────────────────────────┐   │
+│ │                                                         │   │
+│ └───────────────────────────────────────────────────────┘   │
+│                                                               │
+│                                [← Back]  [Create Rule]        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Preview before create:**
+```
+✓ Rule will generate 12 upcoming transactions
+  Next 3: Mar 10, Apr 10, May 10
+
+[Create Rule]
+```
+
+---
+
+### 8.3 Edit Rule Dialog
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Edit Rule: Czynsz                                      [×]    │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│ ⚠️ This rule has 12 unmatched expected transactions.         │
+│    How should we apply changes?                              │
+│                                                               │
+│ ◉ Update only future transactions (recommended)              │
+│   Changes apply from next occurrence onwards.                │
+│   Existing transactions remain unchanged.                    │
+│                                                               │
+│ ○ Update ALL unmatched transactions                          │
+│   Changes apply to all 12 existing + future transactions.    │
+│   Use this if rent amount changed retroactively.             │
+│                                                               │
+│ ─────────────────────────────────────────────────────────────│
+│                                                               │
+│ Amount: [2000] → [2100] PLN  (+100 PLN increase)            │
+│                                                               │
+│ [Cancel]                                       [Apply Changes]│
+└──────────────────────────────────────────────────────────────┘
+```
+
+**UpdateMode options:**
+- `FUTURE_ONLY` - tylko przyszłe (od następnego occurrence)
+- `ALL_UNMATCHED` - wszystkie EXPECTED (nie matched/confirmed)
+
+---
+
+### 8.4 Calendar View Integration
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ March 2026                             [Month ▼] [Filters]   │
+├──────────────────────────────────────────────────────────────┤
+│ Mon    Tue    Wed    Thu    Fri    Sat    Sun                │
+│                                     1      2                  │
+│                                                               │
+│ 3      4      5      6      7      8      9                  │
+│                                                               │
+│ 10     11     12     13     14     15     16                 │
+│ ●2000          ●29                                           │
+│ Czynsz         Netflix                                        │
+│ (EXPECTED)     (EXPECTED)                                     │
+│                                                               │
+│ 17     18     19     20     21     22     23                 │
+│                     ●500                                      │
+│                     Loan                                      │
+│                     (12/24)                                   │
+│                                                               │
+│ 24     25     26     27     28     29     30                 │
+│                                                               │
+│ 31                                                            │
+│                                                               │
+└──────────────────────────────────────────────────────────────┘
+
+Legend:
+● = Expected from recurring rule
+✓ = Matched/confirmed
+⚠ = Overdue
+```
+
+---
+
+## 9. REST API
+
+### 9.1 Endpoints
+
+#### Create Recurring Rule
+
+```http
+POST /cash-flow/{cashFlowId}/recurring-rules
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "name": "Czynsz",
+  "description": "Opłata za mieszkanie",
+  "amount": { "amount": 2000.00, "currency": "PLN" },
+  "amountIsEstimate": false,
+  "type": "OUTFLOW",
+  "categoryName": "Mieszkanie",
+
+  "pattern": {
+    "type": "MONTHLY",
+    "dayOfMonth": 10,
+    "interval": 1
+  },
+
+  "startDate": "2026-03-10",
+  "endDate": null,
+  "maxOccurrences": null,
+
+  "activeMonths": [],
+  "excludedDates": [],
+
+  "counterpartyName": "ZARZĄDCA NIERUCHOMOŚCI",
+  "counterpartyAccount": "PL12345678901234567890123456",
+  "amountTolerance": { "amount": 50.00, "currency": "PLN" },
+  "dateTolerance": 5,
+
+  "notes": ""
+}
+
+Response 201 Created:
+{
+  "ruleId": "RR10000001",
+  "status": "ACTIVE",
+  "generatedCount": 12,
+  "lastGeneratedPeriod": "2027-02",
+  "createdAt": "2026-02-14T10:00:00Z"
+}
+```
+
+#### List Recurring Rules
+
+```http
+GET /cash-flow/{cashFlowId}/recurring-rules
+Authorization: Bearer {token}
+
+Query params:
+  ?status=ACTIVE,PAUSED
+  ?type=OUTFLOW
+  ?categoryName=Mieszkanie
+
+Response 200 OK:
+{
+  "rules": [
+    {
+      "ruleId": "RR10000001",
+      "name": "Czynsz",
+      "amount": { "amount": 2000.00, "currency": "PLN" },
+      "type": "OUTFLOW",
+      "categoryName": "Mieszkanie",
+      "pattern": { "type": "MONTHLY", "dayOfMonth": 10 },
+      "status": "ACTIVE",
+      "nextOccurrence": "2026-03-10",
+      "generatedCount": 12,
+      "createdAt": "2026-02-14T10:00:00Z"
+    }
+  ]
+}
+```
+
+#### Get Rule Details
+
+```http
+GET /cash-flow/{cashFlowId}/recurring-rules/{ruleId}
+Authorization: Bearer {token}
+
+Response 200 OK:
+{
+  "ruleId": "RR10000001",
+  // ... all fields including:
+  "generatedTransactions": [
+    {
+      "cashChangeId": "CC10000123",
+      "dueDate": "2026-03-10",
+      "status": "EXPECTED"
+    },
+    {
+      "cashChangeId": "CC10000124",
+      "dueDate": "2026-04-10",
+      "status": "EXPECTED"
+    }
+  ]
+}
+```
+
+#### Update Recurring Rule
+
+```http
+PUT /cash-flow/{cashFlowId}/recurring-rules/{ruleId}
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "updateMode": "FUTURE_ONLY",  // or "ALL_UNMATCHED"
+  "amount": { "amount": 2100.00, "currency": "PLN" },
+  "categoryName": "Mieszkanie / Czynsz"
+}
+
+Response 200 OK:
+{
+  "ruleId": "RR10000001",
+  "updatedFields": ["amount", "categoryName"],
+  "affectedTransactionsCount": 12,
+  "updatedAt": "2026-02-14T11:00:00Z"
+}
+```
+
+#### Pause Rule
+
+```http
+POST /cash-flow/{cashFlowId}/recurring-rules/{ruleId}/pause
+Authorization: Bearer {token}
+
+Response 200 OK:
+{
+  "ruleId": "RR10000001",
+  "status": "PAUSED",
+  "pausedAt": "2026-02-14T11:30:00Z"
+}
+```
+
+#### Resume Rule
+
+```http
+POST /cash-flow/{cashFlowId}/recurring-rules/{ruleId}/resume
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+  "generateForMissedPeriods": false
+}
+
+Response 200 OK:
+{
+  "ruleId": "RR10000001",
+  "status": "ACTIVE",
+  "resumedAt": "2026-02-14T12:00:00Z",
+  "generatedCount": 8  // if generateForMissedPeriods=true
+}
+```
+
+#### End Rule
+
+```http
+POST /cash-flow/{cashFlowId}/recurring-rules/{ruleId}/end
+Authorization: Bearer {token}
+
+Response 200 OK:
+{
+  "ruleId": "RR10000001",
+  "status": "ENDED",
+  "reason": "MANUAL",
+  "endedAt": "2026-02-14T12:30:00Z"
+}
+```
+
+#### Delete Rule
+
+```http
+DELETE /cash-flow/{cashFlowId}/recurring-rules/{ruleId}
+Authorization: Bearer {token}
+
+Query param:
+  ?deleteGeneratedTransactions=false
+
+Response 204 No Content
+```
+
+**Behavior:**
+- `deleteGeneratedTransactions=true`: usuń regułę + wszystkie EXPECTED wygenerowane z niej
+- `deleteGeneratedTransactions=false`: usuń tylko regułę, EXPECTED pozostają (jako orphaned)
+
+---
+
+### 9.2 Error Responses
+
+```json
+{
+  "errorCode": "RULE_VALIDATION_ERROR",
+  "message": "Start date cannot be in the past",
+  "details": {
+    "field": "startDate",
+    "value": "2026-01-01",
+    "constraint": "must be >= 2026-02-14"
+  }
+}
+```
+
+**Error codes:**
+- `RULE_VALIDATION_ERROR` - walidacja nie powiodła się
+- `OVERLAPPING_RULE_EXISTS` - istnieje reguła dla tej samej kategorii/pattern
+- `RULE_NOT_FOUND` - reguła nie istnieje
+- `RULE_ALREADY_ENDED` - nie można edytować zakończonej reguły
+- `INVALID_UPDATE_MODE` - nieprawidłowy tryb update
+- `GENERATION_FAILED` - błąd podczas generowania transakcji
+
+---
+
+## 10. Baza danych
+
+### 10.1 MongoDB Collection Schema
+
+```javascript
+// Collection: recurring_rules
+{
+  "_id": ObjectId("..."),
+  "ruleId": "RR10000001",
+  "cashFlowId": "CF10000001",
+  "userId": "U10000001",
+
+  "name": "Czynsz",
+  "description": "Opłata za mieszkanie przy ul. Kwiatowej 5",
+  "amount": { "amount": 2000.00, "currency": "PLN" },
+  "amountIsEstimate": false,
+  "type": "OUTFLOW",
+  "categoryName": "Mieszkanie",
+
+  "pattern": {
+    "type": "MONTHLY",
+    "dayOfMonth": 10,
+    "interval": 1,
+    // for other types:
+    // "dayOfWeek": "FRIDAY",
+    // "monthOfYear": 1,
+    // "quarterMonth": 1,
+    // "dueDate": ISODate("2026-12-31")
+  },
+
+  "startDate": ISODate("2026-03-10"),
+  "endDate": null,
+  "maxOccurrences": null,
+
+  "activeMonths": [],  // empty = all months
+  "excludedDates": [],  // ["2026-05-10"]
+
+  "counterpartyName": "ZARZĄDCA NIERUCHOMOŚCI",
+  "counterpartyAccount": "PL12345678901234567890123456",
+  "amountTolerance": { "amount": 50.00, "currency": "PLN" },
+  "dateTolerance": 5,
+
+  "status": "ACTIVE",  // ACTIVE, PAUSED, ENDED
+  "generatedCount": 12,
+  "lastGeneratedPeriod": "2027-02",
+
+  "createdAt": ISODate("2026-02-14T10:00:00Z"),
+  "lastModifiedAt": ISODate("2026-02-14T10:00:00Z"),
+  "endedAt": null,
+  "endReason": null,  // MAX_OCCURRENCES_REACHED, END_DATE_REACHED, MANUAL
+
+  "notes": "",
+
+  "version": 1,  // optimistic locking
+  "deleted": false  // soft delete
+}
+```
+
+### 10.2 Indexes
+
+```javascript
+// Primary lookup
+db.recurring_rules.createIndex({ "ruleId": 1 }, { unique: true })
+
+// By CashFlow
+db.recurring_rules.createIndex({ "cashFlowId": 1, "status": 1 })
+
+// By User
+db.recurring_rules.createIndex({ "userId": 1 })
+
+// Generation scheduler
+db.recurring_rules.createIndex({
+  "status": 1,
+  "lastGeneratedPeriod": 1
+})
+
+// Soft delete
+db.recurring_rules.createIndex({ "deleted": 1 })
+```
+
+### 10.3 Rozszerzenie CashChange
+
+W istniejącej kolekcji `cash_changes` dodajemy nowe pole:
+
+```javascript
+{
+  // ... existing fields
+  "recurringRuleId": "RR10000001",  // optional - link to rule
+  "generatedFromRule": true,  // czy auto-wygenerowane
+  "occurrenceNumber": 12,  // 12/24 (dla maxOccurrences)
+}
+```
+
+---
+
+## 11. Logika biznesowa
+
+### 11.1 Generowanie ExpectedCashChange
+
+**Trigger 1: Utworzenie reguły**
+
+```java
+@Component
+public class RecurringRuleCreatedEventHandler {
+
+    public void handle(RecurringRuleCreatedEvent event) {
+        RecurringRule rule = // reconstruct from event
+
+        // Generate up to forecast horizon (activePeriod + 11 months)
+        YearMonth activePeriod = getActivePeriod(event.cashFlowId());
+        YearMonth horizon = activePeriod.plusMonths(11);
+
+        List<LocalDate> dueDates = calculateOccurrences(
+            rule.getPattern(),
+            rule.getStartDate(),
+            horizon.atEndOfMonth(),
+            rule.getActiveMonths(),
+            rule.getExcludedDates()
+        );
+
+        int count = 0;
+        for (LocalDate dueDate : dueDates) {
+            if (rule.getMaxOccurrences() != null && count >= rule.getMaxOccurrences()) {
+                break;
+            }
+
+            commandGateway.send(new AppendExpectedCashChangeCommand(
+                event.cashFlowId(),
+                event.categoryName(),
+                CashChangeId.generate(),
+                event.name(),
+                event.description(),
+                event.amount(),
+                event.type(),
+                ZonedDateTime.now(clock),
+                dueDate.atStartOfDay(ZoneId.systemDefault())
+            ));
+
+            count++;
+        }
+
+        // Update rule
+        rule.setGeneratedCount(count);
+        rule.setLastGeneratedPeriod(YearMonth.from(dueDates.get(dueDates.size() - 1)));
+        repository.save(rule);
+    }
+}
+```
+
+**Trigger 2: Month Rollover**
+
+```java
+@Component
+public class MonthlyRolloverScheduler {
+
+    @Scheduled(cron = "0 0 2 1 * *")
+    public void performMonthlyRollover() {
+        // ... existing rollover logic
+
+        // NEW: Generate next month for all active rules
+        generateNextMonthFromRules(currentMonth);
+    }
+
+    private void generateNextMonthFromRules(YearMonth newMonth) {
+        List<RecurringRule> activeRules = ruleRepository.findByStatus(RuleStatus.ACTIVE);
+
+        for (RecurringRule rule : activeRules) {
+            // Skip if already generated for this month
+            if (rule.getLastGeneratedPeriod().compareTo(newMonth) >= 0) {
+                continue;
+            }
+
+            // Calculate next 1 month worth of occurrences
+            List<LocalDate> dueDates = calculateOccurrencesForMonth(rule, newMonth);
+
+            for (LocalDate dueDate : dueDates) {
+                generateExpectedCashChange(rule, dueDate);
+            }
+
+            rule.setLastGeneratedPeriod(newMonth);
+
+            // Check if rule should end
+            if (shouldEndRule(rule)) {
+                rule.setStatus(RuleStatus.ENDED);
+                rule.setEndReason(determineEndReason(rule));
+            }
+
+            repository.save(rule);
+        }
+    }
+}
+```
+
+---
+
+### 11.2 Calculation Logic
+
+```java
+public class OccurrenceCalculator {
+
+    public List<LocalDate> calculateOccurrences(
+        RecurrencePattern pattern,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<Month> activeMonths,
+        List<LocalDate> excludedDates
+    ) {
+        return switch (pattern) {
+            case Monthly monthly -> calculateMonthly(monthly, startDate, endDate, activeMonths, excludedDates);
+            case Weekly weekly -> calculateWeekly(weekly, startDate, endDate, activeMonths, excludedDates);
+            case Yearly yearly -> calculateYearly(yearly, startDate, endDate, excludedDates);
+            case Quarterly quarterly -> calculateQuarterly(quarterly, startDate, endDate, excludedDates);
+            case EveryNDays everyNDays -> calculateEveryNDays(everyNDays, startDate, endDate, activeMonths, excludedDates);
+            case Once once -> List.of(once.dueDate());
+        };
+    }
+
+    private List<LocalDate> calculateMonthly(
+        RecurrencePattern.Monthly pattern,
+        LocalDate start,
+        LocalDate end,
+        List<Month> activeMonths,
+        List<LocalDate> excluded
+    ) {
+        List<LocalDate> dates = new ArrayList<>();
+
+        YearMonth current = YearMonth.from(start);
+        YearMonth endMonth = YearMonth.from(end);
+
+        while (!current.isAfter(endMonth)) {
+            // Skip if not in active months
+            if (!activeMonths.isEmpty() && !activeMonths.contains(current.getMonth())) {
+                current = current.plusMonths(pattern.interval() != null ? pattern.interval() : 1);
+                continue;
+            }
+
+            LocalDate occurrence = calculateDayOfMonth(current, pattern.dayOfMonth());
+
+            // Skip if before start or after end
+            if (occurrence.isBefore(start) || occurrence.isAfter(end)) {
+                current = current.plusMonths(pattern.interval() != null ? pattern.interval() : 1);
+                continue;
+            }
+
+            // Skip if excluded
+            if (excluded.contains(occurrence)) {
+                current = current.plusMonths(pattern.interval() != null ? pattern.interval() : 1);
+                continue;
+            }
+
+            dates.add(occurrence);
+
+            current = current.plusMonths(pattern.interval() != null ? pattern.interval() : 1);
+        }
+
+        return dates;
+    }
+
+    private LocalDate calculateDayOfMonth(YearMonth yearMonth, int dayOfMonth) {
+        if (dayOfMonth == -1) {
+            // Last day of month
+            return yearMonth.atEndOfMonth();
+        } else if (dayOfMonth > yearMonth.lengthOfMonth()) {
+            // Day doesn't exist in this month (e.g., 31 in February)
+            // Use last day instead
+            return yearMonth.atEndOfMonth();
+        } else {
+            return yearMonth.atDay(dayOfMonth);
+        }
+    }
+
+    private List<LocalDate> calculateEveryNDays(
+        RecurrencePattern.EveryNDays pattern,
+        LocalDate start,
+        LocalDate end,
+        List<Month> activeMonths,
+        List<LocalDate> excluded
+    ) {
+        List<LocalDate> dates = new ArrayList<>();
+        LocalDate current = start;
+
+        while (!current.isAfter(end)) {
+            // If dayOfWeek constraint, skip if doesn't match
+            if (pattern.constrainToDayOfWeek() != null) {
+                if (current.getDayOfWeek() != pattern.constrainToDayOfWeek()) {
+                    current = current.plusDays(1);
+                    continue;
+                }
+            }
+
+            // Skip if not in active months
+            if (!activeMonths.isEmpty() && !activeMonths.contains(current.getMonth())) {
+                current = current.plusDays(pattern.interval());
+                continue;
+            }
+
+            // Skip if excluded
+            if (excluded.contains(current)) {
+                current = current.plusDays(pattern.interval());
+                continue;
+            }
+
+            dates.add(current);
+            current = current.plusDays(pattern.interval());
+        }
+
+        return dates;
+    }
+
+    // ... similar for Weekly, Yearly, Quarterly
+}
+```
+
+---
+
+### 11.3 Update Logic - FUTURE_ONLY vs ALL_UNMATCHED
+
+```java
+@Component
+public class UpdateRecurringRuleCommandHandler {
+
+    public void handle(UpdateRecurringRuleCommand command) {
+        RecurringRule rule = ruleRepository.findById(command.ruleId())
+            .orElseThrow(() -> new RuleNotFoundException(command.ruleId()));
+
+        if (rule.getStatus() == RuleStatus.ENDED) {
+            throw new RuleAlreadyEndedException(command.ruleId());
+        }
+
+        UpdateMode mode = command.updateMode();
+
+        // Update rule itself
+        rule.update(command);
+        ruleRepository.save(rule);
+
+        // Update generated ExpectedCashChanges
+        if (mode == UpdateMode.FUTURE_ONLY) {
+            updateFutureOnly(rule, command);
+        } else if (mode == UpdateMode.ALL_UNMATCHED) {
+            updateAllUnmatched(rule, command);
+        }
+
+        // Emit event
+        eventEmitter.emit(new RecurringRuleUpdatedEvent(/* ... */));
+    }
+
+    private void updateFutureOnly(RecurringRule rule, UpdateRecurringRuleCommand command) {
+        // Find all EXPECTED with dueDate >= now
+        LocalDate now = LocalDate.now(clock);
+
+        List<CashChange> futureExpected = cashChangeRepository.findByRecurringRuleId(
+            rule.getId(),
+            CashChangeStatus.EXPECTED
+        ).stream()
+         .filter(cc -> LocalDate.from(cc.getDueDate()).isAfter(now) ||
+                       LocalDate.from(cc.getDueDate()).isEqual(now))
+         .toList();
+
+        for (CashChange cc : futureExpected) {
+            cc.setAmount(rule.getAmount());  // if changed
+            cc.setCategoryName(rule.getCategoryName());  // if changed
+            // ... update other fields
+            cashChangeRepository.save(cc);
+        }
+    }
+
+    private void updateAllUnmatched(RecurringRule rule, UpdateRecurringRuleCommand command) {
+        // Find all EXPECTED (regardless of dueDate)
+        List<CashChange> allExpected = cashChangeRepository.findByRecurringRuleId(
+            rule.getId(),
+            CashChangeStatus.EXPECTED
+        );
+
+        for (CashChange cc : allExpected) {
+            cc.setAmount(rule.getAmount());
+            cc.setCategoryName(rule.getCategoryName());
+            // ... update other fields
+            cashChangeRepository.save(cc);
+        }
+    }
+}
+```
+
+---
+
+## 12. Walidacje
+
+### 12.1 Create Rule Validation
+
+```java
+@Component
+public class CreateRecurringRuleValidator {
+
+    public void validate(CreateRecurringRuleCommand command) {
+        // 1. Basic field validation
+        if (command.name() == null || command.name().isBlank()) {
+            throw new ValidationException("name", "Rule name is required");
+        }
+
+        if (command.name().length() > 100) {
+            throw new ValidationException("name", "Rule name max 100 characters");
+        }
+
+        if (command.amount().isNegative()) {
+            throw new ValidationException("amount", "Amount must be positive");
+        }
+
+        // 2. Start date cannot be in the past
+        if (command.startDate().isBefore(LocalDate.now(clock))) {
+            throw new ValidationException("startDate", "Start date cannot be in the past");
+        }
+
+        // 3. End date must be after start date
+        if (command.endDate() != null && command.endDate().isBefore(command.startDate())) {
+            throw new ValidationException("endDate", "End date must be after start date");
+        }
+
+        // 4. MaxOccurrences must be positive
+        if (command.maxOccurrences() != null && command.maxOccurrences() <= 0) {
+            throw new ValidationException("maxOccurrences", "Max occurrences must be positive");
+        }
+
+        // 5. ActiveMonths must be valid (1-12)
+        for (Month month : command.activeMonths()) {
+            if (month.getValue() < 1 || month.getValue() > 12) {
+                throw new ValidationException("activeMonths", "Invalid month: " + month);
+            }
+        }
+
+        // 6. Pattern-specific validation
+        validatePattern(command.pattern());
+
+        // 7. Category must exist
+        if (!categoryExists(command.cashFlowId(), command.categoryName(), command.type())) {
+            throw new ValidationException("categoryName", "Category does not exist: " + command.categoryName());
+        }
+
+        // 8. Check for overlapping rules (optional warning)
+        checkOverlappingRules(command);
+    }
+
+    private void validatePattern(RecurrencePattern pattern) {
+        switch (pattern) {
+            case RecurrencePattern.Monthly monthly -> {
+                if (monthly.dayOfMonth() < 1 || monthly.dayOfMonth() > 28) {
+                    if (monthly.dayOfMonth() != -1) {  // -1 = last day is ok
+                        throw new ValidationException("dayOfMonth", "Day must be 1-28 or -1 (last day)");
+                    }
+                }
+                if (monthly.interval() != null && monthly.interval() < 1) {
+                    throw new ValidationException("interval", "Interval must be >= 1");
+                }
+            }
+            case RecurrencePattern.Weekly weekly -> {
+                if (weekly.dayOfWeek() == null) {
+                    throw new ValidationException("dayOfWeek", "Day of week is required");
+                }
+            }
+            case RecurrencePattern.EveryNDays everyNDays -> {
+                if (everyNDays.interval() < 1) {
+                    throw new ValidationException("interval", "Interval must be >= 1");
+                }
+            }
+            // ... other patterns
+        }
+    }
+
+    private void checkOverlappingRules(CreateRecurringRuleCommand command) {
+        List<RecurringRule> existing = ruleRepository.findByCashFlowIdAndStatus(
+            command.cashFlowId(),
+            RuleStatus.ACTIVE
+        );
+
+        for (RecurringRule rule : existing) {
+            if (rule.getCategoryName().equals(command.categoryName()) &&
+                rule.getPattern().getClass().equals(command.pattern().getClass())) {
+
+                // Similar pattern + same category = potential duplicate
+                logger.warn("Potential overlapping rule detected: {} vs {}",
+                    rule.getName(), command.name());
+                // Could throw or just warn
+            }
+        }
+    }
+}
+```
+
+### 12.2 Generation Validation
+
+```java
+// Before generating ExpectedCashChange, check:
+
+public void validateBeforeGeneration(RecurringRule rule, LocalDate dueDate) {
+    // 1. DueDate must be within allowed range (activePeriod to horizon)
+    YearMonth activePeriod = getActivePeriod(rule.getCashFlowId());
+    YearMonth horizon = activePeriod.plusMonths(11);
+    YearMonth dueDateMonth = YearMonth.from(dueDate);
+
+    if (dueDateMonth.isBefore(activePeriod) || dueDateMonth.isAfter(horizon)) {
+        throw new GenerationValidationException(
+            "DueDate outside allowed range: " + dueDate +
+            " (range: " + activePeriod + " to " + horizon + ")"
+        );
+    }
+
+    // 2. Check for duplicate ExpectedCashChange with same dueDate
+    boolean duplicateExists = cashChangeRepository.existsByRecurringRuleIdAndDueDate(
+        rule.getId(),
+        dueDate.atStartOfDay()
+    );
+
+    if (duplicateExists) {
+        logger.warn("Skipping duplicate generation for rule {} on {}",
+            rule.getId(), dueDate);
+        return;  // skip silently
+    }
+
+    // 3. Category still exists?
+    if (!categoryExists(rule.getCashFlowId(), rule.getCategoryName(), rule.getType())) {
+        throw new GenerationValidationException(
+            "Category no longer exists: " + rule.getCategoryName()
+        );
+    }
+}
+```
+
+---
+
+## 13. Integracja z istniejącym systemem
+
+### 13.1 Rozszerzenie MonthlyRolloverScheduler
+
+```java
+// File: MonthlyRolloverScheduler.java
+
+@Scheduled(cron = "0 0 2 1 * *")
+public void performMonthlyRollover() {
+    // ... existing rollover logic for CashFlows
+
+    // NEW: Generate next month for recurring rules
+    generateRecurringRulesForNewMonth(currentMonth);
+}
+
+private void generateRecurringRulesForNewMonth(YearMonth newMonth) {
+    recurringRuleService.generateForMonth(newMonth);
+}
+```
+
+### 13.2 Rozszerzenie CashFlowDto
+
+```java
+// File: CashFlowDto.java
+
+public record CashFlowDto(
+    // ... existing fields
+
+    // NEW: Recurring rules count
+    int activeRecurringRulesCount,
+    int pausedRecurringRulesCount
+) {}
+```
+
+### 13.3 Rozszerzenie CashChangeSummaryJson
+
+```java
+// File: CashChangeSummaryJson.java
+
+public record CashChangeSummaryJson(
+    // ... existing fields
+
+    // NEW: Link to recurring rule
+    String recurringRuleId,  // optional
+    Boolean generatedFromRule,
+    Integer occurrenceNumber,  // e.g., "12/24" for loans
+    Integer totalOccurrences  // optional
+) {}
+```
+
+### 13.4 Nowy REST Controller
+
+```java
+@RestController
+@RequestMapping("/cash-flow/{cashFlowId}/recurring-rules")
+public class RecurringRuleRestController {
+
+    private final CommandGateway commandGateway;
+    private final QueryGateway queryGateway;
+
+    @PostMapping
+    public ResponseEntity<CreateRuleResponse> createRule(
+        @PathVariable String cashFlowId,
+        @RequestBody CreateRuleRequest request
+    ) {
+        CreateRecurringRuleCommand command = // map from request
+        RecurringRuleId ruleId = commandGateway.send(command);
+
+        return ResponseEntity.status(201).body(
+            new CreateRuleResponse(ruleId, // ...)
+        );
+    }
+
+    @GetMapping
+    public List<RecurringRuleDto> listRules(
+        @PathVariable String cashFlowId,
+        @RequestParam(required = false) RuleStatus status
+    ) {
+        return queryGateway.send(new GetRecurringRulesQuery(cashFlowId, status));
+    }
+
+    // ... other endpoints
+}
+```
+
+---
+
+## 14. Plan implementacji
+
+### Phase 1: Core Domain (2 tygodnie)
+
+**PR#1: Domain model + events**
+- [ ] `RecurringRule` aggregate
+- [ ] `RecurrencePattern` value objects
+- [ ] `RecurringRuleEvent` sealed interface
+- [ ] Testy jednostkowe aggregatu
+
+**PR#2: Generation logic**
+- [ ] `OccurrenceCalculator` service
+- [ ] Testy dla all pattern types (Monthly, Weekly, etc.)
+- [ ] Edge cases (leap year, last day of month, etc.)
+
+**PR#3: Command handlers**
+- [ ] `CreateRecurringRuleCommandHandler`
+- [ ] `UpdateRecurringRuleCommandHandler`
+- [ ] `PauseRecurringRuleCommandHandler`
+- [ ] `ResumeRecurringRuleCommandHandler`
+- [ ] `EndRecurringRuleCommandHandler`
+- [ ] Walidatory
+
+### Phase 2: Persistence (1 tydzień)
+
+**PR#4: MongoDB integration**
+- [ ] `RecurringRuleEntity`
+- [ ] `RecurringRuleRepository`
+- [ ] Indexes
+- [ ] Migracja istniejących danych (jeśli potrzebna)
+
+**PR#5: Event handlers**
+- [ ] `RecurringRuleCreatedEventHandler` (generowanie ExpectedCashChanges)
+- [ ] `RecurringRuleUpdatedEventHandler` (update existing transactions)
+- [ ] Integracja z Kafka
+
+### Phase 3: Scheduler (3 dni)
+
+**PR#6: Month rollover integration**
+- [ ] Rozszerzenie `MonthlyRolloverScheduler`
+- [ ] Generowanie next month dla active rules
+- [ ] Auto-ending rules (maxOccurrences, endDate)
+- [ ] Testy integracyjne
+
+### Phase 4: REST API (1 tydzień)
+
+**PR#7: REST endpoints**
+- [ ] `RecurringRuleRestController`
+- [ ] DTOs (Request/Response)
+- [ ] Query handlers
+- [ ] OpenAPI documentation
+
+**PR#8: Error handling + validation**
+- [ ] Exception handlers
+- [ ] Validation logic
+- [ ] Error codes
+- [ ] Testy API
+
+### Phase 5: UI Integration (2 tygodnie)
+
+**PR#9: Frontend components** (osobny repo?)
+- [ ] List view
+- [ ] Create wizard (3 steps)
+- [ ] Edit dialog
+- [ ] Calendar integration
+- [ ] Pause/Resume/End actions
+
+### Phase 6: Testing & Polish (1 tydzień)
+
+**PR#10: Integration tests**
+- [ ] E2E scenarios (all user stories)
+- [ ] Performance tests (1000 rules, 10000 transactions)
+- [ ] Edge cases
+- [ ] Documentation update
+
+**TOTAL: ~6 tygodni (1.5 miesiąca)**
+
+---
+
+## 15. Future Features (Phase 4+)
+
+### 15.1 AI Pattern Detection
+
+```
+Analyze imported transactions from last 3-6 months
+Detect recurring patterns:
+  - Same merchant + similar amount + regular frequency
+  - Suggest: "Create rule for Netflix (29 PLN monthly)?"
+
+Use case: Onboarding - pre-populate rules from history
+```
+
+### 15.2 Smart Matching z Bank Transactions
+
+```
+When bank transaction arrives:
+  1. Find candidate EXPECTED (by counterparty account - 98% accuracy)
+  2. Auto-match if score > 85
+  3. Suggest if score 60-85
+  4. Manual if < 60
+
+Integration with Reconciliation component (Phase 5)
+```
+
+### 15.3 Split Rules
+
+```
+One rule → multiple categories
+
+Example: "Grocery shopping 400 PLN"
+  - 70% Food
+  - 20% Household
+  - 10% Pet supplies
+
+Useful for: Complex expenses, business/personal split
+```
+
+### 15.4 Conditional Rules
+
+```
+IF-THEN logic:
+
+"IF electricity bill > 200 PLN THEN alert me"
+"IF salary < 5000 PLN THEN postpone gym payment"
+
+Advanced business logic
+```
+
+### 15.5 Rule Templates Library
+
+```
+Pre-made templates:
+  - "Monthly rent (Poland)"
+  - "Netflix subscription"
+  - "Biweekly payroll (US)"
+  - "Quarterly VAT (EU)"
+
+Import from community/marketplace
+```
+
+### 15.6 Shared Rules (Multi-user)
+
+```
+Family/business scenario:
+  - Shared rent rule (split 50/50)
+  - Shared utilities
+  - Employee sees payroll rule (read-only)
+
+Permission system required
+```
+
+---
+
+## Sources
+
+### Competition Analysis Sources:
+
+**YNAB:**
+- [Scheduled Transactions in YNAB: A Guide](https://support.ynab.com/en_us/scheduled-transactions-a-guide-BygrAIFA9)
+- [How to Use Auto-Assign in YNAB](https://support.ynab.com/en_us/auto-assign-a-guide-r1gBNbBJo)
+
+**Monarch Money:**
+- [Tracking Recurring Expenses and Bills](https://help.monarch.com/hc/en-us/articles/4890751141908-Tracking-Recurring-Expenses-and-Bills)
+- [Creating Transaction Rules](https://help.monarch.com/hc/en-us/articles/360048393372-Creating-Transaction-Rules)
+
+**Copilot Money:**
+- [Creating Recurrings](https://help.copilot.money/en/articles/3760068-creating-recurrings)
+- [Recurrings FAQ](https://help.copilot.money/en/articles/10244751-recurrings-faq)
+- [Separating Business and Personal Spending](https://help.copilot.money/en/articles/10760959-separating-business-and-personal-spending)
+
+---
+
+## Changelog
+
+| Data | Zmiana |
+|------|--------|
+| 2026-02-14 | Initial design - complete specification for MVP |

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.5.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.multi</groupId>
@@ -15,7 +15,7 @@
 	<description>multi portfolio app</description>
 	<properties>
 		<java.version>21</java.version>
-		<testcontainers.version>1.19.7</testcontainers.version>
+		<testcontainers.version>1.20.4</testcontainers.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -75,17 +75,17 @@
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-api</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-impl</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -93,15 +93,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<version>4.0.3</version>
+			<version>4.2.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -124,11 +118,7 @@
 			<version>3.2.7-RELEASE</version>
 		</dependency>
 
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-jsr310</artifactId>
-			<version>2.13.4</version>
-		</dependency>
+		<!-- jackson-datatype-jsr310 is managed by Spring Boot -->
 
 	</dependencies>
 
@@ -167,12 +157,10 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<argLine>--enable-preview</argLine>
-					<!-- Enable parallel test execution -->
-					<parallel>classes</parallel>
-					<threadCount>4</threadCount>
-					<perCoreThreadCount>true</perCoreThreadCount>
+					<!-- Disable parallel test execution for test isolation -->
+					<parallel>none</parallel>
 					<forkCount>1</forkCount>
-					<reuseForks>true</reuseForks>
+					<reuseForks>false</reuseForks>
 				</configuration>
 			</plugin>
             <plugin>

--- a/src/main/java/com/multi/vidulum/security/config/SecurityConfiguration.java
+++ b/src/main/java/com/multi/vidulum/security/config/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package com.multi.vidulum.security.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -23,6 +24,7 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 @EnableWebSecurity
 @RequiredArgsConstructor
 @EnableMethodSecurity
+@ConditionalOnProperty(name = "app.security.enabled", havingValue = "true", matchIfMissing = true)
 public class SecurityConfiguration {
 
     private static final String[] WHITE_LIST_URL = {"/api/v1/auth/**"};

--- a/src/test/java/com/multi/vidulum/AbstractHttpIntegrationTest.java
+++ b/src/test/java/com/multi/vidulum/AbstractHttpIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.multi.vidulum;
+
+import com.multi.vidulum.config.FixedClockConfig;
+import com.multi.vidulum.portfolio.app.PortfolioAppConfig;
+import com.multi.vidulum.trading.app.TradingAppConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.test.utils.ContainerTestUtils;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Abstract base class for HTTP integration tests.
+ *
+ * Provides shared Testcontainers (MongoDB and Kafka) that are started once
+ * and reused across all tests, avoiding the issues with Spring Boot 3.5.2
+ * graceful shutdown and container lifecycle management.
+ *
+ * Usage:
+ * - Extend this class for HTTP integration tests
+ * - Override setUp() method for test-specific initialization
+ * - Use restTemplate and port for HTTP calls
+ */
+@Slf4j
+@SpringBootTest(
+        classes = {FixedClockConfig.class, AbstractHttpIntegrationTest.TestSecurityConfig.class},
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@Import({PortfolioAppConfig.class, TradingAppConfig.class})
+@ActiveProfiles("test")
+public abstract class AbstractHttpIntegrationTest {
+
+    // Shared reusable containers - started once and reused across all tests
+    protected static final MongoDBContainer mongoDBContainer;
+    protected static final KafkaContainer kafka;
+
+    static {
+        // Initialize MongoDB container
+        mongoDBContainer = new MongoDBContainer("mongo:8.0");
+        mongoDBContainer.start();
+
+        // Initialize Kafka container
+        kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.8.1"));
+        kafka.start();
+
+        log.info("Testcontainers started - MongoDB: {}, Kafka: {}",
+                mongoDBContainer.getReplicaSetUrl(), kafka.getBootstrapServers());
+    }
+
+    @TestConfiguration
+    public static class TestSecurityConfig {
+        @Bean
+        @Order(1)
+        public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .securityMatcher("/**")
+                    .authorizeHttpRequests(req -> req.anyRequest().permitAll())
+                    .csrf(AbstractHttpConfigurer::disable);
+            return http.build();
+        }
+    }
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+        registry.add("mongodb.port", mongoDBContainer::getFirstMappedPort);
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+    }
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    protected TestRestTemplate restTemplate;
+
+    @Autowired
+    private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
+
+    protected void waitForKafkaListeners() {
+        kafkaListenerEndpointRegistry.getListenerContainers().forEach(container -> {
+            if (container.isRunning()) {
+                try {
+                    ContainerTestUtils.waitForAssignment(container, 1);
+                } catch (IllegalStateException e) {
+                    log.debug("Skipping partition wait for container: {}", e.getMessage());
+                }
+            }
+        });
+    }
+}

--- a/src/test/java/com/multi/vidulum/LockingAssetsTests.java
+++ b/src/test/java/com/multi/vidulum/LockingAssetsTests.java
@@ -68,7 +68,7 @@ class LockingAssetsTests extends IntegrationTest {
 
         TradingDto.OrderSummaryJson placedOrderSummary1 = placeOrder(
                 TradingDto.PlaceOrderJson.builder()
-                        .originOrderId("origin order-id-Y")
+                        .originOrderId(uniqueOriginOrderId("Y"))
                         .portfolioId(registeredPortfolio.getPortfolioId())
                         .broker(registeredPortfolio.getBroker())
                         .symbol("BTC/USD")
@@ -180,7 +180,7 @@ class LockingAssetsTests extends IntegrationTest {
 
         TradingDto.OrderSummaryJson placedOrderSummary1 = placeOrder(
                 TradingDto.PlaceOrderJson.builder()
-                        .originOrderId("origin order-id-Y")
+                        .originOrderId(uniqueOriginOrderId("Y"))
                         .portfolioId(registeredPortfolio.getPortfolioId())
                         .broker(registeredPortfolio.getBroker())
                         .symbol("BTC/USD")
@@ -347,7 +347,7 @@ class LockingAssetsTests extends IntegrationTest {
 
         TradingDto.OrderSummaryJson placedOrderSummary1 = placeOrder(
                 TradingDto.PlaceOrderJson.builder()
-                        .originOrderId("origin order-id-Y")
+                        .originOrderId(uniqueOriginOrderId("Y"))
                         .portfolioId(registeredPortfolio.getPortfolioId())
                         .broker(registeredPortfolio.getBroker())
                         .symbol("BTC/USD")
@@ -369,7 +369,7 @@ class LockingAssetsTests extends IntegrationTest {
 
         TradingDto.OrderSummaryJson placedOrderSummary2 = placeOrder(
                 TradingDto.PlaceOrderJson.builder()
-                        .originOrderId("origin order-id-Y")
+                        .originOrderId(uniqueOriginOrderId("Y"))
                         .portfolioId(registeredPortfolio.getPortfolioId())
                         .broker(registeredPortfolio.getBroker())
                         .symbol("BTC/USD")

--- a/src/test/java/com/multi/vidulum/VidulumApplicationTests.java
+++ b/src/test/java/com/multi/vidulum/VidulumApplicationTests.java
@@ -320,9 +320,10 @@ class VidulumApplicationTests extends IntegrationTest {
                                 .pctProfit(0)
                                 .build());
 
+        String originOrderId3 = uniqueOriginOrderId("Y");
         TradingDto.OrderSummaryJson placedOrder3 = placeOrder(
                 TradingDto.PlaceOrderJson.builder()
-                        .originOrderId("origin order-id-Y")
+                        .originOrderId(originOrderId3)
                         .portfolioId(registeredPortfolio.getPortfolioId())
                         .symbol("BTC/USD")
                         .type(OrderType.OCO)
@@ -356,7 +357,7 @@ class VidulumApplicationTests extends IntegrationTest {
         assertThat(orderExecutionSummaryJson).isEqualTo(
                 TradingDto.OrderExecutionSummaryJson.builder()
                         .originTradeId("origin trade-id-Y")
-                        .originOrderId("origin order-id-Y")
+                        .originOrderId(originOrderId3)
                         .symbol("BTC/USD")
                         .type(OrderType.OCO)
                         .side(SELL)

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowErrorHandlingTest.java
@@ -1,34 +1,13 @@
 package com.multi.vidulum.cashflow.app;
 
+import com.multi.vidulum.AbstractHttpIntegrationTest;
 import com.multi.vidulum.cashflow.domain.Type;
 import com.multi.vidulum.common.Money;
 import com.multi.vidulum.common.error.ApiError;
-import com.multi.vidulum.config.FixedClockConfig;
-import com.multi.vidulum.portfolio.app.PortfolioAppConfig;
-import com.multi.vidulum.trading.app.TradingAppConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import com.multi.vidulum.TestIds;
 
@@ -48,49 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * New error handling tests should be added to this class in future pull requests.
  */
 @Slf4j
-@SpringBootTest(
-        classes = {FixedClockConfig.class, CashFlowErrorHandlingTest.TestSecurityConfig.class},
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-)
-@Import({PortfolioAppConfig.class, TradingAppConfig.class})
-@Testcontainers
-class CashFlowErrorHandlingTest {
-
-    /**
-     * Test security configuration that disables authentication for HTTP integration tests.
-     */
-    @TestConfiguration
-    static class TestSecurityConfig {
-        @Bean
-        @Order(1)
-        public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
-            http
-                    .securityMatcher("/**")
-                    .authorizeHttpRequests(req -> req.anyRequest().permitAll())
-                    .csrf(AbstractHttpConfigurer::disable);
-            return http.build();
-        }
-    }
-
-    @Container
-    public static KafkaContainer kafka =
-            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.8.1"));
-
-    @Container
-    protected static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8.0");
-
-    @LocalServerPort
-    private int port;
-
-    @DynamicPropertySource
-    static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
-        registry.add("mongodb.port", mongoDBContainer::getFirstMappedPort);
-        registry.add("spring.kafka.bootstrap-servers", () -> kafka.getBootstrapServers());
-    }
-
-    @Autowired
-    private TestRestTemplate restTemplate;
+class CashFlowErrorHandlingTest extends AbstractHttpIntegrationTest {
 
     private CashFlowHttpActor actor;
 

--- a/src/test/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateTest.java
@@ -24,6 +24,13 @@ import static com.multi.vidulum.cashflow.domain.Type.OUTFLOW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+/**
+ * Tests for CashFlow aggregate event sourcing and projection.
+ *
+ * <p>Note: This test class extends IntegrationTest which uses shared Testcontainers
+ * with parallel test execution. Each test uses unique IDs from TestIds (atomic counters)
+ * so no cleanup is needed between tests - each CashFlow has its own unique ID.
+ */
 class CashFlowAggregateTest extends IntegrationTest {
 
     @Autowired

--- a/src/test/java/com/multi/vidulum/security/auth/AuthenticationControllerTest.java
+++ b/src/test/java/com/multi/vidulum/security/auth/AuthenticationControllerTest.java
@@ -1,11 +1,9 @@
 package com.multi.vidulum.security.auth;
 
+import com.multi.vidulum.AbstractHttpIntegrationTest;
 import com.multi.vidulum.common.error.ApiError;
 import com.multi.vidulum.common.error.FieldError;
-import com.multi.vidulum.config.FixedClockConfig;
-import com.multi.vidulum.portfolio.app.PortfolioAppConfig;
 import com.multi.vidulum.security.token.TokenRepository;
-import com.multi.vidulum.trading.app.TradingAppConfig;
 import com.multi.vidulum.user.infrastructure.UserMongoRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,20 +11,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.Map;
 import java.util.UUID;
@@ -34,33 +20,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
-@SpringBootTest(
-        classes = FixedClockConfig.class,
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-)
-@Import({PortfolioAppConfig.class, TradingAppConfig.class})
-@Testcontainers
-class AuthenticationControllerTest {
-
-    @Container
-    public static KafkaContainer kafka =
-            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.8.1"));
-
-    @Container
-    protected static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8.0");
-
-    @LocalServerPort
-    private int port;
-
-    @DynamicPropertySource
-    static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
-        registry.add("mongodb.port", mongoDBContainer::getFirstMappedPort);
-        registry.add("spring.kafka.bootstrap-servers", () -> kafka.getBootstrapServers());
-    }
-
-    @Autowired
-    private TestRestTemplate restTemplate;
+class AuthenticationControllerTest extends AbstractHttpIntegrationTest {
 
     @Autowired
     private UserMongoRepository userMongoRepository;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,26 @@
+# Test-specific configuration for Spring Boot 3.5.2+
+# This helps with graceful shutdown when using Testcontainers
+
+spring:
+  lifecycle:
+    # Reduce the graceful shutdown timeout for tests
+    timeout-per-shutdown-phase: 5s
+  kafka:
+    listener:
+      # Prevent long waits during container shutdown
+      immediate-stop: true
+    consumer:
+      # Reduce poll timeout for faster test teardown
+      properties:
+        max.poll.interval.ms: 10000
+        session.timeout.ms: 10000
+        heartbeat.interval.ms: 3000
+    producer:
+      properties:
+        # Reduce timeouts for faster test teardown
+        delivery.timeout.ms: 10000
+        request.timeout.ms: 5000
+        linger.ms: 0
+
+server:
+  shutdown: graceful


### PR DESCRIPTION
  ## Summary
  - Upgrade Spring Boot from 3.2.4 to 3.5.2
  - Update jjwt library from 0.11.5 to 0.12.6 (required for Spring Boot 3.5+ compatibility)
  - Update Testcontainers from 1.19.7 to 1.20.4
  - Update Awaitility from 4.0.3 to 4.2.2
  - Remove explicit jackson-datatype-jsr310 dependency (now managed by Spring Boot)

