### PR TITLE
VID-141: Add last day of month support and auto-complete for recurring rules

### DIFF
--- a/src/main/java/com/multi/vidulum/recurring_rules/app/RecurringRuleService.java
+++ b/src/main/java/com/multi/vidulum/recurring_rules/app/RecurringRuleService.java
@@ -304,6 +304,14 @@ public class RecurringRuleService {
             rule.recordGeneratedCashChanges(generatedIds, fromDate, toDate, clock);
             ruleRepository.save(rule);
             log.info("Generated {} expected cash changes for rule {}", generatedIds.size(), rule.getRuleId().id());
+
+            // Check if rule should auto-complete after reaching maxOccurrences
+            if (rule.shouldAutoComplete()) {
+                rule.complete("Reached maximum occurrences (" + rule.getMaxOccurrences().orElse(0) + ")", clock);
+                ruleRepository.save(rule);
+                log.info("Rule {} auto-completed after reaching {} occurrences",
+                        rule.getRuleId().id(), rule.getMaxOccurrences().orElse(0));
+            }
         }
     }
 

--- a/src/main/java/com/multi/vidulum/recurring_rules/app/dto/RecurringRuleResponse.java
+++ b/src/main/java/com/multi/vidulum/recurring_rules/app/dto/RecurringRuleResponse.java
@@ -35,10 +35,18 @@ public class RecurringRuleResponse {
     private RuleStatus status;
     private PauseInfoDto pauseInfo;
     private List<String> generatedCashChangeIds;
+    private Integer remainingOccurrences;
     private Instant createdAt;
     private Instant lastModifiedAt;
 
     public static RecurringRuleResponse fromSnapshot(RecurringRuleSnapshot snapshot) {
+        // Calculate remaining occurrences if maxOccurrences is set
+        Integer remainingOccurrences = null;
+        if (snapshot.maxOccurrences() != null) {
+            int remaining = snapshot.maxOccurrences() - snapshot.generatedCashChangeIds().size();
+            remainingOccurrences = Math.max(0, remaining);
+        }
+
         return RecurringRuleResponse.builder()
                 .ruleId(snapshot.ruleId().id())
                 .userId(snapshot.userId().getId())
@@ -58,6 +66,7 @@ public class RecurringRuleResponse {
                 .generatedCashChangeIds(snapshot.generatedCashChangeIds().stream()
                         .map(CashChangeId::id)
                         .toList())
+                .remainingOccurrences(remainingOccurrences)
                 .createdAt(snapshot.createdAt())
                 .lastModifiedAt(snapshot.lastModifiedAt())
                 .build();

--- a/src/main/java/com/multi/vidulum/recurring_rules/domain/MonthlyPattern.java
+++ b/src/main/java/com/multi/vidulum/recurring_rules/domain/MonthlyPattern.java
@@ -8,13 +8,27 @@ public record MonthlyPattern(
         boolean adjustForMonthEnd
 ) implements RecurrencePattern {
 
+    /**
+     * Special value for dayOfMonth indicating "last day of month".
+     * When used, the pattern will generate occurrences on the last day of each month
+     * (28, 29, 30, or 31 depending on the month and year).
+     */
+    public static final int LAST_DAY_OF_MONTH = -1;
+
     public MonthlyPattern {
-        if (dayOfMonth < 1 || dayOfMonth > 31) {
-            throw new IllegalArgumentException("Day of month must be between 1 and 31");
+        if (dayOfMonth < LAST_DAY_OF_MONTH || dayOfMonth == 0 || dayOfMonth > 31) {
+            throw new IllegalArgumentException("Day of month must be between 1 and 31, or -1 for last day of month");
         }
         if (intervalMonths < 1 || intervalMonths > 12) {
             throw new IllegalArgumentException("Interval must be between 1 and 12 months");
         }
+    }
+
+    /**
+     * Returns true if this pattern uses the last day of month (-1).
+     */
+    public boolean isLastDayOfMonth() {
+        return dayOfMonth == LAST_DAY_OF_MONTH;
     }
 
     @Override
@@ -24,16 +38,26 @@ public record MonthlyPattern(
 
     @Override
     public LocalDate nextOccurrenceFrom(LocalDate fromDate) {
-        int targetDay = Math.min(dayOfMonth, fromDate.lengthOfMonth());
+        int targetDay;
 
-        if (adjustForMonthEnd && dayOfMonth > fromDate.lengthOfMonth()) {
+        if (isLastDayOfMonth()) {
+            // Use last day of the current month
             targetDay = fromDate.lengthOfMonth();
+        } else {
+            targetDay = Math.min(dayOfMonth, fromDate.lengthOfMonth());
+            if (adjustForMonthEnd && dayOfMonth > fromDate.lengthOfMonth()) {
+                targetDay = fromDate.lengthOfMonth();
+            }
         }
 
         LocalDate candidate = fromDate.withDayOfMonth(targetDay);
         if (candidate.isBefore(fromDate)) {
             candidate = candidate.plusMonths(intervalMonths);
-            targetDay = Math.min(dayOfMonth, candidate.lengthOfMonth());
+            if (isLastDayOfMonth()) {
+                targetDay = candidate.lengthOfMonth();
+            } else {
+                targetDay = Math.min(dayOfMonth, candidate.lengthOfMonth());
+            }
             candidate = candidate.withDayOfMonth(targetDay);
         }
 
@@ -42,12 +66,20 @@ public record MonthlyPattern(
 
     @Override
     public boolean isValidForDate(LocalDate date) {
+        if (isLastDayOfMonth()) {
+            return date.getDayOfMonth() == date.lengthOfMonth();
+        }
         int expectedDay = Math.min(dayOfMonth, date.lengthOfMonth());
         return date.getDayOfMonth() == expectedDay;
     }
 
     @Override
     public String toDisplayString() {
+        if (isLastDayOfMonth()) {
+            return intervalMonths == 1
+                    ? "Monthly on the last day"
+                    : "Every " + intervalMonths + " months on the last day";
+        }
         String daySuffix = getDaySuffix(dayOfMonth);
         return intervalMonths == 1
                 ? "Monthly on the " + dayOfMonth + daySuffix

--- a/src/main/java/com/multi/vidulum/recurring_rules/domain/RecurringRule.java
+++ b/src/main/java/com/multi/vidulum/recurring_rules/domain/RecurringRule.java
@@ -384,10 +384,22 @@ public class RecurringRule implements Aggregate<RecurringRuleId, RecurringRuleSn
 
     /**
      * Checks if the rule should auto-complete based on maxOccurrences.
-     * Returns true if maxOccurrences is set and the execution count has reached the limit.
+     * Returns true if maxOccurrences is set and the generated cash changes count has reached the limit.
      */
     public boolean shouldAutoComplete() {
-        return maxOccurrences != null && executions.size() >= maxOccurrences;
+        return maxOccurrences != null && generatedCashChangeIds.size() >= maxOccurrences;
+    }
+
+    /**
+     * Returns the number of remaining occurrences before auto-complete.
+     * Returns empty if maxOccurrences is not set.
+     */
+    public Optional<Integer> getRemainingOccurrences() {
+        if (maxOccurrences == null) {
+            return Optional.empty();
+        }
+        int remaining = maxOccurrences - generatedCashChangeIds.size();
+        return Optional.of(Math.max(0, remaining));
     }
 
     public boolean isActive() {

--- a/src/test/java/com/multi/vidulum/recurring_rules/app/RecurringRulesHttpActor.java
+++ b/src/test/java/com/multi/vidulum/recurring_rules/app/RecurringRulesHttpActor.java
@@ -132,6 +132,23 @@ public class RecurringRulesHttpActor {
     }
 
     /**
+     * Creates a monthly recurring rule with last day of month (-1).
+     */
+    public String createMonthlyRuleLastDayOfMonth(String cashFlowId, String name, String description,
+                                                   Money baseAmount, String category,
+                                                   LocalDate startDate, LocalDate endDate,
+                                                   int intervalMonths) {
+        PatternDto pattern = PatternDto.builder()
+                .type(RecurrenceType.MONTHLY)
+                .dayOfMonth(-1) // Last day of month
+                .intervalMonths(intervalMonths)
+                .adjustForMonthEnd(false)
+                .build();
+
+        return createRule(cashFlowId, name, description, baseAmount, category, pattern, startDate, endDate);
+    }
+
+    /**
      * Creates a yearly recurring rule.
      */
     public String createYearlyRule(String cashFlowId, String name, String description,

--- a/src/test/java/com/multi/vidulum/recurring_rules/app/RecurringRulesHttpIntegrationTest.java
+++ b/src/test/java/com/multi/vidulum/recurring_rules/app/RecurringRulesHttpIntegrationTest.java
@@ -709,4 +709,280 @@ public class RecurringRulesHttpIntegrationTest extends AuthenticatedHttpIntegrat
 
         log.info("Update advanced options test completed successfully");
     }
+
+    // ==================== LAST DAY OF MONTH TESTS ====================
+
+    @Test
+    void shouldCreateRuleWithLastDayOfMonthAndGenerateCashChangesOnCorrectDates() {
+        // Setup: Create CashFlow with categories
+        YearMonth startPeriod = YearMonth.of(2021, 7);
+        Money initialBalance = Money.of(10000, CURRENCY);
+        String testCashFlowId = cashFlowActor.createCashFlowWithHistory(userId, "Last Day Test", startPeriod, initialBalance);
+
+        await().atMost(60, SECONDS).until(() ->
+                statementRepository.findByCashFlowId(com.multi.vidulum.cashflow.domain.CashFlowId.of(testCashFlowId)).isPresent()
+        );
+
+        cashFlowActor.createCategory(testCashFlowId, "Rent", Type.OUTFLOW);
+        cashFlowActor.attestHistoricalImport(testCashFlowId, initialBalance, false, false);
+
+        // Given: A rule that executes on the last day of each month
+        LocalDate startDate = LocalDate.of(2022, 1, 1);
+        LocalDate endDate = LocalDate.of(2022, 6, 30);
+
+        // When: Create rule with dayOfMonth = -1 (last day)
+        String ruleId = recurringRulesActor.createMonthlyRuleLastDayOfMonth(
+                testCashFlowId,
+                "Monthly Rent",
+                "Rent due on last day of month",
+                Money.of(-1500.00, CURRENCY),
+                "Rent",
+                startDate,
+                endDate,
+                1 // intervalMonths
+        );
+
+        // Then: Rule should be created
+        assertThat(ruleId).isNotNull();
+        log.info("Created last-day-of-month rule: {}", ruleId);
+
+        // And: Verify generated cash changes
+        RecurringRuleResponse rule = recurringRulesActor.getRule(ruleId);
+        assertThat(rule.getStatus()).isEqualTo(RuleStatus.ACTIVE);
+        assertThat(rule.getPattern().getDayOfMonth()).isEqualTo(-1);
+
+        // Should have 6 cash changes (Jan-Jun)
+        assertThat(rule.getGeneratedCashChangeIds()).hasSize(6);
+        log.info("Generated {} cash changes for last-day-of-month rule", rule.getGeneratedCashChangeIds().size());
+
+        // Verify in CashFlow that cash changes exist
+        CashFlowDto.CashFlowSummaryJson cashFlow = cashFlowActor.getCashFlow(testCashFlowId);
+        List<String> generatedIds = rule.getGeneratedCashChangeIds();
+
+        assertThat(generatedIds).allSatisfy(ccId -> {
+            boolean found = cashFlow.getCashChanges().containsKey(ccId);
+            assertThat(found).as("Cash change %s should exist in CashFlow", ccId).isTrue();
+        });
+
+        log.info("Last day of month test completed successfully");
+    }
+
+    @Test
+    void shouldHandleLastDayOfFebruaryCorrectly() {
+        // Setup: Create CashFlow with categories
+        YearMonth startPeriod = YearMonth.of(2021, 7);
+        Money initialBalance = Money.of(10000, CURRENCY);
+        String testCashFlowId = cashFlowActor.createCashFlowWithHistory(userId, "February Test", startPeriod, initialBalance);
+
+        await().atMost(60, SECONDS).until(() ->
+                statementRepository.findByCashFlowId(com.multi.vidulum.cashflow.domain.CashFlowId.of(testCashFlowId)).isPresent()
+        );
+
+        cashFlowActor.createCategory(testCashFlowId, "Utilities", Type.OUTFLOW);
+        cashFlowActor.attestHistoricalImport(testCashFlowId, initialBalance, false, false);
+
+        // Given: A rule starting in February (28 days in non-leap year 2022)
+        LocalDate startDate = LocalDate.of(2022, 2, 1);
+        LocalDate endDate = LocalDate.of(2022, 4, 30);
+
+        // When: Create rule with dayOfMonth = -1
+        String ruleId = recurringRulesActor.createMonthlyRuleLastDayOfMonth(
+                testCashFlowId,
+                "End of Month Payment",
+                "Testing February handling",
+                Money.of(-500.00, CURRENCY),
+                "Utilities",
+                startDate,
+                endDate,
+                1
+        );
+
+        // Then: Should have 3 cash changes (Feb, Mar, Apr)
+        RecurringRuleResponse rule = recurringRulesActor.getRule(ruleId);
+        assertThat(rule.getGeneratedCashChangeIds()).hasSize(3);
+
+        // Verify in CashFlow
+        CashFlowDto.CashFlowSummaryJson cashFlow = cashFlowActor.getCashFlow(testCashFlowId);
+        rule.getGeneratedCashChangeIds().forEach(ccId -> {
+            assertThat(cashFlow.getCashChanges()).containsKey(ccId);
+        });
+
+        log.info("February last day test completed - generated {} cash changes", rule.getGeneratedCashChangeIds().size());
+    }
+
+    // ==================== AUTO-COMPLETE TESTS ====================
+
+    @Test
+    void shouldAutoCompleteRuleWhenMaxOccurrencesReached() {
+        // Setup: Create CashFlow with categories
+        YearMonth startPeriod = YearMonth.of(2021, 7);
+        Money initialBalance = Money.of(10000, CURRENCY);
+        String testCashFlowId = cashFlowActor.createCashFlowWithHistory(userId, "Auto-Complete Test", startPeriod, initialBalance);
+
+        await().atMost(60, SECONDS).until(() ->
+                statementRepository.findByCashFlowId(com.multi.vidulum.cashflow.domain.CashFlowId.of(testCashFlowId)).isPresent()
+        );
+
+        cashFlowActor.createCategory(testCashFlowId, "Subscription", Type.OUTFLOW);
+        cashFlowActor.attestHistoricalImport(testCashFlowId, initialBalance, false, false);
+
+        // Given: A rule with maxOccurrences = 3
+        LocalDate startDate = LocalDate.of(2022, 1, 1);
+
+        // When: Create rule with maxOccurrences = 3
+        String ruleId = recurringRulesActor.createMonthlyRuleWithAdvancedOptions(
+                testCashFlowId,
+                "3-Month Trial",
+                "Trial subscription for 3 months",
+                Money.of(-99.00, CURRENCY),
+                "Subscription",
+                startDate,
+                null, // no end date
+                15,   // dayOfMonth
+                1,    // intervalMonths
+                false,
+                3,    // maxOccurrences = 3
+                null, // no activeMonths filter
+                null  // no excludedDates
+        );
+
+        // Then: Rule should be auto-completed after generating 3 cash changes
+        RecurringRuleResponse rule = recurringRulesActor.getRule(ruleId);
+        assertThat(rule.getGeneratedCashChangeIds()).hasSize(3);
+        assertThat(rule.getStatus()).isEqualTo(RuleStatus.COMPLETED);
+        assertThat(rule.getRemainingOccurrences()).isEqualTo(0);
+
+        log.info("Auto-complete test passed - rule status: {}, generated: {} cash changes",
+                rule.getStatus(), rule.getGeneratedCashChangeIds().size());
+    }
+
+    @Test
+    void shouldNotAutoCompleteWhenBelowMaxOccurrences() {
+        // Setup: Create CashFlow with categories
+        YearMonth startPeriod = YearMonth.of(2021, 7);
+        Money initialBalance = Money.of(10000, CURRENCY);
+        String testCashFlowId = cashFlowActor.createCashFlowWithHistory(userId, "Below Max Test", startPeriod, initialBalance);
+
+        await().atMost(60, SECONDS).until(() ->
+                statementRepository.findByCashFlowId(com.multi.vidulum.cashflow.domain.CashFlowId.of(testCashFlowId)).isPresent()
+        );
+
+        cashFlowActor.createCategory(testCashFlowId, "Subscription", Type.OUTFLOW);
+        cashFlowActor.attestHistoricalImport(testCashFlowId, initialBalance, false, false);
+
+        // Given: A rule with maxOccurrences = 10 but only 3 months in date range
+        LocalDate startDate = LocalDate.of(2022, 1, 1);
+        LocalDate endDate = LocalDate.of(2022, 3, 31);
+
+        // When: Create rule
+        String ruleId = recurringRulesActor.createMonthlyRuleWithAdvancedOptions(
+                testCashFlowId,
+                "Long Subscription",
+                "10-month subscription",
+                Money.of(-50.00, CURRENCY),
+                "Subscription",
+                startDate,
+                endDate,
+                1,    // dayOfMonth
+                1,    // intervalMonths
+                false,
+                10,   // maxOccurrences = 10 (but only 3 months available)
+                null,
+                null
+        );
+
+        // Then: Rule should remain ACTIVE (not completed)
+        RecurringRuleResponse rule = recurringRulesActor.getRule(ruleId);
+        assertThat(rule.getGeneratedCashChangeIds()).hasSize(3);
+        assertThat(rule.getStatus()).isEqualTo(RuleStatus.ACTIVE);
+        assertThat(rule.getRemainingOccurrences()).isEqualTo(7); // 10 - 3 = 7
+
+        log.info("Below max occurrences test passed - status: {}, remaining: {}",
+                rule.getStatus(), rule.getRemainingOccurrences());
+    }
+
+    @Test
+    void shouldShowRemainingOccurrencesInResponse() {
+        // Setup: Create CashFlow with categories
+        YearMonth startPeriod = YearMonth.of(2021, 7);
+        Money initialBalance = Money.of(10000, CURRENCY);
+        String testCashFlowId = cashFlowActor.createCashFlowWithHistory(userId, "Remaining Test", startPeriod, initialBalance);
+
+        await().atMost(60, SECONDS).until(() ->
+                statementRepository.findByCashFlowId(com.multi.vidulum.cashflow.domain.CashFlowId.of(testCashFlowId)).isPresent()
+        );
+
+        cashFlowActor.createCategory(testCashFlowId, "Subscription", Type.OUTFLOW);
+        cashFlowActor.attestHistoricalImport(testCashFlowId, initialBalance, false, false);
+
+        // Given: A rule with maxOccurrences = 6
+        LocalDate startDate = LocalDate.of(2022, 1, 1);
+        LocalDate endDate = LocalDate.of(2022, 3, 31);
+
+        // When: Create rule
+        String ruleId = recurringRulesActor.createMonthlyRuleWithAdvancedOptions(
+                testCashFlowId,
+                "6-Month Plan",
+                "Limited plan",
+                Money.of(-100.00, CURRENCY),
+                "Subscription",
+                startDate,
+                endDate,
+                15,
+                1,
+                false,
+                6,    // maxOccurrences = 6
+                null,
+                null
+        );
+
+        // Then: Should show correct remaining occurrences
+        RecurringRuleResponse rule = recurringRulesActor.getRule(ruleId);
+        assertThat(rule.getMaxOccurrences()).isEqualTo(6);
+        assertThat(rule.getGeneratedCashChangeIds()).hasSize(3);
+        assertThat(rule.getRemainingOccurrences()).isEqualTo(3); // 6 - 3 = 3
+
+        log.info("Remaining occurrences test passed - max: {}, generated: {}, remaining: {}",
+                rule.getMaxOccurrences(), rule.getGeneratedCashChangeIds().size(), rule.getRemainingOccurrences());
+    }
+
+    @Test
+    void shouldShowNullRemainingOccurrencesWhenNoMaxSet() {
+        // Setup: Create CashFlow with categories
+        YearMonth startPeriod = YearMonth.of(2021, 7);
+        Money initialBalance = Money.of(10000, CURRENCY);
+        String testCashFlowId = cashFlowActor.createCashFlowWithHistory(userId, "Null Remaining Test", startPeriod, initialBalance);
+
+        await().atMost(60, SECONDS).until(() ->
+                statementRepository.findByCashFlowId(com.multi.vidulum.cashflow.domain.CashFlowId.of(testCashFlowId)).isPresent()
+        );
+
+        cashFlowActor.createCategory(testCashFlowId, "Subscription", Type.OUTFLOW);
+        cashFlowActor.attestHistoricalImport(testCashFlowId, initialBalance, false, false);
+
+        // Given: A rule without maxOccurrences
+        LocalDate startDate = LocalDate.of(2022, 1, 1);
+        LocalDate endDate = LocalDate.of(2022, 3, 31);
+
+        // When: Create rule without maxOccurrences
+        String ruleId = recurringRulesActor.createMonthlyRule(
+                testCashFlowId,
+                "Unlimited Plan",
+                "No limit",
+                Money.of(-100.00, CURRENCY),
+                "Subscription",
+                startDate,
+                endDate,
+                15,
+                1,
+                false
+        );
+
+        // Then: remainingOccurrences should be null
+        RecurringRuleResponse rule = recurringRulesActor.getRule(ruleId);
+        assertThat(rule.getMaxOccurrences()).isNull();
+        assertThat(rule.getRemainingOccurrences()).isNull();
+
+        log.info("Null remaining occurrences test passed");
+    }
 }


### PR DESCRIPTION
  ## Summary
  - Add `dayOfMonth = -1` support in MonthlyPattern for scheduling on the last day of each month
  - Implement automatic rule completion when `maxOccurrences` limit is reached
  - Add `remainingOccurrences` field to API response

