### PR TITLE
VID-152: Add counterpartyAccount field and hybrid pattern grouping for AI categorization

### DIFF
--- a/docs/analysis/VID-151-AI-CATEGORIZATION-IMPROVEMENTS.md
+++ b/docs/analysis/VID-151-AI-CATEGORIZATION-IMPROVEMENTS.md
@@ -1,0 +1,277 @@
+# VID-151: Analiza problemu granularności kategoryzacji AI
+
+**Data analizy**: 2026-04-15
+**Kontekst**: AI kategoryzuje transakcje do zbyt ogólnych kategorii ("Inne wydatki") zamiast bardziej szczegółowych
+
+## Problem
+
+Po wgraniu pliku CSV dla użytkownika, AI poprawnie rozpoznaje ZUS i Urząd Skarbowy jako "Opłaty obowiązkowe", ale wiele innych transakcji ląduje w generycznej kategorii "Inne wydatki":
+
+| Pattern | AI sugeruje | Mogłoby być |
+|---------|-------------|-------------|
+| LUCJAN BIK PEKAO | Inne wydatki | Oszczędności / Kredyty |
+| IKANO | Inne wydatki | Kredyty / Raty |
+| SANTANDER | Inne wydatki | Kredyty / Raty |
+| CREDIT AGRICOLE | Inne wydatki | Kredyty / Raty |
+| PGE | Inne wydatki | Opłaty obowiązkowe / Rachunki |
+| TUIR WARTA | Inne wydatki | Ubezpieczenia |
+| SILVA SILVA | Inne wydatki | Mieszkanie / Czynsz |
+
+## Analiza danych wejściowych
+
+### Struktura transakcji w CSV (Nest Bank)
+
+```csv
+Data,Rodzaj operacji,Kwota,Dane kontrahenta,Numer rachunku kontrahenta,Tytuł operacji
+31-12-2025,Przelewy wychodzące,-3000,Lucjan Bik Pekao,PL98124014441111001078171074,zycie
+12-12-2025,Przelewy wychodzące,-2837,Urzad skarbowy w Mielcu,68101000712222817219307000,PIT28
+12-12-2025,Przelewy wychodzące,-2415.9,ZUS,29600000020260018172193070,składki ZUS
+```
+
+### Najczęstsi kontrahenci
+
+| Kontrahent | Ilość | Suma PLN | Tytuły operacji |
+|------------|-------|----------|-----------------|
+| Lucjan Bik Pekao | 74 | 329k | "zycie", "mieszkanie kredyt" |
+| Urząd skarbowy | 51 | 330k | "PIT28", "VAT7K" |
+| ZUS | 37 | 89k | "składki ZUS" |
+| Ikano | 36 | 116k | "rata kredytu" |
+| IFIRMA SA | 35 | 10k | "Faktura VAT nr..." |
+| Lucjan Bik mbank | 32 | 167k | "mieszkanie kredyt", "nadplata" |
+| Silva Silva | 15 | - | "czynsz" |
+| Santander | 9 | 7k | "rata kredytu" |
+| Credit Agricole | 9 | 4k | "umowa kredytu" |
+
+### Najczęstsze tytuły operacji
+
+| Tytuł | Ilość | Znaczenie |
+|-------|-------|-----------|
+| "zycie" | 66 | Przelewy własne (oszczędności?) |
+| "składki ZUS" | 36 | Składki społeczne |
+| "mieszkanie kredyt" | 29 | Rata kredytu hipotecznego |
+| "rata kredytu" | 21 | Rata kredytu |
+| "czynsz" | 15 | Opłata za mieszkanie |
+
+## Kluczowe odkrycie: AI nie widzi tytułów!
+
+W obecnej implementacji `AiCategorizationPromptBuilder.formatPatternGroup()`:
+
+```java
+sb.append(String.format("    | name: \"%s\"\n", pg.sampleTransaction()));
+sb.append(String.format("    | title: \"%s\"\n", pg.sampleDescription()));
+```
+
+**Problem**: `sampleDescription` jest często puste lub zawiera tylko jeden przykład.
+
+AI otrzymuje:
+```
+[74 txns, 329.2k] LUCJAN BIK PEKAO
+  | name: "Lucjan Bik Pekao"
+  | bank: Przelewy wychodzące
+```
+
+Ale **nie widzi**, że:
+- 66 transakcji ma tytuł "zycie"
+- 8 transakcji ma tytuł "mieszkanie kredyt"
+
+---
+
+## Pomysły na rozwiązanie
+
+### Pomysł 1: Pokazać najczęstsze tytuły w promptcie
+
+**Zmiana**: W `PatternDeduplicator` zbierać top 3 najczęstszych tytułów dla każdego wzorca.
+
+**Przed**:
+```
+[74 txns, 329.2k] LUCJAN BIK PEKAO
+  | name: "Lucjan Bik Pekao"
+  | bank: Przelewy wychodzące
+```
+
+**Po**:
+```
+[74 txns, 329.2k] LUCJAN BIK PEKAO
+  | name: "Lucjan Bik Pekao"
+  | common titles: "zycie" (66x), "mieszkanie kredyt" (8x)
+  | bank: Przelewy wychodzące
+```
+
+**Korzyści**:
+- AI zobaczy, że "Lucjan Bik Pekao" z tytułem "mieszkanie kredyt" to spłata kredytu
+- AI może zasugerować podział na subkategorie na podstawie tytułów
+
+**Wymagane zmiany**:
+- `PatternDeduplicator.PatternGroup` - nowe pole `commonTitles: Map<String, Integer>`
+- `AiCategorizationPromptBuilder.formatPatternGroup()` - wyświetlić top 3 tytuły
+
+---
+
+### Pomysł 2: Słownik polskich instytucji finansowych
+
+**Zmiana**: Dodać do `getSystemPrompt()` wiedzę domenową o polskim rynku.
+
+```
+Polish financial institutions knowledge:
+
+MANDATORY PAYMENTS (Opłaty obowiązkowe):
+- ZUS = Zakład Ubezpieczeń Społecznych - mandatory social insurance
+- Urząd Skarbowy = Tax Office - PIT, VAT, CIT payments
+
+BANKS (likely loan/mortgage payments):
+- Santander, mBank, ING, Credit Agricole, PKO BP, Pekao, BNP Paribas
+- Ikano Bank = IKEA financing, installment loans for furniture
+
+INSURANCE COMPANIES (Ubezpieczenia):
+- WARTA, PZU, UNIQA, Allianz, Generali, AXA, Ergo Hestia
+
+UTILITIES (Rachunki):
+- PGE, TAURON, ENEA, Energa = Electricity
+- PGNiG = Gas
+- Veolia, MPWiK = Water
+
+TELECOM (Telekomunikacja):
+- Play, Orange, T-Mobile, Plus
+
+ACCOUNTING SaaS (Księgowość):
+- IFIRMA, inFakt, wFirma = Accounting software for freelancers/B2B
+
+CATEGORIZATION HINTS:
+- If counterparty is a bank AND title contains "rata", "kredyt" → category: Kredyty
+- If title contains "czynsz" → category: Mieszkanie
+- If title contains "składki ZUS" → category: ZUS (parent: Opłaty obowiązkowe)
+```
+
+**Korzyści**:
+- AI będzie wiedział, że Ikano to bank = prawdopodobnie raty
+- AI rozpozna PGE jako rachunki za prąd
+- AI przypisze WARTA do ubezpieczeń
+
+**Wymagane zmiany**:
+- `AiCategorizationPromptBuilder.getSystemPrompt()` - rozszerzyć o słownik
+
+---
+
+### Pomysł 3: Grupowanie po tytule dla znanych banków
+
+**Obserwacja**: Dla kontrahentów będących bankami, nazwa kontrahenta jest mało informacyjna. Tytuł operacji ("rata kredytu") jest kluczowy.
+
+**Zmiana**: W `PatternDeduplicator` dla kontrahentów rozpoznanych jako banki, grupować dodatkowo po tytule.
+
+**Przed** (1 grupa):
+```
+LUCJAN BIK PEKAO [74 txns] → Inne wydatki
+```
+
+**Po** (2 grupy):
+```
+LUCJAN BIK PEKAO / zycie [66 txns] → Oszczędności
+LUCJAN BIK PEKAO / mieszkanie kredyt [8 txns] → Kredyty
+```
+
+**Wymagane zmiany**:
+- Lista znanych banków (hardcoded lub konfiguracja)
+- Logika w `PatternDeduplicator.deduplicate()` - dla banków grupować po `name + title`
+
+---
+
+### Pomysł 4: Dwuetapowa kategoryzacja
+
+**Etap 1**: Obecne podejście - kategoryzacja po kontrahentach
+**Etap 2**: Dla kategorii "Inne wydatki" z > 10 transakcjami - drugie przejście AI analizujące tytuły
+
+**Korzyści**:
+- Nie zmienia obecnego flow dla prostych przypadków
+- Dodatkowa granularność tylko gdzie potrzebna
+
+**Wady**:
+- Podwójny koszt AI dla niektórych transakcji
+- Bardziej skomplikowany flow
+
+---
+
+### Pomysł 5: Heurystyki pre-AI
+
+**Zmiana**: Przed wysłaniem do AI, zastosować deterministyczne reguły.
+
+```java
+// Pre-AI rules
+if (counterparty.contains("ZUS")) → category: "ZUS", parent: "Opłaty obowiązkowe"
+if (counterparty.contains("Urząd Skarbowy")) → category: "Podatki", parent: "Opłaty obowiązkowe"
+if (title.contains("rata kredytu") || title.contains("kredyt")) → category: "Kredyty"
+if (title.contains("czynsz")) → category: "Mieszkanie"
+if (counterparty in KNOWN_BANKS && title.contains("rata")) → category: "Kredyty"
+```
+
+**Korzyści**:
+- Deterministyczne, przewidywalne wyniki
+- Szybsze (nie czeka na AI)
+- Tańsze (mniej tokenów do AI)
+
+**Wady**:
+- Wymaga utrzymania listy reguł
+- Może być zbyt sztywne
+
+---
+
+## Rekomendacja
+
+### Faza 1 (Quick Win): Pomysł 1 + 2
+
+1. **Rozszerzyć prompt o common titles** - pokazać AI najczęstsze tytuły dla każdego wzorca
+2. **Dodać słownik polskich instytucji** - dać AI wiedzę domenową
+
+**Dlaczego**:
+- Minimalny refaktor kodu
+- Nie zmienia architektury
+- Wykorzystuje istniejące dane (tytuły są już w transakcjach)
+
+### Faza 2 (Opcjonalnie): Pomysł 3
+
+Jeśli Faza 1 nie da wystarczającej granularności, rozważyć grupowanie po tytule dla banków.
+
+---
+
+## Pliki do zmiany (Faza 1)
+
+| Plik | Zmiana |
+|------|--------|
+| `PatternDeduplicator.java` | Dodać `commonTitles` do `PatternGroup` |
+| `AiCategorizationPromptBuilder.java` | Wyświetlić common titles w promptcie |
+| `AiCategorizationPromptBuilder.java` | Rozszerzyć system prompt o słownik instytucji |
+
+---
+
+## Przykład oczekiwanego wyniku po zmianach
+
+**Przed**:
+```
+OUTFLOW:
+  Opłaty obowiązkowe
+    - ZUS
+    - Urząd skarbowy
+  Inne wydatki (585 txns)
+    - Lucjan Bik, Ikano, Santander, Credit Agricole, PGE, WARTA...
+```
+
+**Po**:
+```
+OUTFLOW:
+  Opłaty obowiązkowe
+    - ZUS
+    - Podatki (Urząd skarbowy)
+    - Rachunki (PGE)
+  Kredyty i raty
+    - Kredyt hipoteczny (mBank)
+    - Raty Ikano
+    - Raty Santander
+    - Raty Credit Agricole
+  Mieszkanie
+    - Czynsz (Silva Silva)
+  Ubezpieczenia
+    - WARTA
+  Księgowość
+    - IFIRMA
+  Inne wydatki
+    - Przelewy własne (Lucjan Bik Pekao)
+```

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/AiPromptBuilder.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/AiPromptBuilder.java
@@ -34,8 +34,29 @@ public class AiPromptBuilder {
         - type: INFLOW (positive/credit) or OUTFLOW (negative/debit)
         - operationDate: YYYY-MM-DD format (REQUIRED)
         - bookingDate: YYYY-MM-DD format (same as operationDate if not available)
-        - sourceAccountNumber: sender's IBAN for INFLOW, empty for OUTFLOW (see IBAN NORMALIZATION)
-        - targetAccountNumber: recipient's IBAN for OUTFLOW, empty for INFLOW (see IBAN NORMALIZATION)
+        - sourceAccountNumber: COUNTERPARTY account for INFLOW transactions (the person/company who sent money to you)
+        - targetAccountNumber: COUNTERPARTY account for OUTFLOW transactions (the person/company you paid)
+
+        CRITICAL ACCOUNT NUMBER PLACEMENT RULE (READ CAREFULLY):
+        The bank CSV column "Numer rachunku kontrahenta" contains the counterparty account number.
+        You MUST place it in the CORRECT column based on transaction type:
+
+        IF type=INFLOW (money coming IN to your account):
+          - sourceAccountNumber = counterparty account (who SENT money)
+          - targetAccountNumber = EMPTY (leave blank)
+
+        IF type=OUTFLOW (money going OUT of your account):
+          - sourceAccountNumber = EMPTY (leave blank)
+          - targetAccountNumber = counterparty account (who RECEIVED money)
+
+        EXAMPLES:
+        - INFLOW from MINDBOX (account 82109018830000000109874194):
+          ...,INFLOW,2025-12-11,2025-12-11,PL82109018830000000109874194,,
+          (sourceAccountNumber filled, targetAccountNumber empty)
+
+        - OUTFLOW to ZUS (account 83101010230000261395100000):
+          ...,OUTFLOW,2025-12-11,2025-12-11,,PL83101010230000261395100000,
+          (sourceAccountNumber empty, targetAccountNumber filled)
 
         ## IBAN NORMALIZATION (CRITICAL):
         Account numbers MUST be normalized to full IBAN format with country prefix:

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionDto.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionDto.java
@@ -133,6 +133,7 @@ public class BankDataIngestionDto {
         private ZonedDateTime paidDate;
         private String merchant;
         private Double merchantConfidence;
+        private String counterpartyAccount;
     }
 
     @Data

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionRestController.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/BankDataIngestionRestController.java
@@ -621,7 +621,8 @@ public class BankDataIngestionRestController {
                 json.getType(),
                 json.getPaidDate(),
                 json.getMerchant(),
-                json.getMerchantConfidence()
+                json.getMerchantConfidence(),
+                json.getCounterpartyAccount()
         );
     }
 

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/categorization/PatternDeduplicator.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/categorization/PatternDeduplicator.java
@@ -15,9 +15,16 @@ import java.util.stream.Collectors;
  * Takes N transactions and deduplicates them into M unique patterns (M << N).
  * This reduces the number of patterns sent to AI, significantly lowering costs.
  *
+ * Uses hybrid grouping:
+ * 1. First groups by normalized pattern + type
+ * 2. Then merges groups that share the same counterpartyAccount (bank account number)
+ *
+ * This solves the "Mindbox problem" where the same recipient appears with different
+ * name variants (e.g., "MINDBOX SP. Z O.O.", "MINDBOX SP.Z O.O.") but same bank account.
+ *
  * Example:
  * - Input: 402 transactions
- * - Output: 45 unique patterns
+ * - Output: 45 unique patterns (after merging by counterpartyAccount)
  */
 @Component
 @RequiredArgsConstructor
@@ -31,6 +38,9 @@ public class PatternDeduplicator {
      * IMPORTANT: When merchant is available (extracted by AI), use it for grouping
      * instead of the name. This separates transactions like "BANK PEKAO S.A."
      * into individual merchants (BADOO, NETFLIX, OPENAI, etc.).
+     *
+     * After initial grouping, performs hybrid merging by counterpartyAccount
+     * to merge groups that have the same bank account but different name patterns.
      *
      * @param transactions the staged transactions to group
      * @return a list of pattern groups, sorted by transaction count (descending)
@@ -48,6 +58,7 @@ public class PatternDeduplicator {
             String originalName = transaction.originalData().name();
             String merchant = transaction.originalData().merchant();
             Double merchantConfidence = transaction.originalData().merchantConfidence();
+            String counterpartyAccount = transaction.originalData().counterpartyAccount();
 
             // Use effectiveMerchant for grouping: merchant if available, otherwise name
             String patternSource = transaction.originalData().effectiveMerchant();
@@ -64,13 +75,21 @@ public class PatternDeduplicator {
                             transaction.originalData().money().getAmount(),
                             transaction.originalData().bankCategory(),
                             merchant,
-                            merchantConfidence
+                            merchantConfidence,
+                            counterpartyAccount
                     ));
         }
 
         // Convert to PatternGroup objects
-        return groups.entrySet().stream()
+        List<PatternGroup> patternGroups = groups.entrySet().stream()
                 .map(entry -> createPatternGroup(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        // Phase 2: Merge groups by counterpartyAccount (hybrid grouping)
+        List<PatternGroup> mergedGroups = mergeGroupsByCounterpartyAccount(patternGroups);
+
+        // Sort by transaction count (descending)
+        return mergedGroups.stream()
                 .sorted(Comparator.comparingInt(PatternGroup::transactionCount).reversed())
                 .toList();
     }
@@ -114,6 +133,7 @@ public class PatternDeduplicator {
 
         // Get most common bank category
         String mostCommonBankCategory = transactions.stream()
+                .filter(t -> t.bankCategory() != null)
                 .collect(Collectors.groupingBy(TransactionInfo::bankCategory, Collectors.counting()))
                 .entrySet().stream()
                 .max(Comparator.comparingLong(Map.Entry::getValue))
@@ -125,6 +145,16 @@ public class PatternDeduplicator {
                 .map(TransactionInfo::transactionId)
                 .toList();
 
+        // Get most common counterpartyAccount (for hybrid grouping)
+        String mostCommonCounterpartyAccount = transactions.stream()
+                .map(TransactionInfo::counterpartyAccount)
+                .filter(acc -> acc != null && !acc.isBlank())
+                .collect(Collectors.groupingBy(acc -> acc, Collectors.counting()))
+                .entrySet().stream()
+                .max(Comparator.comparingLong(Map.Entry::getValue))
+                .map(Map.Entry::getKey)
+                .orElse(null);
+
         return new PatternGroup(
                 key.pattern(),
                 sampleTransaction,
@@ -135,8 +165,167 @@ public class PatternDeduplicator {
                 transactions.size(),
                 totalAmount,
                 mostCommonBankCategory,
-                transactionIds
+                transactionIds,
+                mostCommonCounterpartyAccount
         );
+    }
+
+    /**
+     * Merges pattern groups that share the same counterpartyAccount.
+     *
+     * This solves the "Mindbox problem" where the same recipient appears with different
+     * name variants (e.g., "MINDBOX SP. Z O.O.", "MINDBOX SP.Z O.O.") but same bank account.
+     *
+     * Algorithm:
+     * 1. Group patterns by (counterpartyAccount, type) - only non-null accounts
+     * 2. If multiple patterns share the same account, merge them
+     * 3. Use common prefix or shortest pattern as merged pattern name
+     *
+     * @param groups list of pattern groups to potentially merge
+     * @return merged list with groups sharing counterpartyAccount combined
+     */
+    private List<PatternGroup> mergeGroupsByCounterpartyAccount(List<PatternGroup> groups) {
+        // Separate groups with and without counterpartyAccount
+        Map<AccountKey, List<PatternGroup>> groupsByAccount = new HashMap<>();
+        List<PatternGroup> groupsWithoutAccount = new ArrayList<>();
+
+        for (PatternGroup group : groups) {
+            if (group.counterpartyAccount() != null && !group.counterpartyAccount().isBlank()) {
+                AccountKey key = new AccountKey(group.counterpartyAccount(), group.type());
+                groupsByAccount.computeIfAbsent(key, k -> new ArrayList<>()).add(group);
+            } else {
+                groupsWithoutAccount.add(group);
+            }
+        }
+
+        // Merge groups that share the same counterpartyAccount
+        List<PatternGroup> mergedGroups = new ArrayList<>(groupsWithoutAccount);
+
+        for (Map.Entry<AccountKey, List<PatternGroup>> entry : groupsByAccount.entrySet()) {
+            List<PatternGroup> accountGroups = entry.getValue();
+
+            if (accountGroups.size() == 1) {
+                // Only one group for this account - no merge needed
+                mergedGroups.add(accountGroups.get(0));
+            } else {
+                // Multiple groups share same account - merge them
+                PatternGroup merged = mergePatternGroups(accountGroups, entry.getKey());
+                mergedGroups.add(merged);
+            }
+        }
+
+        return mergedGroups;
+    }
+
+    /**
+     * Key for grouping by counterpartyAccount.
+     */
+    private record AccountKey(String account, Type type) {
+    }
+
+    /**
+     * Merges multiple pattern groups into one.
+     */
+    private PatternGroup mergePatternGroups(List<PatternGroup> groups, AccountKey key) {
+        // Find common prefix of all patterns
+        String mergedPattern = findCommonPrefix(
+                groups.stream().map(PatternGroup::pattern).toList()
+        );
+
+        // If no common prefix found, use the shortest pattern
+        if (mergedPattern.isEmpty() || mergedPattern.length() < 3) {
+            mergedPattern = groups.stream()
+                    .min(Comparator.comparingInt(g -> g.pattern().length()))
+                    .map(PatternGroup::pattern)
+                    .orElse("");
+        }
+
+        // Use sample from group with highest transaction count
+        PatternGroup dominantGroup = groups.stream()
+                .max(Comparator.comparingInt(PatternGroup::transactionCount))
+                .orElse(groups.get(0));
+
+        // Aggregate values
+        int totalTransactionCount = groups.stream()
+                .mapToInt(PatternGroup::transactionCount)
+                .sum();
+
+        BigDecimal totalAmount = groups.stream()
+                .map(PatternGroup::totalAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Combine all transaction IDs
+        List<String> allTransactionIds = groups.stream()
+                .flatMap(g -> g.transactionIds().stream())
+                .toList();
+
+        // Use most common bank category across all groups
+        String mostCommonBankCategory = groups.stream()
+                .filter(g -> g.bankCategory() != null && !g.bankCategory().isBlank())
+                .collect(Collectors.groupingBy(
+                        PatternGroup::bankCategory,
+                        Collectors.summingInt(PatternGroup::transactionCount)
+                ))
+                .entrySet().stream()
+                .max(Comparator.comparingInt(Map.Entry::getValue))
+                .map(Map.Entry::getKey)
+                .orElse(dominantGroup.bankCategory());
+
+        // Calculate weighted average merchant confidence
+        double totalWeightedConfidence = groups.stream()
+                .filter(g -> g.averageMerchantConfidence() != null)
+                .mapToDouble(g -> g.averageMerchantConfidence() * g.transactionCount())
+                .sum();
+        int confidenceCount = groups.stream()
+                .filter(g -> g.averageMerchantConfidence() != null)
+                .mapToInt(PatternGroup::transactionCount)
+                .sum();
+        Double averageMerchantConfidence = confidenceCount > 0
+                ? totalWeightedConfidence / confidenceCount
+                : null;
+
+        return new PatternGroup(
+                mergedPattern,
+                dominantGroup.sampleTransaction(),
+                dominantGroup.sampleMerchant(),
+                averageMerchantConfidence,
+                dominantGroup.sampleDescription(),
+                key.type(),
+                totalTransactionCount,
+                totalAmount,
+                mostCommonBankCategory,
+                allTransactionIds,
+                key.account()
+        );
+    }
+
+    /**
+     * Finds the longest common prefix of multiple strings.
+     */
+    private String findCommonPrefix(List<String> strings) {
+        if (strings == null || strings.isEmpty()) {
+            return "";
+        }
+        if (strings.size() == 1) {
+            return strings.get(0);
+        }
+
+        String first = strings.get(0);
+        int prefixLength = first.length();
+
+        for (int i = 1; i < strings.size(); i++) {
+            String current = strings.get(i);
+            prefixLength = Math.min(prefixLength, current.length());
+
+            for (int j = 0; j < prefixLength; j++) {
+                if (first.charAt(j) != current.charAt(j)) {
+                    prefixLength = j;
+                    break;
+                }
+            }
+        }
+
+        return first.substring(0, prefixLength).trim();
     }
 
     /**
@@ -155,7 +344,8 @@ public class PatternDeduplicator {
             BigDecimal amount,
             String bankCategory,
             String merchant,
-            Double merchantConfidence
+            Double merchantConfidence,
+            String counterpartyAccount
     ) {
     }
 
@@ -172,7 +362,8 @@ public class PatternDeduplicator {
             int transactionCount,
             BigDecimal totalAmount,
             String bankCategory,
-            List<String> transactionIds
+            List<String> transactionIds,
+            String counterpartyAccount
     ) {
         /**
          * Returns a shortened pattern for display (max 30 chars).

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/commands/stage_transactions/StageTransactionsCommand.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/commands/stage_transactions/StageTransactionsCommand.java
@@ -32,6 +32,7 @@ public record StageTransactionsCommand(
      * @param paidDate          when the transaction was paid
      * @param merchant          extracted merchant name (nullable) - for bank intermediary transactions
      * @param merchantConfidence confidence score for merchant extraction (0.0-1.0, nullable)
+     * @param counterpartyAccount the other party's bank account number (for OUTFLOW: recipient, for INFLOW: sender)
      */
     public record BankTransaction(
             String bankTransactionId,
@@ -42,7 +43,8 @@ public record StageTransactionsCommand(
             Type type,
             ZonedDateTime paidDate,
             String merchant,
-            Double merchantConfidence
+            Double merchantConfidence,
+            String counterpartyAccount
     ) {
     }
 }

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/commands/stage_transactions/StageTransactionsCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/commands/stage_transactions/StageTransactionsCommandHandler.java
@@ -209,7 +209,8 @@ public class StageTransactionsCommandHandler
                 txn.type(),
                 txn.paidDate(),
                 txn.merchant(),
-                txn.merchantConfidence()
+                txn.merchantConfidence(),
+                txn.counterpartyAccount()
         );
 
         // Priority 0: Direct bankCategory match to existing CashFlow category (case-insensitive)

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/commands/upload_csv/UploadCsvCommandHandler.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/commands/upload_csv/UploadCsvCommandHandler.java
@@ -87,7 +87,8 @@ public class UploadCsvCommandHandler
                 row.type(),
                 paidDate,
                 row.merchant(),
-                row.merchantConfidence()
+                row.merchantConfidence(),
+                row.counterpartyAccount()
         );
     }
 

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/domain/BankCsvRow.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/domain/BankCsvRow.java
@@ -128,4 +128,30 @@ public record BankCsvRow(
         return merchant != null && !merchant.isBlank()
                 && merchantConfidence != null && merchantConfidence >= 0.7;
     }
+
+    /**
+     * Returns the counterparty account number (the other party's bank account).
+     * AI may put the account in either column, so we check both:
+     * - First, we try the semantically correct column based on type
+     * - If that's empty, we fall back to the other column
+     * For OUTFLOW: prefer targetAccountNumber (recipient), fallback to sourceAccountNumber
+     * For INFLOW: prefer sourceAccountNumber (sender), fallback to targetAccountNumber
+     */
+    public String counterpartyAccount() {
+        if (type == Type.OUTFLOW) {
+            // OUTFLOW: recipient's account should be in targetAccountNumber
+            if (targetAccountNumber != null && !targetAccountNumber.isBlank()) {
+                return targetAccountNumber;
+            }
+            // Fallback: AI might have put it in sourceAccountNumber
+            return sourceAccountNumber;
+        } else {
+            // INFLOW: sender's account should be in sourceAccountNumber
+            if (sourceAccountNumber != null && !sourceAccountNumber.isBlank()) {
+                return sourceAccountNumber;
+            }
+            // Fallback: AI might have put it in targetAccountNumber
+            return targetAccountNumber;
+        }
+    }
 }

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/domain/OriginalTransactionData.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/domain/OriginalTransactionData.java
@@ -17,6 +17,7 @@ import java.time.ZonedDateTime;
  * @param paidDate          when the transaction was paid
  * @param merchant          extracted merchant name (from description for bank intermediary transactions)
  * @param merchantConfidence confidence score for merchant extraction (0.0 - 1.0)
+ * @param counterpartyAccount the other party's bank account number (for OUTFLOW: recipient, for INFLOW: sender)
  */
 public record OriginalTransactionData(
         String bankTransactionId,
@@ -27,7 +28,8 @@ public record OriginalTransactionData(
         Type type,
         ZonedDateTime paidDate,
         String merchant,
-        Double merchantConfidence
+        Double merchantConfidence,
+        String counterpartyAccount
 ) {
     /**
      * Returns effective merchant (name if merchant is null).

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/infrastructure/entity/StagedTransactionEntity.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/infrastructure/entity/StagedTransactionEntity.java
@@ -60,6 +60,7 @@ public class StagedTransactionEntity {
         private Date paidDate;
         private String merchant;
         private Double merchantConfidence;
+        private String counterpartyAccount;
 
         public static OriginalDataDocument fromDomain(OriginalTransactionData data) {
             return OriginalDataDocument.builder()
@@ -73,6 +74,7 @@ public class StagedTransactionEntity {
                     .paidDate(Date.from(data.paidDate().toInstant()))
                     .merchant(data.merchant())
                     .merchantConfidence(data.merchantConfidence())
+                    .counterpartyAccount(data.counterpartyAccount())
                     .build();
         }
 
@@ -86,7 +88,8 @@ public class StagedTransactionEntity {
                     type,
                     ZonedDateTime.ofInstant(paidDate.toInstant(), ZoneOffset.UTC),
                     merchant,
-                    merchantConfidence
+                    merchantConfidence,
+                    counterpartyAccount
             );
         }
     }

--- a/src/test/java/com/multi/vidulum/bank_data_ingestion/app/categorization/AiCategorizationPromptBuilderTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_ingestion/app/categorization/AiCategorizationPromptBuilderTest.java
@@ -69,7 +69,8 @@ class AiCategorizationPromptBuilderTest {
                         3,
                         new BigDecimal("150.00"),
                         "Zakupy",
-                        List.of("tx1", "tx2", "tx3")
+                        List.of("tx1", "tx2", "tx3"),
+                        null // counterpartyAccount
                 )
         );
 
@@ -138,7 +139,8 @@ class AiCategorizationPromptBuilderTest {
                         1,
                         new BigDecimal("49.99"),
                         "Subscriptions",
-                        List.of("tx1")
+                        List.of("tx1"),
+                        null // counterpartyAccount
                 ),
                 new PatternDeduplicator.PatternGroup(
                         "WYPLATA",
@@ -150,7 +152,8 @@ class AiCategorizationPromptBuilderTest {
                         1,
                         new BigDecimal("8500.00"),
                         "Przychody",
-                        List.of("tx2")
+                        List.of("tx2"),
+                        null // counterpartyAccount
                 )
         );
 
@@ -180,7 +183,8 @@ class AiCategorizationPromptBuilderTest {
                         1,
                         new BigDecimal("10.00"),
                         "",
-                        List.of("tx1")
+                        List.of("tx1"),
+                        null // counterpartyAccount
                 )
         );
 
@@ -209,7 +213,8 @@ class AiCategorizationPromptBuilderTest {
                         1,
                         new BigDecimal("2500.00"),
                         "Przelewy wychodzące",
-                        List.of("tx1")
+                        List.of("tx1"),
+                        null // counterpartyAccount
                 )
         );
 

--- a/src/test/java/com/multi/vidulum/bank_data_ingestion/app/categorization/AiCategorizationResponseParserTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_ingestion/app/categorization/AiCategorizationResponseParserTest.java
@@ -60,7 +60,8 @@ class AiCategorizationResponseParserTest {
                         5,
                         new BigDecimal("250.00"),
                         "",
-                        List.of("tx1", "tx2", "tx3", "tx4", "tx5")
+                        List.of("tx1", "tx2", "tx3", "tx4", "tx5"),
+                        null // counterpartyAccount
                 )
         );
 
@@ -118,21 +119,21 @@ class AiCategorizationResponseParserTest {
                         "Biedronka", null, null, "",
                         Type.OUTFLOW,
                         1, new BigDecimal("50.00"),
-                        "", List.of("tx1")
+                        "", List.of("tx1"), null
                 ),
                 new PatternDeduplicator.PatternGroup(
                         "XYZ123ABC",
                         "XYZ123ABC", null, null, "",
                         Type.OUTFLOW,
                         2, new BigDecimal("100.00"),
-                        "", List.of("tx2", "tx3")
+                        "", List.of("tx2", "tx3"), null
                 ),
                 new PatternDeduplicator.PatternGroup(
                         "UNKNOWN_REF_999",
                         "Unknown ref", null, null, "",
                         Type.INFLOW,
                         1, new BigDecimal("500.00"),
-                        "", List.of("tx4")
+                        "", List.of("tx4"), null
                 )
         );
 
@@ -180,7 +181,7 @@ class AiCategorizationResponseParserTest {
                         "Test", null, null, "",
                         Type.OUTFLOW,
                         1, new BigDecimal("10.00"),
-                        "", List.of("tx1")
+                        "", List.of("tx1"), null
                 )
         );
 
@@ -241,7 +242,7 @@ class AiCategorizationResponseParserTest {
                         "Test", null, null, "",
                         Type.OUTFLOW,
                         1, new BigDecimal("10.00"),
-                        "", List.of("tx1")
+                        "", List.of("tx1"), null
                 )
         );
 
@@ -315,12 +316,12 @@ class AiCategorizationResponseParserTest {
                 """;
 
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
-                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 3, new BigDecimal("150.00"), "", List.of()),
-                new PatternDeduplicator.PatternGroup("RESTAURACJA", "Restauracja", null, null, "", Type.OUTFLOW, 2, new BigDecimal("100.00"), "", List.of()),
-                new PatternDeduplicator.PatternGroup("ORLEN", "Orlen", null, null, "", Type.OUTFLOW, 4, new BigDecimal("400.00"), "", List.of()),
-                new PatternDeduplicator.PatternGroup("ZTM", "ZTM", null, null, "", Type.OUTFLOW, 5, new BigDecimal("50.00"), "", List.of()),
-                new PatternDeduplicator.PatternGroup("PENSJA", "Pensja", null, null, "", Type.INFLOW, 1, new BigDecimal("5000.00"), "", List.of()),
-                new PatternDeduplicator.PatternGroup("PREMIA", "Premia", null, null, "", Type.INFLOW, 1, new BigDecimal("1000.00"), "", List.of())
+                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 3, new BigDecimal("150.00"), "", List.of(), null),
+                new PatternDeduplicator.PatternGroup("RESTAURACJA", "Restauracja", null, null, "", Type.OUTFLOW, 2, new BigDecimal("100.00"), "", List.of(), null),
+                new PatternDeduplicator.PatternGroup("ORLEN", "Orlen", null, null, "", Type.OUTFLOW, 4, new BigDecimal("400.00"), "", List.of(), null),
+                new PatternDeduplicator.PatternGroup("ZTM", "ZTM", null, null, "", Type.OUTFLOW, 5, new BigDecimal("50.00"), "", List.of(), null),
+                new PatternDeduplicator.PatternGroup("PENSJA", "Pensja", null, null, "", Type.INFLOW, 1, new BigDecimal("5000.00"), "", List.of(), null),
+                new PatternDeduplicator.PatternGroup("PREMIA", "Premia", null, null, "", Type.INFLOW, 1, new BigDecimal("1000.00"), "", List.of(), null)
         );
 
         // when
@@ -362,7 +363,7 @@ class AiCategorizationResponseParserTest {
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
                 new PatternDeduplicator.PatternGroup(
                         "BIEDRONKA", "Biedronka zakupy", null, null, "", Type.OUTFLOW,
-                        5, new BigDecimal("250.00"), "", List.of()
+                        5, new BigDecimal("250.00"), "", List.of(), null
                 )
         );
 
@@ -401,8 +402,8 @@ class AiCategorizationResponseParserTest {
                 """;
 
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
-                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("250.00"), "", List.of()),
-                new PatternDeduplicator.PatternGroup("PIZZERIA", "Pizzeria", null, null, "", Type.OUTFLOW, 3, new BigDecimal("150.00"), "", List.of())
+                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("250.00"), "", List.of(), null),
+                new PatternDeduplicator.PatternGroup("PIZZERIA", "Pizzeria", null, null, "", Type.OUTFLOW, 3, new BigDecimal("150.00"), "", List.of(), null)
         );
 
         // when
@@ -445,8 +446,8 @@ class AiCategorizationResponseParserTest {
 
         // Note: No INFLOW patterns - "Wynagrodzenie" has 0 transactions
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
-                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("250.00"), "", List.of()),
-                new PatternDeduplicator.PatternGroup("PIZZERIA", "Pizzeria", null, null, "", Type.OUTFLOW, 3, new BigDecimal("150.00"), "", List.of())
+                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("250.00"), "", List.of(), null),
+                new PatternDeduplicator.PatternGroup("PIZZERIA", "Pizzeria", null, null, "", Type.OUTFLOW, 3, new BigDecimal("150.00"), "", List.of(), null)
         );
 
         // when
@@ -486,8 +487,8 @@ class AiCategorizationResponseParserTest {
                 """;
 
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
-                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("250.00"), "", List.of()),
-                new PatternDeduplicator.PatternGroup("LIDL", "Lidl", null, null, "", Type.OUTFLOW, 3, new BigDecimal("150.00"), "", List.of())
+                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("250.00"), "", List.of(), null),
+                new PatternDeduplicator.PatternGroup("LIDL", "Lidl", null, null, "", Type.OUTFLOW, 3, new BigDecimal("150.00"), "", List.of(), null)
         );
 
         // when
@@ -527,7 +528,7 @@ class AiCategorizationResponseParserTest {
 
         // Only "Sklepy spożywcze" has transactions, "Restauracje" has 0
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
-                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("250.00"), "", List.of())
+                new PatternDeduplicator.PatternGroup("BIEDRONKA", "Biedronka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("250.00"), "", List.of(), null)
         );
 
         // when
@@ -587,8 +588,8 @@ class AiCategorizationResponseParserTest {
 
         // Bank category groups
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
-                new PatternDeduplicator.PatternGroup("TX1", "Transfer 1", null, null, "", Type.OUTFLOW, 3, new BigDecimal("300.00"), "Przelewy wychodzące", List.of()),
-                new PatternDeduplicator.PatternGroup("TX2", "Transfer 2", null, null, "", Type.OUTFLOW, 2, new BigDecimal("200.00"), "Przelewy wychodzące", List.of())
+                new PatternDeduplicator.PatternGroup("TX1", "Transfer 1", null, null, "", Type.OUTFLOW, 3, new BigDecimal("300.00"), "Przelewy wychodzące", List.of(), null),
+                new PatternDeduplicator.PatternGroup("TX2", "Transfer 2", null, null, "", Type.OUTFLOW, 2, new BigDecimal("200.00"), "Przelewy wychodzące", List.of(), null)
         );
 
         // when
@@ -630,7 +631,7 @@ class AiCategorizationResponseParserTest {
                         "ZABKA", "Zabka zakupy", null, null, "",
                         Type.OUTFLOW, 5, new BigDecimal("100.00"),
                         "TRANSAKCJA KARTĄ PŁATNICZĄ",  // ← actual bankCategory from bank
-                        List.of()
+                        List.of(), null
                 )
         );
 
@@ -662,8 +663,8 @@ class AiCategorizationResponseParserTest {
                 """;
 
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
-                new PatternDeduplicator.PatternGroup("TX1", "Transfer", null, null, "", Type.OUTFLOW, 3, new BigDecimal("300.00"), "PRZELEW", List.of()),
-                new PatternDeduplicator.PatternGroup("TX2", "Salary", null, null, "", Type.INFLOW, 1, new BigDecimal("5000.00"), "WPŁYWY REGULARNE", List.of())
+                new PatternDeduplicator.PatternGroup("TX1", "Transfer", null, null, "", Type.OUTFLOW, 3, new BigDecimal("300.00"), "PRZELEW", List.of(), null),
+                new PatternDeduplicator.PatternGroup("TX2", "Salary", null, null, "", Type.INFLOW, 1, new BigDecimal("5000.00"), "WPŁYWY REGULARNE", List.of(), null)
         );
 
         // when
@@ -713,9 +714,9 @@ class AiCategorizationResponseParserTest {
 
         // All transactions have the same generic bankCategory
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
-                new PatternDeduplicator.PatternGroup("ZABKA", "Zabka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("100.00"), "TRANSAKCJA KARTĄ PŁATNICZĄ", List.of()),
-                new PatternDeduplicator.PatternGroup("NETFLIX", "Netflix", null, null, "", Type.OUTFLOW, 3, new BigDecimal("50.00"), "TRANSAKCJA KARTĄ PŁATNICZĄ", List.of()),
-                new PatternDeduplicator.PatternGroup("ORLEN", "Orlen", null, null, "", Type.OUTFLOW, 4, new BigDecimal("400.00"), "TRANSAKCJA KARTĄ PŁATNICZĄ", List.of())
+                new PatternDeduplicator.PatternGroup("ZABKA", "Zabka", null, null, "", Type.OUTFLOW, 5, new BigDecimal("100.00"), "TRANSAKCJA KARTĄ PŁATNICZĄ", List.of(), null),
+                new PatternDeduplicator.PatternGroup("NETFLIX", "Netflix", null, null, "", Type.OUTFLOW, 3, new BigDecimal("50.00"), "TRANSAKCJA KARTĄ PŁATNICZĄ", List.of(), null),
+                new PatternDeduplicator.PatternGroup("ORLEN", "Orlen", null, null, "", Type.OUTFLOW, 4, new BigDecimal("400.00"), "TRANSAKCJA KARTĄ PŁATNICZĄ", List.of(), null)
         );
 
         // when
@@ -744,7 +745,7 @@ class AiCategorizationResponseParserTest {
                 """;
 
         List<PatternDeduplicator.PatternGroup> patterns = List.of(
-                new PatternDeduplicator.PatternGroup("TX1", "Transfer", null, null, "", Type.OUTFLOW, 3, new BigDecimal("300.00"), "PRZELEW", List.of())
+                new PatternDeduplicator.PatternGroup("TX1", "Transfer", null, null, "", Type.OUTFLOW, 3, new BigDecimal("300.00"), "PRZELEW", List.of(), null)
         );
 
         // when


### PR DESCRIPTION
## Summary

  - Add `counterpartyAccount` field to transaction data model to track the other party's bank account number
  - Implement hybrid pattern grouping in `PatternDeduplicator` that merges transaction patterns sharing the same bank account
  - Add fallback logic in `BankCsvRow.counterpartyAccount()` to handle AI placing account in wrong column

  ### New Field: `counterpartyAccount`
  - `OriginalTransactionData` - added `counterpartyAccount` field
  - `StagedTransactionEntity` - persistence support
  - `BankCsvRow.counterpartyAccount()` - smart accessor with fallback logic for AI column placement errors

  ### Hybrid Pattern Grouping
  - `PatternDeduplicator.mergeGroupsByCounterpartyAccount()` - merges pattern groups that share the same (counterpartyAccount, type) tuple
  - Uses common prefix or shortest pattern name for merged group

  ### AI Prompt Improvements
  - `AiPromptBuilder` - explicit instructions for account column placement (sourceAccountNumber vs targetAccountNumber based on INFLOW/OUTFLOW type)

