### PR TITLE
VID-125: Fix null-safety issues for Boolean fields in Jackson 3 deserialization

### DIFF
--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
@@ -284,9 +284,11 @@ public final class CashFlowDto {
         @NotNull(message = "confirmedBalance is required")
         private Money confirmedBalance;
         /** If true, attest even if confirmed balance differs from calculated balance */
-        private boolean forceAttestation;
+        @NotNull(message = "forceAttestation is required")
+        private Boolean forceAttestation;
         /** If true and balance differs, create an adjustment transaction to reconcile the difference */
-        private boolean createAdjustment;
+        @NotNull(message = "createAdjustment is required")
+        private Boolean createAdjustment;
     }
 
     /**

--- a/src/main/java/com/multi/vidulum/common/Currency.java
+++ b/src/main/java/com/multi/vidulum/common/Currency.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Currency {
-    private String Id;
+    private String id;
 
     public static Currency of(String id) {
         return new Currency(id);

--- a/src/main/java/com/multi/vidulum/common/Money.java
+++ b/src/main/java/com/multi/vidulum/common/Money.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.common;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,6 +14,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Money {
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER_FLOAT)
     private BigDecimal amount;
     private String currency;
 

--- a/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
+++ b/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
@@ -62,6 +62,7 @@ public class ErrorHttpHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiError> handleJsonParse(HttpMessageNotReadableException ex) {
+        log.error("JSON parse error: {}", ex.getMessage(), ex);
         ApiError error = ApiError.of(ErrorCode.VALIDATION_INVALID_JSON);
         return ResponseEntity.status(error.httpStatus()).body(error);
     }


### PR DESCRIPTION
  ## Summary
  - Fix NullPointerException when deserializing `AttestHistoricalImportJson` with null Boolean fields
  - Add null-safe handling for `forceAttestation` and `createAdjustment` fields in `CashFlowRestController`
  - Fix `Currency.id` field naming convention (was `Id` with uppercase)
  - Add `@JsonFormat` annotation to `Money.amount` for consistent JSON serialization
  - Add error logging for JSON parse exceptions in `ErrorHttpHandler`
  - Fix flaky test `shouldGetForecastStatementWithCashChanges` - wait for all 2 events instead of 1

