### PR TITLE
VID-147: Add Move Category API for reorganizing category hierarchy

### DIFF
--- a/docs/FEATURES_BACKLOG_DETAILED.md
+++ b/docs/FEATURES_BACKLOG_DETAILED.md
@@ -9,6 +9,9 @@ Ten dokument zawiera szczegółowy opis wszystkich niezaimplementowanych funkcji
 **🔴 START HERE TOMORROW:**
 0. [🔴 HIGH: Dashboard & Upcoming Transactions (VID-150)](#0--high-dashboard--upcoming-transactions-vid-150)
 
+**🟡 UI Integration (Category Management):**
+0.1. [🟡 MEDIUM: Category Ordering Support (VID-151)](#01--medium-category-ordering-support-vid-151)
+
 **Existing items:**
 1. [✅ DONE: Integration Tests with JWT Authentication](#1--done-integration-tests-with-jwt-authentication)
 2. [✅ DONE: Month Rollover & Ongoing Sync](#2--done-month-rollover--ongoing-sync)
@@ -177,6 +180,44 @@ RecurringRulesHttpIntegrationTest.java - dodać testy
 ### Powiązane pliki mockup
 
 - `docs/design/recurring-rules-web-mockups-en.html` - Screen 11 (Dashboard)
+
+---
+
+## 0.1. 🟡 MEDIUM: Category Ordering Support (VID-151)
+
+**Plik:** `docs/features-backlog/VID-151-category-ordering-support.md`
+**Priorytet:** 🟡 MEDIUM - UI Enhancement Request
+**Szacowany czas:** 3-4 godziny
+**Status:** TODO
+**Zależności:** VID-144 (Move Category) - DONE
+
+### Problem
+
+Aktualny endpoint `POST /cash-flow/cf={cashFlowId}/category/move` pozwala przenieść kategorię do innego rodzica, ale nie wspiera określenia pozycji wśród "rodzeństwa". Gdy użytkownik robi drag-and-drop, oczekuje że kategoria pojawi się dokładnie tam gdzie ją upuścił.
+
+### Rozwiązanie
+
+Rozszerzyć endpoint o opcjonalne pole `position`:
+
+```json
+{
+  "categoryName": "Groceries",
+  "categoryType": "OUTFLOW",
+  "newParentCategoryName": "Food",
+  "position": 0
+}
+```
+
+### Kluczowe zmiany
+
+1. **DTO** - dodać `@Min(0) Integer position`
+2. **Command/Event** - dodać pole `position`
+3. **Handler** - logika wstawiania na pozycję w LinkedList
+4. **Walidacja** - zmodyfikować `CATEGORY_MOVE_TO_SAME_PARENT` (pozwolić na reorder)
+
+### Uwaga
+
+Feature jest **nice-to-have**. UI może tymczasowo sortować alfabetycznie po stronie klienta.
 
 ---
 

--- a/docs/features-backlog/VID-151-category-ordering-support.md
+++ b/docs/features-backlog/VID-151-category-ordering-support.md
@@ -1,0 +1,261 @@
+# VID-151: Category Ordering Support
+
+**Priorytet:** 🟡 MEDIUM
+**Szacowany czas:** 3-4 godziny
+**Status:** TODO
+**Zależności:** VID-144 (Move Category) - DONE
+
+---
+
+## Kontekst
+
+Feature request od UI developera - potrzebują wsparcia dla drag-and-drop z zachowaniem kolejności.
+
+---
+
+## Problem
+
+Aktualny endpoint `POST /cash-flow/cf={cashFlowId}/category/move` pozwala przenieść kategorię do innego rodzica, ale **nie wspiera określenia pozycji** wśród "rodzeństwa" (siblings).
+
+### Aktualny Request Body
+```json
+{
+  "categoryName": "ChildCategory",
+  "categoryType": "OUTFLOW",
+  "newParentCategoryName": "NewParent"
+}
+```
+
+### Brakująca funkcjonalność
+Gdy użytkownik przeciąga kategorię w UI, oczekuje że pojawi się ona **dokładnie w miejscu** gdzie ją upuścił, nie tylko pod nowym rodzicem.
+
+---
+
+## Analiza aktualnej implementacji
+
+### Model domenowy (`Category.java`)
+```java
+List<Category> subCategories;  // LinkedList - zachowuje kolejność
+```
+
+**Wniosek:** Model już wspiera kolejność (LinkedList), ale brak API do jej kontrolowania.
+
+### Obecne zachowanie przy move
+- Kategoria jest usuwana ze starej lokalizacji
+- Kategoria jest dodawana do nowej listy (prawdopodobnie `add()` = na koniec)
+- Kolejność nie jest kontrolowana
+
+---
+
+## Proponowane rozwiązania
+
+### Opcja A: Rozszerzenie Move Endpoint (REKOMENDOWANE)
+
+Dodać opcjonalne pole `position`:
+
+```json
+{
+  "categoryName": "ChildCategory",
+  "categoryType": "OUTFLOW",
+  "newParentCategoryName": "NewParent",
+  "position": 2
+}
+```
+
+**Zachowanie:**
+| Przypadek | Działanie |
+|-----------|-----------|
+| `position` pominięte | Dodaj na koniec (obecne zachowanie) |
+| `position` podane | Wstaw na danej pozycji, przesuń pozostałe |
+| `position` > ilość dzieci | Dodaj na koniec |
+| `position` < 0 | Błąd walidacji |
+
+**Zalety:**
+- Jedno wywołanie API per drag-drop
+- Atomowa operacja (zmiana rodzica + pozycji)
+- Proste UI - brak konieczności dwóch wywołań
+
+### Opcja B: Osobny endpoint Reorder
+
+```
+POST /cash-flow/cf={cashFlowId}/category/reorder
+```
+
+```json
+{
+  "parentCategoryName": "ParentCategory",
+  "categoryType": "OUTFLOW",
+  "orderedChildren": ["Child1", "Child2", "Child3"]
+}
+```
+
+**Wady:**
+- Wymaga dwóch wywołań przy move + reorder
+- Większy payload
+- Race conditions przy równoległych edycjach
+
+---
+
+## Przypadki użycia UI
+
+### 1. Reorder w tym samym rodzicu
+Użytkownik przeciąga "Groceries" nad "Utilities" (oba pod "Expenses")
+
+```json
+{
+  "categoryName": "Groceries",
+  "categoryType": "OUTFLOW",
+  "newParentCategoryName": "Expenses",
+  "position": 0
+}
+```
+
+### 2. Move do innego rodzica na określoną pozycję
+Użytkownik przeciąga "Subscriptions" z roota do "Entertainment" jako pierwsze dziecko
+
+```json
+{
+  "categoryName": "Subscriptions",
+  "categoryType": "OUTFLOW",
+  "newParentCategoryName": "Entertainment",
+  "position": 0
+}
+```
+
+### 3. Move do roota na określoną pozycję
+Użytkownik przeciąga "Rent" z "Housing" na poziom główny jako 3. element
+
+```json
+{
+  "categoryName": "Rent",
+  "categoryType": "OUTFLOW",
+  "newParentCategoryName": null,
+  "position": 2
+}
+```
+
+---
+
+## Zmiany w logice błędów
+
+### Obecny błąd do zmodyfikowania:
+`CATEGORY_MOVE_TO_SAME_PARENT` - aktualnie zwracany gdy rodzic się nie zmienia
+
+**Nowe zachowanie:**
+- Jeśli rodzic ten sam **I** pozycja ta sama → błąd (no-op)
+- Jeśli rodzic ten sam **ALE** pozycja inna → dozwolone (reorder)
+
+### Pseudokod walidacji:
+```java
+if (currentParent.equals(newParent)) {
+    if (position == null || currentPosition == position) {
+        throw new CategoryMoveToSameParentException(...);
+    }
+    // else: reorder allowed
+}
+```
+
+---
+
+## Plan implementacji
+
+### 1. Zmiany w DTO (`CashFlowDto.MoveCategoryJson`)
+```java
+@Data
+@Builder
+public static class MoveCategoryJson {
+    @NotBlank
+    private String categoryName;
+    @NotNull
+    private Type categoryType;
+    private String newParentCategoryName;
+    @Min(0)
+    private Integer position;  // NEW - nullable, 0-based
+}
+```
+
+### 2. Zmiany w Command
+```java
+public record MoveCategoryCommand(
+    CashFlowId cashFlowId,
+    CategoryName categoryName,
+    CategoryName newParentCategoryName,
+    Type categoryType,
+    Integer position  // NEW - nullable
+) {}
+```
+
+### 3. Zmiany w Event
+```java
+public record CategoryMovedEvent(
+    CashFlowId cashFlowId,
+    CategoryName categoryName,
+    CategoryName previousParent,
+    CategoryName newParent,
+    Type type,
+    Integer newPosition,  // NEW - nullable
+    ZonedDateTime occurredAt
+) implements CashFlowEvent {}
+```
+
+### 4. Zmiany w Handler (`MoveCategoryCommandHandler`)
+- Dodać logikę wstawiania na pozycję w liście
+- Zmodyfikować walidację `CATEGORY_MOVE_TO_SAME_PARENT`
+
+### 5. Zmiany w Forecast Processor (`CategoryMovedEventHandler`)
+- Obsłużyć nowe pole `position` przy aktualizacji struktury
+
+### 6. Testy
+- `shouldMoveCategoryWithPosition`
+- `shouldReorderCategoryWithinSameParent`
+- `shouldRejectMoveToSamePositionUnderSameParent`
+- `shouldAppendToEndWhenPositionExceedsSiblingCount`
+
+---
+
+## Estymacja
+
+| Zadanie | Czas |
+|---------|------|
+| Zmiany DTO/Command/Event | 30 min |
+| Handler logic | 1h |
+| Walidacja position | 30 min |
+| Forecast processor | 30 min |
+| Testy jednostkowe | 30 min |
+| Testy integracyjne | 1h |
+| **RAZEM** | **4h** |
+
+---
+
+## Alternatywne podejście: displayOrder field
+
+Zamiast manipulować pozycją w liście, można dodać pole `displayOrder: int` do `Category`:
+
+```java
+@Data
+class Category {
+    CategoryName categoryName;
+    int displayOrder;  // NEW
+    List<Category> subCategories;
+    // ...
+}
+```
+
+**Zalety:**
+- Łatwiejsze zapytania (sortowanie po displayOrder)
+- Brak konieczności przesuwania elementów w liście
+
+**Wady:**
+- Wymaga reindeksacji przy każdej zmianie
+- Większa złożoność przy dodawaniu/usuwaniu kategorii
+- Więcej pól w modelu
+
+**Rekomendacja:** Zostać przy manipulacji pozycją w liście (LinkedList) - prostsze i wystarczające dla płytkiej hierarchii (max 1 poziom zagnieżdżenia).
+
+---
+
+## Uwagi końcowe
+
+- Feature jest **nice-to-have**, nie blokuje UI MVP
+- UI może tymczasowo sortować kategorie alfabetycznie po stronie klienta
+- Implementacja może być odłożona do późniejszej iteracji

--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowDto.java
@@ -539,6 +539,27 @@ public final class CashFlowDto {
     }
 
     /**
+     * Request to move a category to a different parent.
+     * <p>
+     * All subcategories of the moved category will move with it, preserving the subtree structure.
+     * Transactions associated with the moved categories remain unchanged.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MoveCategoryJson {
+        /** The name of the category to move */
+        @NotBlank(message = "categoryName is required")
+        private String categoryName;
+        /** The type of the category (INFLOW or OUTFLOW) */
+        @NotNull(message = "categoryType is required")
+        private Type categoryType;
+        /** The new parent category (null or empty to move to root level) */
+        private String newParentCategoryName;
+    }
+
+    /**
      * Response with category details including archiving status.
      */
     @Data

--- a/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/CashFlowRestController.java
@@ -20,6 +20,7 @@ import com.multi.vidulum.cashflow.app.commands.create.CreateCashFlowCommand;
 import com.multi.vidulum.cashflow.app.commands.create.CreateCashFlowWithHistoryCommand;
 import com.multi.vidulum.cashflow.app.commands.edit.EditCashChangeCommand;
 import com.multi.vidulum.cashflow.app.commands.importhistorical.ImportHistoricalCashChangeCommand;
+import com.multi.vidulum.cashflow.app.commands.move.MoveCategoryCommand;
 import com.multi.vidulum.cashflow.app.commands.reject.RejectCashChangeCommand;
 import com.multi.vidulum.cashflow.app.commands.update.BatchUpdateCashChangesCommand;
 import com.multi.vidulum.cashflow.app.commands.update.BatchUpdateResult;
@@ -397,6 +398,42 @@ public class CashFlowRestController {
                 new UnarchiveCategoryCommand(
                         CashFlowId.of(cashFlowId),
                         new CategoryName(request.getCategoryName()),
+                        request.getCategoryType()
+                )
+        );
+    }
+
+    /**
+     * Move a category to a different parent (or to root level).
+     * <p>
+     * All subcategories of the moved category will move with it, preserving the subtree structure.
+     * Transactions associated with the moved categories remain unchanged.
+     * <p>
+     * Validations:
+     * <ul>
+     *   <li>Category must exist</li>
+     *   <li>New parent must exist (if not moving to root)</li>
+     *   <li>Cannot move system categories (e.g., "Uncategorized")</li>
+     *   <li>Cannot create circular dependency (moving to own descendant)</li>
+     *   <li>Cannot move to same parent (no-op)</li>
+     * </ul>
+     *
+     * @param cashFlowId the CashFlow containing the category
+     * @param request    the move request with category name, type, and new parent
+     */
+    @PostMapping("/cf={cashFlowId}/category/move")
+    public void moveCategory(
+            @PathVariable("cashFlowId") String cashFlowId,
+            @Valid @RequestBody CashFlowDto.MoveCategoryJson request) {
+        CategoryName newParent = (request.getNewParentCategoryName() == null || request.getNewParentCategoryName().isBlank())
+                ? CategoryName.NOT_DEFINED
+                : new CategoryName(request.getNewParentCategoryName());
+
+        commandGateway.send(
+                new MoveCategoryCommand(
+                        CashFlowId.of(cashFlowId),
+                        new CategoryName(request.getCategoryName()),
+                        newParent,
                         request.getCategoryType()
                 )
         );

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/move/MoveCategoryCommand.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/move/MoveCategoryCommand.java
@@ -1,0 +1,25 @@
+package com.multi.vidulum.cashflow.app.commands.move;
+
+import com.multi.vidulum.cashflow.domain.CashFlowId;
+import com.multi.vidulum.cashflow.domain.CategoryName;
+import com.multi.vidulum.cashflow.domain.Type;
+import com.multi.vidulum.shared.cqrs.commands.Command;
+
+/**
+ * Command to move a category to a different parent (or to root level).
+ * <p>
+ * All subcategories of the moved category will move with it, preserving the subtree structure.
+ * Transactions associated with the moved categories remain unchanged.
+ *
+ * @param cashFlowId            the CashFlow containing the category
+ * @param categoryName          the name of the category to move
+ * @param newParentCategoryName the new parent category (use NOT_DEFINED to move to root level)
+ * @param categoryType          whether this is an INFLOW or OUTFLOW category
+ */
+public record MoveCategoryCommand(
+        CashFlowId cashFlowId,
+        CategoryName categoryName,
+        CategoryName newParentCategoryName,
+        Type categoryType
+) implements Command {
+}

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/move/MoveCategoryCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/move/MoveCategoryCommandHandler.java
@@ -1,0 +1,171 @@
+package com.multi.vidulum.cashflow.app.commands.move;
+
+import com.multi.vidulum.cashflow.app.commands.archive.CategoryNotFoundException;
+import com.multi.vidulum.cashflow.domain.*;
+import com.multi.vidulum.cashflow.domain.CannotChangeCategoryTypeException;
+import com.multi.vidulum.common.JsonContent;
+import com.multi.vidulum.common.events.CashFlowUnifiedEvent;
+import com.multi.vidulum.shared.cqrs.commands.CommandHandler;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handler for moving a category to a different parent in a CashFlow.
+ * <p>
+ * Performs validation:
+ * <ul>
+ *   <li>Category must exist</li>
+ *   <li>New parent must exist (if not moving to root)</li>
+ *   <li>Cannot move system categories (e.g., "Uncategorized")</li>
+ *   <li>Cannot create circular dependency (moving to own descendant)</li>
+ *   <li>Cannot move to same parent (no-op)</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@AllArgsConstructor
+public class MoveCategoryCommandHandler implements CommandHandler<MoveCategoryCommand, Void> {
+
+    private final DomainCashFlowRepository domainCashFlowRepository;
+    private final CashFlowEventEmitter cashFlowEventEmitter;
+    private final Clock clock;
+
+    @Override
+    public Void handle(MoveCategoryCommand command) {
+        CashFlow cashFlow = domainCashFlowRepository.findById(command.cashFlowId())
+                .orElseThrow(() -> new CashFlowDoesNotExistsException(command.cashFlowId()));
+
+        List<Category> categories = command.categoryType() == Type.INFLOW
+                ? cashFlow.getSnapshot().inflowCategories()
+                : cashFlow.getSnapshot().outflowCategories();
+
+        List<Category> oppositeCategories = command.categoryType() == Type.INFLOW
+                ? cashFlow.getSnapshot().outflowCategories()
+                : cashFlow.getSnapshot().inflowCategories();
+
+        // 1. Find the category to move
+        Category categoryToMove = findCategory(categories, command.categoryName());
+        if (categoryToMove == null) {
+            // Check if category exists in opposite type - if so, throw specific error
+            Category categoryInOppositeType = findCategory(oppositeCategories, command.categoryName());
+            if (categoryInOppositeType != null) {
+                Type actualType = command.categoryType() == Type.INFLOW ? Type.OUTFLOW : Type.INFLOW;
+                throw new CannotChangeCategoryTypeException(command.categoryName(), actualType, command.categoryType());
+            }
+            throw new CategoryNotFoundException(command.categoryName(), command.categoryType());
+        }
+
+        // 2. Check if it's a system category
+        if (categoryToMove.getOrigin() == CategoryOrigin.SYSTEM) {
+            throw new CannotMoveSystemCategoryException(command.categoryName());
+        }
+
+        // 3. Find current parent
+        CategoryName currentParentName = findParentCategoryName(command.categoryName(), categories);
+
+        // 4. Check if moving to same parent (no-op)
+        if (currentParentName.equals(command.newParentCategoryName())) {
+            throw new CategoryMoveToSameParentException(command.categoryName(), command.newParentCategoryName());
+        }
+
+        // 5. Validate new parent exists (if not moving to root)
+        if (command.newParentCategoryName().isDefined()) {
+            Category newParent = findCategory(categories, command.newParentCategoryName());
+            if (newParent == null) {
+                throw new CategoryNotFoundException(command.newParentCategoryName(), command.categoryType());
+            }
+
+            // 6. Check for circular dependency - cannot move to own descendant
+            if (isDescendant(categoryToMove, command.newParentCategoryName())) {
+                throw new CircularCategoryDependencyException(command.categoryName(), command.newParentCategoryName());
+            }
+        }
+
+        // Create and apply event
+        CashFlowEvent.CategoryMovedEvent event = new CashFlowEvent.CategoryMovedEvent(
+                command.cashFlowId(),
+                command.categoryName(),
+                currentParentName,
+                command.newParentCategoryName(),
+                command.categoryType(),
+                ZonedDateTime.now(clock)
+        );
+
+        cashFlow.apply(event);
+
+        domainCashFlowRepository.save(cashFlow);
+
+        cashFlowEventEmitter.emit(
+                CashFlowUnifiedEvent.builder()
+                        .metadata(Map.of("event", CashFlowEvent.CategoryMovedEvent.class.getSimpleName()))
+                        .content(JsonContent.asPrettyJson(event))
+                        .build()
+        );
+
+        log.info("Category [{}] moved from [{}] to [{}] in cashflow [{}]",
+                command.categoryName().name(),
+                currentParentName.isDefined() ? currentParentName.name() : "root",
+                command.newParentCategoryName().isDefined() ? command.newParentCategoryName().name() : "root",
+                command.cashFlowId().id());
+
+        return null;
+    }
+
+    private Category findCategory(List<Category> categories, CategoryName categoryName) {
+        for (Category category : categories) {
+            if (category.getCategoryName().equals(categoryName)) {
+                return category;
+            }
+            Category found = findCategory(category.getSubCategories(), categoryName);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the parent category name of a given category.
+     *
+     * @return CategoryName of the parent, or NOT_DEFINED if at root level
+     */
+    private CategoryName findParentCategoryName(CategoryName target, List<Category> categories) {
+        return findParentRecursive(target, categories, CategoryName.NOT_DEFINED);
+    }
+
+    private CategoryName findParentRecursive(CategoryName target, List<Category> categories, CategoryName currentParent) {
+        for (Category category : categories) {
+            // Check direct children
+            for (Category child : category.getSubCategories()) {
+                if (child.getCategoryName().equals(target)) {
+                    return category.getCategoryName();
+                }
+            }
+
+            // Check if target is this category at root level
+            if (category.getCategoryName().equals(target)) {
+                return currentParent;
+            }
+
+            // Recurse into children
+            CategoryName found = findParentRecursive(target, category.getSubCategories(), category.getCategoryName());
+            if (found != null) {
+                return found;
+            }
+        }
+        return CategoryName.NOT_DEFINED;
+    }
+
+    /**
+     * Checks if potentialDescendant is a descendant of ancestor.
+     */
+    private boolean isDescendant(Category ancestor, CategoryName potentialDescendant) {
+        return findCategory(ancestor.getSubCategories(), potentialDescendant) != null;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow/app/commands/move/MoveCategoryCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow/app/commands/move/MoveCategoryCommandHandler.java
@@ -141,21 +141,21 @@ public class MoveCategoryCommandHandler implements CommandHandler<MoveCategoryCo
 
     private CategoryName findParentRecursive(CategoryName target, List<Category> categories, CategoryName currentParent) {
         for (Category category : categories) {
-            // Check direct children
+            // Check direct children first
             for (Category child : category.getSubCategories()) {
                 if (child.getCategoryName().equals(target)) {
                     return category.getCategoryName();
                 }
             }
 
-            // Check if target is this category at root level
+            // Check if target is this category at current level
             if (category.getCategoryName().equals(target)) {
                 return currentParent;
             }
 
-            // Recurse into children
+            // Recurse into children - only continue if result is defined (found)
             CategoryName found = findParentRecursive(target, category.getSubCategories(), category.getCategoryName());
-            if (found != null) {
+            if (found != null && found.isDefined()) {
                 return found;
             }
         }

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CannotChangeCategoryTypeException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CannotChangeCategoryTypeException.java
@@ -1,0 +1,22 @@
+package com.multi.vidulum.cashflow.domain;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when attempting to move a category between different types (INFLOW <-> OUTFLOW).
+ * Categories cannot change their type once created.
+ */
+@Getter
+public class CannotChangeCategoryTypeException extends RuntimeException {
+    private final CategoryName categoryName;
+    private final Type currentType;
+    private final Type requestedType;
+
+    public CannotChangeCategoryTypeException(CategoryName categoryName, Type currentType, Type requestedType) {
+        super(String.format("Cannot change category type for '%s' from %s to %s. Categories cannot be moved between INFLOW and OUTFLOW.",
+                categoryName.name(), currentType, requestedType));
+        this.categoryName = categoryName;
+        this.currentType = currentType;
+        this.requestedType = requestedType;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CannotMoveSystemCategoryException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CannotMoveSystemCategoryException.java
@@ -1,0 +1,17 @@
+package com.multi.vidulum.cashflow.domain;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when attempting to move a system category (e.g., "Uncategorized").
+ * System categories cannot be moved to maintain application integrity.
+ */
+@Getter
+public class CannotMoveSystemCategoryException extends RuntimeException {
+    private final CategoryName categoryName;
+
+    public CannotMoveSystemCategoryException(CategoryName categoryName) {
+        super("Cannot move system category: " + categoryName.name());
+        this.categoryName = categoryName;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlow.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlow.java
@@ -583,6 +583,85 @@ public class CashFlow implements Aggregate<CashFlowId, CashFlowSnapshot> {
     }
 
     /**
+     * Moves a category to a new parent (or to root level if newParentCategoryName is NOT_DEFINED).
+     * <p>
+     * All subcategories of the moved category move with it, preserving the subtree structure.
+     * Transactions associated with the moved categories remain unchanged.
+     * <p>
+     * Validation (done in command handler):
+     * <ul>
+     *   <li>Category must exist</li>
+     *   <li>New parent must exist (if not moving to root)</li>
+     *   <li>Cannot move system categories (e.g., "Uncategorized")</li>
+     *   <li>Cannot create circular dependency (moving to own descendant)</li>
+     *   <li>Category type must match new parent type (INFLOW/OUTFLOW)</li>
+     * </ul>
+     */
+    public void apply(CashFlowEvent.CategoryMovedEvent event) {
+        List<Category> categories = Type.INFLOW.equals(event.categoryType()) ? inflowCategories : outflowCategories;
+
+        // Find the category to move
+        Category categoryToMove = findCategoryByName(event.categoryName(), categories)
+                .orElseThrow(() -> new CategoryDoesNotExistsException(event.categoryName()));
+
+        // Remove from old parent (or root list)
+        if (event.oldParentCategoryName().isDefined()) {
+            Category oldParent = findCategoryByName(event.oldParentCategoryName(), categories)
+                    .orElseThrow(() -> new CategoryDoesNotExistsException(event.oldParentCategoryName()));
+            oldParent.getSubCategories().removeIf(c -> c.getCategoryName().equals(event.categoryName()));
+        } else {
+            categories.removeIf(c -> c.getCategoryName().equals(event.categoryName()));
+        }
+
+        // Add to new parent (or root list)
+        if (event.newParentCategoryName().isDefined()) {
+            Category newParent = findCategoryByName(event.newParentCategoryName(), categories)
+                    .orElseThrow(() -> new CategoryDoesNotExistsException(event.newParentCategoryName()));
+            newParent.getSubCategories().add(categoryToMove);
+        } else {
+            categories.add(categoryToMove);
+        }
+
+        add(event);
+    }
+
+    /**
+     * Finds the parent category of a given category.
+     *
+     * @param categoryName the name of the category to find parent for
+     * @param categories   the list of root categories to search in
+     * @return Optional containing the parent category name, or NOT_DEFINED if at root level
+     */
+    public CategoryName findParentCategoryName(CategoryName categoryName, List<Category> categories) {
+        return findParentCategoryNameRecursive(categoryName, categories, CategoryName.NOT_DEFINED);
+    }
+
+    private CategoryName findParentCategoryNameRecursive(CategoryName target, List<Category> categories, CategoryName currentParent) {
+        for (Category category : categories) {
+            if (category.getCategoryName().equals(target)) {
+                return currentParent;
+            }
+            CategoryName foundInChildren = findParentCategoryNameRecursive(target, category.getSubCategories(), category.getCategoryName());
+            if (foundInChildren != null) {
+                return foundInChildren;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a category is a descendant of another category.
+     * Used for circular dependency detection when moving categories.
+     *
+     * @param potentialAncestor the category that might be an ancestor
+     * @param potentialDescendant the category that might be a descendant
+     * @return true if potentialDescendant is under potentialAncestor
+     */
+    public boolean isDescendantOf(Category potentialAncestor, CategoryName potentialDescendant) {
+        return findCategoryByName(potentialDescendant, potentialAncestor.getSubCategories()).isPresent();
+    }
+
+    /**
      * Deletes a single PENDING cash change from the CashFlow.
      * Used primarily by Recurring Rules module when deleting individual transactions.
      * <p>

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateProjector.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowAggregateProjector.java
@@ -32,6 +32,7 @@ public class CashFlowAggregateProjector {
                 case CashFlowEvent.ExpectedCashChangeDeletedEvent event -> cashFlow.apply(event);
                 case CashFlowEvent.ExpectedCashChangesBatchDeletedEvent event -> cashFlow.apply(event);
                 case CashFlowEvent.CashChangesBatchUpdatedEvent event -> cashFlow.apply(event);
+                case CashFlowEvent.CategoryMovedEvent event -> cashFlow.apply(event);
             }
         });
         return cashFlow;

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowEvent.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CashFlowEvent.java
@@ -30,6 +30,7 @@ public sealed interface CashFlowEvent extends DomainEvent
         CashFlowEvent.CategoryCreatedEvent,
         CashFlowEvent.CategoryArchivedEvent,
         CashFlowEvent.CategoryUnarchivedEvent,
+        CashFlowEvent.CategoryMovedEvent,
         CashFlowEvent.BudgetingSetEvent,
         CashFlowEvent.BudgetingUpdatedEvent,
         CashFlowEvent.BudgetingRemovedEvent {
@@ -429,6 +430,33 @@ public sealed interface CashFlowEvent extends DomainEvent
         @Override
         public ZonedDateTime occurredAt() {
             return updatedAt;
+        }
+    }
+
+    /**
+     * Event for moving a category to a different parent (or to root level).
+     * <p>
+     * Moving a category also moves all its subcategories with it.
+     * Transactions remain associated with their categories - only the hierarchy changes.
+     *
+     * @param cashFlowId            the CashFlow containing the category
+     * @param categoryName          the name of the category being moved
+     * @param oldParentCategoryName the previous parent (NOT_DEFINED if was at root)
+     * @param newParentCategoryName the new parent (NOT_DEFINED if moving to root)
+     * @param categoryType          INFLOW or OUTFLOW
+     * @param movedAt               timestamp when the move occurred
+     */
+    record CategoryMovedEvent(
+            CashFlowId cashFlowId,
+            CategoryName categoryName,
+            CategoryName oldParentCategoryName,
+            CategoryName newParentCategoryName,
+            Type categoryType,
+            ZonedDateTime movedAt
+    ) implements CashFlowEvent {
+        @Override
+        public ZonedDateTime occurredAt() {
+            return movedAt;
         }
     }
 }

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CategoryMoveToSameParentException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CategoryMoveToSameParentException.java
@@ -1,0 +1,20 @@
+package com.multi.vidulum.cashflow.domain;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when attempting to move a category to its current parent.
+ * This is a no-op and indicates a client-side validation issue.
+ */
+@Getter
+public class CategoryMoveToSameParentException extends RuntimeException {
+    private final CategoryName categoryName;
+    private final CategoryName parentName;
+
+    public CategoryMoveToSameParentException(CategoryName categoryName, CategoryName parentName) {
+        super("Category [" + categoryName.name() + "] is already under parent ["
+                + (parentName.isDefined() ? parentName.name() : "root") + "]");
+        this.categoryName = categoryName;
+        this.parentName = parentName;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CategoryTypeMismatchException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CategoryTypeMismatchException.java
@@ -1,0 +1,25 @@
+package com.multi.vidulum.cashflow.domain;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when attempting to move a category to a parent of different type.
+ * INFLOW categories can only have INFLOW parents, OUTFLOW categories can only have OUTFLOW parents.
+ */
+@Getter
+public class CategoryTypeMismatchException extends RuntimeException {
+    private final CategoryName categoryName;
+    private final Type categoryType;
+    private final CategoryName targetParentName;
+    private final Type targetParentType;
+
+    public CategoryTypeMismatchException(CategoryName categoryName, Type categoryType,
+                                         CategoryName targetParentName, Type targetParentType) {
+        super("Cannot move " + categoryType + " category [" + categoryName.name() + "] to "
+                + targetParentType + " parent [" + targetParentName.name() + "]");
+        this.categoryName = categoryName;
+        this.categoryType = categoryType;
+        this.targetParentName = targetParentName;
+        this.targetParentType = targetParentType;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow/domain/CircularCategoryDependencyException.java
+++ b/src/main/java/com/multi/vidulum/cashflow/domain/CircularCategoryDependencyException.java
@@ -1,0 +1,20 @@
+package com.multi.vidulum.cashflow.domain;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when a category move would create a circular dependency.
+ * A category cannot be moved to become a child of its own descendant.
+ */
+@Getter
+public class CircularCategoryDependencyException extends RuntimeException {
+    private final CategoryName categoryName;
+    private final CategoryName targetParentName;
+
+    public CircularCategoryDependencyException(CategoryName categoryName, CategoryName targetParentName) {
+        super("Cannot move category [" + categoryName.name() + "] to [" + targetParentName.name()
+                + "] - would create circular dependency");
+        this.categoryName = categoryName;
+        this.targetParentName = targetParentName;
+    }
+}

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowEventListener.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CashFlowEventListener.java
@@ -82,6 +82,9 @@ public class CashFlowEventListener {
             case "CategoryUnarchivedEvent" -> {
                 return event.getContent().to(CashFlowEvent.CategoryUnarchivedEvent.class);
             }
+            case "CategoryMovedEvent" -> {
+                return event.getContent().to(CashFlowEvent.CategoryMovedEvent.class);
+            }
             case "ExpectedCashChangeDeletedEvent" -> {
                 return event.getContent().to(CashFlowEvent.ExpectedCashChangeDeletedEvent.class);
             }

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CategoryNode.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/CategoryNode.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 @Getter
 @NoArgsConstructor
 public class CategoryNode {
+    @Setter
     @JsonIgnore
     private CategoryNode parentCategoryNode;
     private CategoryName categoryName;

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CashFlowForecastProcessor.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CashFlowForecastProcessor.java
@@ -34,6 +34,7 @@ public class CashFlowForecastProcessor {
     private final BudgetingRemovedEventHandler budgetingRemovedEventHandler;
     private final CategoryArchivedEventHandler categoryArchivedEventHandler;
     private final CategoryUnarchivedEventHandler categoryUnarchivedEventHandler;
+    private final CategoryMovedEventHandler categoryMovedEventHandler;
     private final ExpectedCashChangeDeletedEventHandler expectedCashChangeDeletedEventHandler;
     private final ExpectedCashChangesBatchDeletedEventHandler expectedCashChangesBatchDeletedEventHandler;
     private final CashChangesBatchUpdatedEventHandler cashChangesBatchUpdatedEventHandler;
@@ -63,6 +64,7 @@ public class CashFlowForecastProcessor {
             case CashFlowEvent.BudgetingRemovedEvent event -> budgetingRemovedEventHandler.handle(event);
             case CashFlowEvent.CategoryArchivedEvent event -> categoryArchivedEventHandler.handle(event);
             case CashFlowEvent.CategoryUnarchivedEvent event -> categoryUnarchivedEventHandler.handle(event);
+            case CashFlowEvent.CategoryMovedEvent event -> categoryMovedEventHandler.handle(event);
             case CashFlowEvent.ExpectedCashChangeDeletedEvent event -> expectedCashChangeDeletedEventHandler.handle(event);
             case CashFlowEvent.ExpectedCashChangesBatchDeletedEvent event -> expectedCashChangesBatchDeletedEventHandler.handle(event);
             case CashFlowEvent.CashChangesBatchUpdatedEvent event -> cashChangesBatchUpdatedEventHandler.handle(event);

--- a/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CategoryMovedEventHandler.java
+++ b/src/main/java/com/multi/vidulum/cashflow_forecast_processor/app/processing/CategoryMovedEventHandler.java
@@ -1,0 +1,210 @@
+package com.multi.vidulum.cashflow_forecast_processor.app.processing;
+
+import com.multi.vidulum.cashflow.domain.CashFlowDoesNotExistsException;
+import com.multi.vidulum.cashflow.domain.CashFlowEvent;
+import com.multi.vidulum.cashflow.domain.CategoryName;
+import com.multi.vidulum.cashflow.domain.Type;
+import com.multi.vidulum.cashflow_forecast_processor.app.*;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Stack;
+
+/**
+ * Handles CategoryMovedEvent by updating:
+ * <ul>
+ *   <li>CurrentCategoryStructure - the template for creating new monthly forecasts</li>
+ *   <li>All existing CashFlowMonthlyForecasts - moving the category tree in each month</li>
+ * </ul>
+ * <p>
+ * When a category is moved, all its subcategories move with it, preserving the tree structure.
+ * Transactions within those categories remain associated with them.
+ */
+@Slf4j
+@Component
+@AllArgsConstructor
+public class CategoryMovedEventHandler implements CashFlowEventHandler<CashFlowEvent.CategoryMovedEvent> {
+
+    private final CashFlowForecastStatementRepository statementRepository;
+
+    @Override
+    public void handle(CashFlowEvent.CategoryMovedEvent event) {
+        CashFlowForecastStatement statement = statementRepository.findByCashFlowId(event.cashFlowId())
+                .orElseThrow(() -> new CashFlowDoesNotExistsException(event.cashFlowId()));
+
+        // 1. Update CurrentCategoryStructure (template for new months)
+        updateCategoryStructure(statement.getCategoryStructure(), event);
+
+        // 2. Update all monthly forecasts
+        statement.getForecasts().values().forEach(monthlyForecast -> {
+            moveCategoryInForecast(monthlyForecast, event);
+        });
+
+        // 3. Recalculate stats (in case category sums affect totals)
+        statement.updateStats();
+
+        updateSyncMetadata(statement, event);
+        statementRepository.save(statement);
+
+        log.info("Category [{}] moved from [{}] to [{}] in forecast statement for cashflow [{}]",
+                event.categoryName().name(),
+                event.oldParentCategoryName().isDefined() ? event.oldParentCategoryName().name() : "root",
+                event.newParentCategoryName().isDefined() ? event.newParentCategoryName().name() : "root",
+                event.cashFlowId().id());
+    }
+
+    /**
+     * Updates the CurrentCategoryStructure by moving the CategoryNode.
+     */
+    private void updateCategoryStructure(CurrentCategoryStructure categoryStructure, CashFlowEvent.CategoryMovedEvent event) {
+        List<CategoryNode> categoryNodes = Type.INFLOW.equals(event.categoryType())
+                ? categoryStructure.inflowCategoryStructure()
+                : categoryStructure.outflowCategoryStructure();
+
+        // Find and remove the node from old location
+        CategoryNode movingNode = findAndRemoveNode(categoryNodes, event.categoryName(), event.oldParentCategoryName());
+
+        if (movingNode == null) {
+            log.warn("CategoryNode [{}] not found in category structure for cashflow [{}]",
+                    event.categoryName().name(), event.cashFlowId().id());
+            return;
+        }
+
+        // Add to new location
+        if (event.newParentCategoryName().isDefined()) {
+            // Add as child of new parent
+            CategoryNode newParent = findCategoryNodeByName(categoryNodes, event.newParentCategoryName());
+            if (newParent != null) {
+                movingNode.setParentCategoryNode(newParent);
+                newParent.getNodes().add(movingNode);
+            } else {
+                log.warn("New parent CategoryNode [{}] not found, adding to root",
+                        event.newParentCategoryName().name());
+                movingNode.setParentCategoryNode(null);
+                categoryNodes.add(movingNode);
+            }
+        } else {
+            // Add to root level
+            movingNode.setParentCategoryNode(null);
+            categoryNodes.add(movingNode);
+        }
+    }
+
+    /**
+     * Moves a CashCategory within a monthly forecast.
+     */
+    private void moveCategoryInForecast(CashFlowMonthlyForecast monthlyForecast, CashFlowEvent.CategoryMovedEvent event) {
+        List<CashCategory> categories = Type.INFLOW.equals(event.categoryType())
+                ? monthlyForecast.getCategorizedInFlows()
+                : monthlyForecast.getCategorizedOutFlows();
+
+        // Find and remove from old location
+        CashCategory movingCategory = findAndRemoveCategory(categories, event.categoryName(), event.oldParentCategoryName());
+
+        if (movingCategory == null) {
+            log.warn("CashCategory [{}] not found in monthly forecast for cashflow [{}]",
+                    event.categoryName().name(), event.cashFlowId().id());
+            return;
+        }
+
+        // Add to new location
+        if (event.newParentCategoryName().isDefined()) {
+            // Add as child of new parent
+            CashCategory newParent = findCategoryByName(categories, event.newParentCategoryName());
+            if (newParent != null) {
+                newParent.getSubCategories().add(movingCategory);
+            } else {
+                log.warn("New parent CashCategory [{}] not found, adding to root",
+                        event.newParentCategoryName().name());
+                categories.add(movingCategory);
+            }
+        } else {
+            // Add to root level
+            categories.add(movingCategory);
+        }
+    }
+
+    /**
+     * Finds and removes a CategoryNode from the tree structure.
+     *
+     * @return The removed CategoryNode, or null if not found
+     */
+    private CategoryNode findAndRemoveNode(List<CategoryNode> categoryNodes, CategoryName categoryName, CategoryName oldParentName) {
+        if (!oldParentName.isDefined()) {
+            // Was at root level
+            for (int i = 0; i < categoryNodes.size(); i++) {
+                if (categoryNodes.get(i).getCategoryName().equals(categoryName)) {
+                    return categoryNodes.remove(i);
+                }
+            }
+        } else {
+            // Was under a parent
+            CategoryNode oldParent = findCategoryNodeByName(categoryNodes, oldParentName);
+            if (oldParent != null) {
+                List<CategoryNode> childNodes = oldParent.getNodes();
+                for (int i = 0; i < childNodes.size(); i++) {
+                    if (childNodes.get(i).getCategoryName().equals(categoryName)) {
+                        return childNodes.remove(i);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds and removes a CashCategory from the tree structure.
+     *
+     * @return The removed CashCategory, or null if not found
+     */
+    private CashCategory findAndRemoveCategory(List<CashCategory> categories, CategoryName categoryName, CategoryName oldParentName) {
+        if (!oldParentName.isDefined()) {
+            // Was at root level
+            for (int i = 0; i < categories.size(); i++) {
+                if (categories.get(i).getCategoryName().equals(categoryName)) {
+                    return categories.remove(i);
+                }
+            }
+        } else {
+            // Was under a parent
+            CashCategory oldParent = findCategoryByName(categories, oldParentName);
+            if (oldParent != null) {
+                List<CashCategory> subCategories = oldParent.getSubCategories();
+                for (int i = 0; i < subCategories.size(); i++) {
+                    if (subCategories.get(i).getCategoryName().equals(categoryName)) {
+                        return subCategories.remove(i);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private CategoryNode findCategoryNodeByName(List<CategoryNode> categoryNodes, CategoryName categoryName) {
+        Stack<CategoryNode> stack = new Stack<>();
+        categoryNodes.forEach(stack::push);
+        while (!stack.isEmpty()) {
+            CategoryNode node = stack.pop();
+            if (node.getCategoryName().equals(categoryName)) {
+                return node;
+            }
+            node.getNodes().forEach(stack::push);
+        }
+        return null;
+    }
+
+    private CashCategory findCategoryByName(List<CashCategory> cashCategories, CategoryName categoryName) {
+        Stack<CashCategory> stack = new Stack<>();
+        cashCategories.forEach(stack::push);
+        while (!stack.isEmpty()) {
+            CashCategory category = stack.pop();
+            if (category.getCategoryName().equals(categoryName)) {
+                return category;
+            }
+            category.getSubCategories().forEach(stack::push);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
+++ b/src/main/java/com/multi/vidulum/common/error/ErrorCode.java
@@ -64,6 +64,10 @@ public enum ErrorCode {
     // CashFlow - Categories
     CATEGORY_IS_ARCHIVED(HttpStatus.BAD_REQUEST, "Category is archived"),
     CANNOT_ARCHIVE_SYSTEM_CATEGORY(HttpStatus.BAD_REQUEST, "Cannot archive system category"),
+    CANNOT_MOVE_SYSTEM_CATEGORY(HttpStatus.BAD_REQUEST, "Cannot move system category"),
+    CATEGORY_CIRCULAR_DEPENDENCY(HttpStatus.BAD_REQUEST, "Cannot move category to its own descendant"),
+    CANNOT_CHANGE_CATEGORY_TYPE(HttpStatus.BAD_REQUEST, "Cannot move category between INFLOW and OUTFLOW"),
+    CATEGORY_MOVE_TO_SAME_PARENT(HttpStatus.BAD_REQUEST, "Category is already under this parent"),
 
     // CashFlow - Bank Account Validation
     INVALID_BANK_ACCOUNT(HttpStatus.BAD_REQUEST, "Invalid bank account data"),

--- a/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
+++ b/src/main/java/com/multi/vidulum/security/config/ErrorHttpHandler.java
@@ -5,6 +5,9 @@ import com.multi.vidulum.bank_data_ingestion.domain.*;
 import com.multi.vidulum.cashflow.app.commands.archive.CannotArchiveSystemCategoryException;
 import com.multi.vidulum.cashflow.app.commands.archive.CategoryNotFoundException;
 import com.multi.vidulum.cashflow.domain.*;
+import com.multi.vidulum.cashflow.domain.CannotMoveSystemCategoryException;
+import com.multi.vidulum.cashflow.domain.CircularCategoryDependencyException;
+import com.multi.vidulum.cashflow.domain.CategoryMoveToSameParentException;
 import com.multi.vidulum.cashflow.domain.InvalidCashChangeIdFormatException;
 import com.multi.vidulum.cashflow.domain.InvalidCashFlowIdFormatException;
 import com.multi.vidulum.common.InvalidUserIdFormatException;
@@ -326,6 +329,36 @@ public class ErrorHttpHandler {
     public ResponseEntity<ApiError> handleCannotArchiveSystemCategory(CannotArchiveSystemCategoryException ex) {
         log.debug("Cannot archive system category: {}", ex.getMessage());
         ApiError error = ApiError.of(ErrorCode.CANNOT_ARCHIVE_SYSTEM_CATEGORY, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    // ============ CashFlow - Move Category Operations (400) ============
+
+    @ExceptionHandler(CannotMoveSystemCategoryException.class)
+    public ResponseEntity<ApiError> handleCannotMoveSystemCategory(CannotMoveSystemCategoryException ex) {
+        log.debug("Cannot move system category: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CANNOT_MOVE_SYSTEM_CATEGORY, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(CircularCategoryDependencyException.class)
+    public ResponseEntity<ApiError> handleCircularCategoryDependency(CircularCategoryDependencyException ex) {
+        log.debug("Circular category dependency: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CATEGORY_CIRCULAR_DEPENDENCY, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(CategoryMoveToSameParentException.class)
+    public ResponseEntity<ApiError> handleCategoryMoveToSameParent(CategoryMoveToSameParentException ex) {
+        log.debug("Category move to same parent: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CATEGORY_MOVE_TO_SAME_PARENT, ex.getMessage());
+        return ResponseEntity.status(error.httpStatus()).body(error);
+    }
+
+    @ExceptionHandler(CannotChangeCategoryTypeException.class)
+    public ResponseEntity<ApiError> handleCannotChangeCategoryType(CannotChangeCategoryTypeException ex) {
+        log.debug("Cannot change category type: {}", ex.getMessage());
+        ApiError error = ApiError.of(ErrorCode.CANNOT_CHANGE_CATEGORY_TYPE, ex.getMessage());
         return ResponseEntity.status(error.httpStatus()).body(error);
     }
 

--- a/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/CashFlowHttpActor.java
@@ -934,4 +934,74 @@ public class CashFlowHttpActor {
                 request
         );
     }
+
+    // ============ Move Category Operations ============
+
+    /**
+     * Moves a category to a new parent (or to root level) via HTTP.
+     *
+     * @param cashFlowId            the CashFlow containing the category
+     * @param categoryName          the name of the category to move
+     * @param newParentCategoryName the new parent (null or empty for root level)
+     * @param categoryType          the type (INFLOW or OUTFLOW)
+     */
+    public void moveCategory(String cashFlowId, String categoryName, String newParentCategoryName, Type categoryType) {
+        CashFlowDto.MoveCategoryJson request = CashFlowDto.MoveCategoryJson.builder()
+                .categoryName(categoryName)
+                .newParentCategoryName(newParentCategoryName)
+                .categoryType(categoryType)
+                .build();
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category/move",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        log.debug("Moved category via HTTP: cashFlowId={}, category={}, newParent={}",
+                cashFlowId, categoryName, newParentCategoryName);
+    }
+
+    /**
+     * Moves a category expecting an error response.
+     */
+    public ResponseEntity<ApiError> moveCategoryExpectingError(String cashFlowId, String categoryName,
+                                                                String newParentCategoryName, Type categoryType) {
+        CashFlowDto.MoveCategoryJson request = CashFlowDto.MoveCategoryJson.builder()
+                .categoryName(categoryName)
+                .newParentCategoryName(newParentCategoryName)
+                .categoryType(categoryType)
+                .build();
+
+        return executeExpectingError(
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category/move",
+                HttpMethod.POST,
+                request
+        );
+    }
+
+    /**
+     * Creates a subcategory under a parent category via HTTP.
+     * Uses isImport=true to allow category creation in SETUP mode.
+     */
+    public void createSubcategory(String cashFlowId, String parentCategoryName, String subcategoryName, Type type) {
+        CashFlowDto.CreateCategoryJson request = CashFlowDto.CreateCategoryJson.builder()
+                .parentCategoryName(parentCategoryName)
+                .category(subcategoryName)
+                .type(type)
+                .build();
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                baseUrl + "/cash-flow/cf=" + cashFlowId + "/category?isImport=true",
+                HttpMethod.POST,
+                new HttpEntity<>(request, jsonHeaders()),
+                Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        log.debug("Created subcategory via HTTP: cashFlowId={}, parent={}, subcategory={}, type={}",
+                cashFlowId, parentCategoryName, subcategoryName, type);
+    }
 }

--- a/src/test/java/com/multi/vidulum/cashflow/app/MoveCategoryIntegrationTest.java
+++ b/src/test/java/com/multi/vidulum/cashflow/app/MoveCategoryIntegrationTest.java
@@ -1,0 +1,385 @@
+package com.multi.vidulum.cashflow.app;
+
+import com.multi.vidulum.AuthenticatedHttpIntegrationTest;
+import com.multi.vidulum.cashflow.domain.CashFlow;
+import com.multi.vidulum.cashflow.domain.CashFlowEvent;
+import com.multi.vidulum.cashflow.domain.CashFlowId;
+import com.multi.vidulum.cashflow.domain.Category;
+import com.multi.vidulum.cashflow.domain.DomainCashFlowRepository;
+import com.multi.vidulum.cashflow.domain.Type;
+import com.multi.vidulum.cashflow_forecast_processor.app.CashFlowForecastStatement;
+import com.multi.vidulum.cashflow_forecast_processor.app.CashFlowForecastStatementRepository;
+import com.multi.vidulum.cashflow_forecast_processor.app.CategoryNode;
+import com.multi.vidulum.cashflow_forecast_processor.app.CurrentCategoryStructure;
+import com.multi.vidulum.cashflow_forecast_processor.infrastructure.CashFlowForecastEntity;
+import com.multi.vidulum.cashflow_forecast_processor.infrastructure.CashFlowForecastMongoRepository;
+import com.multi.vidulum.common.Money;
+import com.multi.vidulum.common.error.ApiError;
+import com.multi.vidulum.common.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Clock;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Integration tests for the Move Category functionality.
+ * <p>
+ * Tests cover:
+ * - Moving categories within the same hierarchy level (root to root parent)
+ * - Moving categories from root to subcategory
+ * - Moving subcategories to root
+ * - Moving categories with nested subcategories (subtree moves together)
+ * - Validation errors (circular dependency, system category, same parent, not found)
+ * - Forecast processing (categories properly updated in forecast statement)
+ */
+@Slf4j
+public class MoveCategoryIntegrationTest extends AuthenticatedHttpIntegrationTest {
+
+    private static final AtomicInteger NAME_COUNTER = new AtomicInteger(0);
+    private static final ZonedDateTime FIXED_NOW = ZonedDateTime.parse("2022-01-01T00:00:00Z[UTC]");
+
+    @Autowired
+    private CashFlowRestController cashFlowRestController;
+
+    @Autowired
+    private DomainCashFlowRepository domainCashFlowRepository;
+
+    @Autowired
+    private CashFlowForecastMongoRepository cashFlowForecastMongoRepository;
+
+    @Autowired
+    private CashFlowForecastStatementRepository statementRepository;
+
+    @Autowired
+    private Clock clock;
+
+    private CashFlowHttpActor actor;
+
+    private CashFlowHttpActor createActor() {
+        // Register a unique user for each test and get JWT token
+        registerAndAuthenticate();
+        CashFlowHttpActor newActor = new CashFlowHttpActor(restTemplate, port);
+        newActor.setJwtToken(accessToken);
+        return newActor;
+    }
+
+    private String uniqueCashFlowName() {
+        return "MoveCatCF-" + NAME_COUNTER.incrementAndGet();
+    }
+
+    // ============ Success Cases ============
+
+    @Test
+    void shouldMoveCategoryFromRootToAnotherRootCategory() {
+        // Given: CashFlow with two root categories: "Bills" and "Housing"
+        actor = createActor();
+        YearMonth startPeriod = YearMonth.now(clock).minusMonths(2);
+
+        String cashFlowId = actor.createCashFlowWithHistory(userId, uniqueCashFlowName(), startPeriod, Money.of(5000, "PLN"));
+        CashFlowId cfId = CashFlowId.of(cashFlowId);
+
+        // Create categories
+        actor.createCategory(cashFlowId, "Bills", Type.OUTFLOW);
+        actor.createCategory(cashFlowId, "Housing", Type.OUTFLOW);
+
+        // Attest to move to OPEN mode
+        Money confirmedBalance = Money.of(5000, "PLN");
+        actor.attestHistoricalImport(cashFlowId, confirmedBalance, false, false);
+
+        // Wait for events to be processed
+        waitForEventProcessed(cashFlowId, CashFlowEvent.HistoricalImportAttestedEvent.class.getSimpleName());
+
+        // When: Move "Bills" to be a subcategory of "Housing"
+        actor.moveCategory(cashFlowId, "Bills", "Housing", Type.OUTFLOW);
+
+        // Wait for CategoryMovedEvent to be processed
+        waitForEventProcessed(cashFlowId, CashFlowEvent.CategoryMovedEvent.class.getSimpleName());
+
+        // Then: Verify in domain model
+        CashFlow cashFlow = domainCashFlowRepository.findById(cfId).orElseThrow();
+        List<Category> outflowCategories = cashFlow.getSnapshot().outflowCategories();
+
+        // "Bills" should no longer be at root level
+        assertThat(outflowCategories.stream().map(c -> c.getCategoryName().name()))
+                .doesNotContain("Bills");
+
+        // "Bills" should be a subcategory of "Housing"
+        Category housing = outflowCategories.stream()
+                .filter(c -> c.getCategoryName().name().equals("Housing"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(housing.getSubCategories()).hasSize(1);
+        assertThat(housing.getSubCategories().get(0).getCategoryName().name()).isEqualTo("Bills");
+
+        // Verify in forecast statement
+        await().atMost(10, SECONDS).until(() ->
+                statementRepository.findByCashFlowId(cfId).isPresent());
+
+        CashFlowForecastStatement statement = statementRepository.findByCashFlowId(cfId).orElseThrow();
+        CurrentCategoryStructure structure = statement.getCategoryStructure();
+
+        // Check structure: Housing should have Bills as child
+        CategoryNode housingNode = structure.outflowCategoryStructure().stream()
+                .filter(n -> n.getCategoryName().name().equals("Housing"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(housingNode.getNodes()).hasSize(1);
+        assertThat(housingNode.getNodes().get(0).getCategoryName().name()).isEqualTo("Bills");
+
+        log.info("Successfully moved category 'Bills' under 'Housing'");
+    }
+
+    @Test
+    void shouldMoveCategoryFromSubcategoryToRoot() {
+        // Given: CashFlow with "Housing" category that has "Bills" as subcategory
+        actor = createActor();
+        YearMonth startPeriod = YearMonth.now(clock).minusMonths(2);
+
+        String cashFlowId = actor.createCashFlowWithHistory(userId, uniqueCashFlowName(), startPeriod, Money.of(5000, "PLN"));
+        CashFlowId cfId = CashFlowId.of(cashFlowId);
+
+        // Create categories with hierarchy
+        actor.createCategory(cashFlowId, "Housing", Type.OUTFLOW);
+        actor.createSubcategory(cashFlowId, "Housing", "Bills", Type.OUTFLOW);
+
+        // Attest
+        actor.attestHistoricalImport(cashFlowId, Money.of(5000, "PLN"), false, false);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.HistoricalImportAttestedEvent.class.getSimpleName());
+
+        // When: Move "Bills" to root level (null parent)
+        actor.moveCategory(cashFlowId, "Bills", null, Type.OUTFLOW);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.CategoryMovedEvent.class.getSimpleName());
+
+        // Then: Verify "Bills" is now at root level
+        CashFlow cashFlow = domainCashFlowRepository.findById(cfId).orElseThrow();
+        List<Category> outflowCategories = cashFlow.getSnapshot().outflowCategories();
+
+        assertThat(outflowCategories.stream().map(c -> c.getCategoryName().name()))
+                .contains("Bills", "Housing", "Uncategorized");
+
+        // Housing should have no subcategories
+        Category housing = outflowCategories.stream()
+                .filter(c -> c.getCategoryName().name().equals("Housing"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(housing.getSubCategories()).isEmpty();
+
+        log.info("Successfully moved category 'Bills' to root level");
+    }
+
+    @Test
+    void shouldMoveCategoryWithNestedSubcategories() {
+        // Given: CashFlow with nested hierarchy: "Housing" -> "Bills" -> "Electricity"
+        actor = createActor();
+        YearMonth startPeriod = YearMonth.now(clock).minusMonths(2);
+
+        String cashFlowId = actor.createCashFlowWithHistory(userId, uniqueCashFlowName(), startPeriod, Money.of(5000, "PLN"));
+        CashFlowId cfId = CashFlowId.of(cashFlowId);
+
+        // Create hierarchy
+        actor.createCategory(cashFlowId, "Housing", Type.OUTFLOW);
+        actor.createSubcategory(cashFlowId, "Housing", "Bills", Type.OUTFLOW);
+        actor.createSubcategory(cashFlowId, "Bills", "Electricity", Type.OUTFLOW);
+        actor.createCategory(cashFlowId, "Other", Type.OUTFLOW);
+
+        // Attest
+        actor.attestHistoricalImport(cashFlowId, Money.of(5000, "PLN"), false, false);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.HistoricalImportAttestedEvent.class.getSimpleName());
+
+        // When: Move "Bills" (with "Electricity" subtree) to "Other"
+        actor.moveCategory(cashFlowId, "Bills", "Other", Type.OUTFLOW);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.CategoryMovedEvent.class.getSimpleName());
+
+        // Then: Verify entire subtree moved
+        CashFlow cashFlow = domainCashFlowRepository.findById(cfId).orElseThrow();
+        List<Category> outflowCategories = cashFlow.getSnapshot().outflowCategories();
+
+        // "Other" should have "Bills" which has "Electricity"
+        Category other = outflowCategories.stream()
+                .filter(c -> c.getCategoryName().name().equals("Other"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(other.getSubCategories()).hasSize(1);
+        Category bills = other.getSubCategories().get(0);
+        assertThat(bills.getCategoryName().name()).isEqualTo("Bills");
+        assertThat(bills.getSubCategories()).hasSize(1);
+        assertThat(bills.getSubCategories().get(0).getCategoryName().name()).isEqualTo("Electricity");
+
+        // "Housing" should have no subcategories
+        Category housing = outflowCategories.stream()
+                .filter(c -> c.getCategoryName().name().equals("Housing"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(housing.getSubCategories()).isEmpty();
+
+        log.info("Successfully moved category subtree 'Bills->Electricity' under 'Other'");
+    }
+
+    // ============ Error Cases ============
+
+    @Test
+    void shouldRejectMovingSystemCategory() {
+        // Given: CashFlow with system "Uncategorized" category
+        actor = createActor();
+        YearMonth startPeriod = YearMonth.now(clock).minusMonths(2);
+
+        String cashFlowId = actor.createCashFlowWithHistory(userId, uniqueCashFlowName(), startPeriod, Money.of(5000, "PLN"));
+
+        actor.createCategory(cashFlowId, "Housing", Type.OUTFLOW);
+        actor.attestHistoricalImport(cashFlowId, Money.of(5000, "PLN"), false, false);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.HistoricalImportAttestedEvent.class.getSimpleName());
+
+        // When: Try to move "Uncategorized" (system category)
+        ResponseEntity<ApiError> response = actor.moveCategoryExpectingError(
+                cashFlowId, "Uncategorized", "Housing", Type.OUTFLOW);
+
+        // Then: Should get CANNOT_MOVE_SYSTEM_CATEGORY error
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().code()).isEqualTo(ErrorCode.CANNOT_MOVE_SYSTEM_CATEGORY.name());
+
+        log.info("Correctly rejected moving system category");
+    }
+
+    @Test
+    void shouldRejectCircularDependency() {
+        // Given: CashFlow with "Parent" -> "Child" hierarchy
+        actor = createActor();
+        YearMonth startPeriod = YearMonth.now(clock).minusMonths(2);
+
+        String cashFlowId = actor.createCashFlowWithHistory(userId, uniqueCashFlowName(), startPeriod, Money.of(5000, "PLN"));
+
+        actor.createCategory(cashFlowId, "Parent", Type.OUTFLOW);
+        actor.createSubcategory(cashFlowId, "Parent", "Child", Type.OUTFLOW);
+        actor.attestHistoricalImport(cashFlowId, Money.of(5000, "PLN"), false, false);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.HistoricalImportAttestedEvent.class.getSimpleName());
+
+        // When: Try to move "Parent" under "Child" (circular dependency)
+        ResponseEntity<ApiError> response = actor.moveCategoryExpectingError(
+                cashFlowId, "Parent", "Child", Type.OUTFLOW);
+
+        // Then: Should get CATEGORY_CIRCULAR_DEPENDENCY error
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().code()).isEqualTo(ErrorCode.CATEGORY_CIRCULAR_DEPENDENCY.name());
+
+        log.info("Correctly rejected circular dependency");
+    }
+
+    @Test
+    void shouldRejectMoveToSameParent() {
+        // Given: CashFlow with "Parent" -> "Child" hierarchy
+        actor = createActor();
+        YearMonth startPeriod = YearMonth.now(clock).minusMonths(2);
+
+        String cashFlowId = actor.createCashFlowWithHistory(userId, uniqueCashFlowName(), startPeriod, Money.of(5000, "PLN"));
+
+        actor.createCategory(cashFlowId, "Parent", Type.OUTFLOW);
+        actor.createSubcategory(cashFlowId, "Parent", "Child", Type.OUTFLOW);
+        actor.attestHistoricalImport(cashFlowId, Money.of(5000, "PLN"), false, false);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.HistoricalImportAttestedEvent.class.getSimpleName());
+
+        // When: Try to move "Child" to same parent "Parent" (no-op)
+        ResponseEntity<ApiError> response = actor.moveCategoryExpectingError(
+                cashFlowId, "Child", "Parent", Type.OUTFLOW);
+
+        // Then: Should get CATEGORY_MOVE_TO_SAME_PARENT error
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().code()).isEqualTo(ErrorCode.CATEGORY_MOVE_TO_SAME_PARENT.name());
+
+        log.info("Correctly rejected move to same parent");
+    }
+
+    @Test
+    void shouldRejectMovingNonExistentCategory() {
+        // Given: CashFlow without "NonExistent" category
+        actor = createActor();
+        YearMonth startPeriod = YearMonth.now(clock).minusMonths(2);
+
+        String cashFlowId = actor.createCashFlowWithHistory(userId, uniqueCashFlowName(), startPeriod, Money.of(5000, "PLN"));
+
+        actor.attestHistoricalImport(cashFlowId, Money.of(5000, "PLN"), false, false);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.HistoricalImportAttestedEvent.class.getSimpleName());
+
+        // When: Try to move non-existent category
+        ResponseEntity<ApiError> response = actor.moveCategoryExpectingError(
+                cashFlowId, "NonExistent", null, Type.OUTFLOW);
+
+        // Then: Should get CATEGORY_NOT_FOUND error
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody().code()).isEqualTo(ErrorCode.CATEGORY_NOT_FOUND.name());
+
+        log.info("Correctly rejected moving non-existent category");
+    }
+
+    @Test
+    void shouldRejectMovingToNonExistentParent() {
+        // Given: CashFlow with "Bills" category but no "NonExistent" parent
+        actor = createActor();
+        YearMonth startPeriod = YearMonth.now(clock).minusMonths(2);
+
+        String cashFlowId = actor.createCashFlowWithHistory(userId, uniqueCashFlowName(), startPeriod, Money.of(5000, "PLN"));
+
+        actor.createCategory(cashFlowId, "Bills", Type.OUTFLOW);
+        actor.attestHistoricalImport(cashFlowId, Money.of(5000, "PLN"), false, false);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.HistoricalImportAttestedEvent.class.getSimpleName());
+
+        // When: Try to move to non-existent parent
+        ResponseEntity<ApiError> response = actor.moveCategoryExpectingError(
+                cashFlowId, "Bills", "NonExistent", Type.OUTFLOW);
+
+        // Then: Should get CATEGORY_NOT_FOUND error
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody().code()).isEqualTo(ErrorCode.CATEGORY_NOT_FOUND.name());
+
+        log.info("Correctly rejected moving to non-existent parent");
+    }
+
+    @Test
+    void shouldRejectMovingCategoryWithWrongType() {
+        // Given: CashFlow with "Salary" as INFLOW category
+        actor = createActor();
+        YearMonth startPeriod = YearMonth.now(clock).minusMonths(2);
+
+        String cashFlowId = actor.createCashFlowWithHistory(userId, uniqueCashFlowName(), startPeriod, Money.of(5000, "PLN"));
+
+        // Create an INFLOW category
+        actor.createCategory(cashFlowId, "Salary", Type.INFLOW);
+        actor.createCategory(cashFlowId, "Bills", Type.OUTFLOW);
+        actor.attestHistoricalImport(cashFlowId, Money.of(5000, "PLN"), false, false);
+        waitForEventProcessed(cashFlowId, CashFlowEvent.HistoricalImportAttestedEvent.class.getSimpleName());
+
+        // When: Try to move "Salary" (INFLOW) but specify OUTFLOW type - attempting to change type
+        ResponseEntity<ApiError> response = actor.moveCategoryExpectingError(
+                cashFlowId, "Salary", "Bills", Type.OUTFLOW);
+
+        // Then: Should get CANNOT_CHANGE_CATEGORY_TYPE error (not generic NOT_FOUND)
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().code()).isEqualTo(ErrorCode.CANNOT_CHANGE_CATEGORY_TYPE.name());
+        assertThat(response.getBody().message()).contains("INFLOW");
+        assertThat(response.getBody().message()).contains("OUTFLOW");
+
+        log.info("Correctly rejected moving category with wrong type specified");
+    }
+
+    // ============ Helper Methods ============
+
+    private void waitForEventProcessed(String cashFlowId, String eventTypeName) {
+        await().atMost(10, SECONDS).until(() ->
+                cashFlowForecastMongoRepository.findByCashFlowId(cashFlowId)
+                        .map(entity -> entity.getEvents().stream()
+                                .map(CashFlowForecastEntity.Processing::type)
+                                .toList()
+                                .contains(eventTypeName))
+                        .orElse(false));
+    }
+}


### PR DESCRIPTION
  ## Summary

  - Add new endpoint `POST /cash-flow/cf={cashFlowId}/category/move` to reorganize category hierarchy
  - Support moving categories between parents (root ↔ subcategory) within the same type (INFLOW/OUTFLOW)
  - Full Kafka event integration with `CashFlowForecastProcessor` for real-time forecast updates
  - Comprehensive validation with specific error codes for all edge cases

