### PR TITLE
VID-154: Add AI-powered transaction enrichment with merchant extraction and classification

### DIFF
--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/AiBankCsvTransformService.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/AiBankCsvTransformService.java
@@ -1,5 +1,7 @@
 package com.multi.vidulum.bank_data_adapter.app;
 
+import com.multi.vidulum.bank_data_adapter.app.enrichment.EnrichmentResult;
+import com.multi.vidulum.bank_data_adapter.app.enrichment.TransactionEnrichmentService;
 import com.multi.vidulum.bank_data_adapter.domain.AiCsvTransformationDocument;
 import com.multi.vidulum.bank_data_adapter.domain.AiCsvTransformationRepository;
 import com.multi.vidulum.bank_data_adapter.domain.DetectionResult;
@@ -62,6 +64,7 @@ public class AiBankCsvTransformService {
     private final MappingRulesCacheService mappingRulesCacheService;
     private final AiCsvTransformationRepository transformationRepository;
     private final CsvFormatDetector csvFormatDetector;
+    private final TransactionEnrichmentService enrichmentService;
     private final Clock clock;
 
     @Value("${bank-data-adapter.max-file-size-bytes:5242880}")
@@ -189,6 +192,49 @@ public class AiBankCsvTransformService {
         } else {
             // No rules available - use direct AI
             return transformWithDirectAi(document, csvString, bankHint, startTime);
+        }
+
+        // ========== ETAP 2: ENRICHMENT ==========
+        // Fill merchant and bankCategory for all transactions using AI
+        if (enrichmentService.needsEnrichment(transformedCsv)) {
+            log.info("🔄 ENRICHMENT: Starting enrichment for {} rows", rowCount);
+            try {
+                EnrichmentResult enrichmentResult = enrichmentService.enrich(
+                        transformedCsv,
+                        rules.getBankName(),
+                        rules.getLanguage()
+                );
+
+                if (enrichmentResult.isEnrichmentApplied()) {
+                    transformedCsv = enrichmentResult.getEnrichedCsvContent();
+                    warnings.addAll(enrichmentResult.getWarnings());
+
+                    // Update document with enrichment stats
+                    document.setEnrichmentApplied(true);
+                    document.setEnrichedAt(AiCsvTransformationDocument.toDate(ZonedDateTime.now(clock)));
+                    document.setEnrichmentTimeMs(enrichmentResult.getProcessingTimeMs());
+                    document.setEnrichmentAiCalls(enrichmentResult.getAiCallCount());
+                    document.setMerchantsExtracted(enrichmentResult.getMerchantsExtracted());
+                    document.setBankCategoriesInferred(enrichmentResult.getBankCategoriesInferred());
+                    document.setBankCategoriesKept(enrichmentResult.getBankCategoriesKept());
+                    document.setEnrichmentFallbackCount(enrichmentResult.getFallbackCount());
+                    document.setEnrichmentNotes(enrichmentResult.getProcessingNotes());
+
+                    log.info("✅ ENRICHMENT completed: {} merchants extracted, {} categories inferred, {} kept, {}ms",
+                            enrichmentResult.getMerchantsExtracted(),
+                            enrichmentResult.getBankCategoriesInferred(),
+                            enrichmentResult.getBankCategoriesKept(),
+                            enrichmentResult.getProcessingTimeMs());
+                }
+            } catch (Exception e) {
+                log.error("❌ ENRICHMENT failed, continuing with unenriched CSV", e);
+                warnings.add("Enrichment failed: " + e.getMessage());
+                document.setEnrichmentApplied(false);
+                document.setEnrichmentNotes("Enrichment failed: " + e.getMessage());
+            }
+        } else {
+            log.info("⏭️ ENRICHMENT not needed (disabled or no transactions)");
+            document.setEnrichmentApplied(false);
         }
 
         // Complete document

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichedTransaction.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichedTransaction.java
@@ -1,0 +1,76 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a single transaction after enrichment by AI.
+ * Contains extracted merchant and optionally inferred bankCategory.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EnrichedTransaction {
+
+    /**
+     * Row index from original CSV (0-based).
+     * Used to match enrichment result back to original transaction.
+     */
+    private int rowIndex;
+
+    /**
+     * Extracted merchant name (normalized, uppercase).
+     * Examples: "ŻABKA", "NETFLIX", "JAN KOWALSKI", "ZUS"
+     */
+    private String merchant;
+
+    /**
+     * Confidence score for merchant extraction (0.0 to 1.0).
+     * - 0.95+ = exact business name found
+     * - 0.8-0.95 = clear company/person name extracted
+     * - 0.5-0.8 = inferred from context
+     * - <0.5 = uncertain, used fallback
+     */
+    private double merchantConfidence;
+
+    /**
+     * Bank category for the transaction.
+     * Either original (if non-empty) or AI-inferred.
+     */
+    private String bankCategory;
+
+    /**
+     * Source of bankCategory value.
+     */
+    private BankCategorySource bankCategorySource;
+
+    /**
+     * Indicates where the bankCategory value came from.
+     */
+    public enum BankCategorySource {
+        /**
+         * Original value from bank CSV (e.g., Pekao).
+         * AI did not modify this value.
+         */
+        ORIGINAL,
+
+        /**
+         * AI inferred the category from transaction context.
+         * Original value was empty (e.g., Nest Bank).
+         */
+        AI_INFERRED,
+
+        /**
+         * AI could not determine category, used fallback ("Inne").
+         */
+        AI_FALLBACK,
+
+        /**
+         * Error during enrichment, used system default.
+         */
+        FALLBACK_ERROR
+    }
+}

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichedTransaction.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichedTransaction.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.bank_data_adapter.app.enrichment;
 
+import com.multi.vidulum.bank_data_adapter.domain.TransactionClassification;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -7,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * Represents a single transaction after enrichment by AI.
- * Contains extracted merchant and optionally inferred bankCategory.
+ * Contains extracted merchant, classification, and optionally inferred bankCategory.
  */
 @Data
 @Builder
@@ -22,8 +23,15 @@ public class EnrichedTransaction {
     private int rowIndex;
 
     /**
+     * Transaction classification determined by AI.
+     * Indicates the type of transaction: MERCHANT, BANK_FEE, CASH_WITHDRAWAL, etc.
+     */
+    private TransactionClassification classification;
+
+    /**
      * Extracted merchant name (normalized, uppercase).
      * Examples: "ŻABKA", "NETFLIX", "JAN KOWALSKI", "ZUS"
+     * Null for non-merchant transactions (BANK_FEE, CASH_WITHDRAWAL, etc.)
      */
     private String merchant;
 
@@ -33,8 +41,9 @@ public class EnrichedTransaction {
      * - 0.8-0.95 = clear company/person name extracted
      * - 0.5-0.8 = inferred from context
      * - <0.5 = uncertain, used fallback
+     * Null for non-merchant transactions.
      */
-    private double merchantConfidence;
+    private Double merchantConfidence;
 
     /**
      * Bank category for the transaction.
@@ -46,6 +55,22 @@ public class EnrichedTransaction {
      * Source of bankCategory value.
      */
     private BankCategorySource bankCategorySource;
+
+    /**
+     * Reason why AI chose this classification.
+     * Useful for debugging and understanding AI decisions.
+     * Examples:
+     * - "Card payment at grocery store"
+     * - "Express transfer commission - bank internal charge"
+     * - "ATM terminal code pattern detected"
+     */
+    private String classificationReason;
+
+    /**
+     * Location extracted from transaction (for ATM, physical locations).
+     * Examples: "WARSZAWA", "KRAKÓW", "UL. MARSZAŁKOWSKA 10"
+     */
+    private String location;
 
     /**
      * Indicates where the bankCategory value came from.
@@ -72,5 +97,26 @@ public class EnrichedTransaction {
          * Error during enrichment, used system default.
          */
         FALLBACK_ERROR
+    }
+
+    /**
+     * Returns effective classification (UNKNOWN if null).
+     */
+    public TransactionClassification effectiveClassification() {
+        return classification != null ? classification : TransactionClassification.UNKNOWN;
+    }
+
+    /**
+     * Whether this transaction has a meaningful merchant.
+     */
+    public boolean hasMerchant() {
+        return merchant != null && !merchant.isBlank() && effectiveClassification().hasMerchant();
+    }
+
+    /**
+     * Whether this transaction should be auto-categorized (skip AI categorization).
+     */
+    public boolean isAutoCategorizeable() {
+        return effectiveClassification().isAutoCategorizeable();
     }
 }

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentBatchResult.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentBatchResult.java
@@ -57,16 +57,34 @@ public class EnrichmentBatchResult {
         @JsonProperty("rowIndex")
         private int rowIndex;
 
+        /**
+         * Transaction classification: MERCHANT, BANK_FEE, CASH_WITHDRAWAL, etc.
+         */
+        @JsonProperty("classification")
+        private String classification;
+
         @JsonProperty("merchant")
         private String merchant;
 
         @JsonProperty("merchantConfidence")
-        private double merchantConfidence;
+        private Double merchantConfidence;
 
         @JsonProperty("bankCategory")
         private String bankCategory;
 
         @JsonProperty("bankCategorySource")
         private String bankCategorySource;
+
+        /**
+         * Reason for classification decision.
+         */
+        @JsonProperty("classificationReason")
+        private String classificationReason;
+
+        /**
+         * Location info (for ATM, physical locations).
+         */
+        @JsonProperty("location")
+        private String location;
     }
 }

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentBatchResult.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentBatchResult.java
@@ -1,0 +1,72 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Result of enrichment for a single batch of transactions.
+ * This is the expected JSON structure from AI response.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EnrichmentBatchResult {
+
+    /**
+     * Whether the AI processing succeeded.
+     */
+    @JsonProperty("success")
+    private boolean success;
+
+    /**
+     * List of enriched transactions.
+     */
+    @JsonProperty("enrichedTransactions")
+    private List<EnrichedTransactionJson> enrichedTransactions;
+
+    /**
+     * Optional notes from AI about ambiguous cases or processing issues.
+     */
+    @JsonProperty("processingNotes")
+    private String processingNotes;
+
+    /**
+     * Error message if success=false.
+     */
+    @JsonProperty("errorMessage")
+    private String errorMessage;
+
+    /**
+     * JSON structure for a single enriched transaction from AI.
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class EnrichedTransactionJson {
+
+        @JsonProperty("rowIndex")
+        private int rowIndex;
+
+        @JsonProperty("merchant")
+        private String merchant;
+
+        @JsonProperty("merchantConfidence")
+        private double merchantConfidence;
+
+        @JsonProperty("bankCategory")
+        private String bankCategory;
+
+        @JsonProperty("bankCategorySource")
+        private String bankCategorySource;
+    }
+}

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentPromptBuilder.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentPromptBuilder.java
@@ -1,0 +1,184 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds prompts for transaction enrichment.
+ *
+ * Enrichment extracts:
+ * 1. MERCHANT - normalized business/person name (always)
+ * 2. BANK_CATEGORY - only if original is empty (e.g., Nest Bank)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EnrichmentPromptBuilder {
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * System prompt for enrichment.
+     * Contains rules for merchant extraction and category inference.
+     */
+    public String getSystemPrompt() {
+        return """
+            You are a transaction data enrichment specialist for Polish bank statements.
+
+            ## YOUR TASK
+
+            For each transaction in the input, extract:
+            1. **merchant** - normalized business/person name (WHO the transaction is with)
+            2. **bankCategory** - ONLY if the original is empty, otherwise keep original
+
+            ## MERCHANT EXTRACTION RULES
+
+            Extract the clean, human-recognizable entity name:
+
+            | Input name/description | Output merchant |
+            |------------------------|-----------------|
+            | "ŻABKA POLSKA 4521 WARSZAWA UL MARSZALKOWSKA" | "ŻABKA" |
+            | "BIEDRONKA SKLEP 1234 KRAKÓW" | "BIEDRONKA" |
+            | "BANK PEKAO S.A." + desc: "Badoo help@badoo.com Dublin" | "BADOO" |
+            | "Silva Silva, Warszawa" + desc: "czynsz" | "SILVA SILVA" |
+            | "NETFLIX.COM 866-579-7172" | "NETFLIX" |
+            | "Przelew od Jan Kowalski" | "JAN KOWALSKI" |
+            | "ZUS" | "ZUS" |
+            | "SHIVAGO SPOLKA Z OGRANICZONA ODPOWIEDZIALNOSCIA" | "SHIVAGO" |
+            | "ALLEGRO.PL SP. Z O.O." | "ALLEGRO" |
+            | "ORLEN STACJA 1234 WARSZAWA" | "ORLEN" |
+            | "MINDBOX SP Z O O WARSZAWA" | "MINDBOX" |
+
+            Rules:
+            - UPPERCASE for consistency
+            - Remove: S.A., SP. Z O.O., SPÓŁKA, Z OGRANICZONA ODPOWIEDZIALNOSCIA, SP Z O O
+            - Remove: addresses, cities, postal codes, terminal IDs, store numbers
+            - Remove: transaction codes, card numbers, references
+            - If name is bank intermediary (BANK PEKAO, PKO BP, BANK BNP), extract real merchant from description
+            - For email domains in description, use company name (help@badoo.com → BADOO)
+            - For "Przelew od/do [NAME]" pattern, extract the person/company name
+            - Keep well-known abbreviations: ZUS, US, PZU, PKP
+
+            ## BANK_CATEGORY RULES
+
+            **CRITICAL**: Only infer bankCategory if original is EMPTY string.
+            If original bankCategory exists (non-empty), KEEP IT UNCHANGED and set bankCategorySource: "ORIGINAL".
+
+            When inferring from context:
+            | Keywords in name/description | bankCategory |
+            |------------------------------|--------------|
+            | czynsz, mieszkanie, najem, lokal | "Mieszkanie" |
+            | ZUS, podatek, US, składki, urząd skarbowy | "Podatki i składki" |
+            | Netflix, Spotify, HBO, Disney, kino, bilety | "Rozrywka" |
+            | Biedronka, Lidl, Żabka, Carrefour, Auchan, sklep | "Zakupy spożywcze" |
+            | prowizja, opłata, fee, bank | "Opłaty bankowe" |
+            | przelew przychodzący, wpływ, wynagrodzenie | "Przelewy przychodzące" |
+            | przelew wychodzący, przelew do | "Przelewy wychodzące" |
+            | BLIK | "Płatności BLIK" |
+            | karta, card, płatność kartą | "Płatności kartą" |
+            | paliwo, Orlen, BP, Shell, stacja | "Transport" |
+            | restauracja, kawiarnia, bar, jedzenie | "Gastronomia" |
+            | apteka, lekarz, szpital, zdrowie | "Zdrowie" |
+            | ubezpieczenie, PZU, polisa | "Ubezpieczenia" |
+            | telefon, internet, abonament | "Telekomunikacja" |
+
+            If cannot determine category, use "Inne".
+
+            ## MERCHANT_CONFIDENCE
+
+            Score 0.0 to 1.0:
+            - 0.95+ = exact business name found (email domain, known brand like Netflix, Allegro)
+            - 0.8-0.95 = clear company/person name extracted (ŻABKA from "ŻABKA POLSKA 4521")
+            - 0.5-0.8 = inferred from context, less certain
+            - <0.5 = uncertain, used fallback to cleaned name
+
+            ## OUTPUT FORMAT
+
+            Return ONLY valid JSON. No markdown, no explanation, no code blocks.
+
+            {
+              "success": true,
+              "enrichedTransactions": [
+                {
+                  "rowIndex": 0,
+                  "merchant": "EXTRACTED_NAME",
+                  "merchantConfidence": 0.95,
+                  "bankCategory": "Category",
+                  "bankCategorySource": "ORIGINAL" or "AI_INFERRED" or "AI_FALLBACK"
+                }
+              ],
+              "processingNotes": "optional notes about ambiguous cases"
+            }
+
+            ## ERROR HANDLING
+
+            If you cannot determine merchant, use fallback:
+            - merchant: first recognizable word from name, uppercase
+            - merchantConfidence: 0.3
+            - Add note to processingNotes
+
+            If you cannot determine bankCategory (and original is empty):
+            - bankCategory: "Inne"
+            - bankCategorySource: "AI_FALLBACK"
+
+            NEVER return null or undefined values. Always return valid JSON.
+            ALWAYS include all transactions from input in output (same count).
+            """;
+    }
+
+    /**
+     * Builds user prompt for a batch of transactions.
+     *
+     * @param transactions List of transactions to enrich
+     * @param batchNumber  Current batch number (1-based)
+     * @param totalBatches Total number of batches
+     * @param bankName     Detected bank name (for context)
+     * @param language     Detected language (pl, en, etc.)
+     * @return User prompt as string
+     */
+    public String buildUserPrompt(List<TransactionForEnrichment> transactions,
+                                   int batchNumber,
+                                   int totalBatches,
+                                   String bankName,
+                                   String language) {
+        try {
+            Map<String, Object> request = new HashMap<>();
+
+            Map<String, Object> batchInfo = new HashMap<>();
+            batchInfo.put("batchNumber", batchNumber);
+            batchInfo.put("totalBatches", totalBatches);
+            batchInfo.put("transactionsInBatch", transactions.size());
+            batchInfo.put("bankName", bankName != null ? bankName : "Unknown");
+            batchInfo.put("language", language != null ? language : "pl");
+
+            request.put("batchInfo", batchInfo);
+            request.put("transactions", transactions.stream()
+                    .map(this::transactionToMap)
+                    .toList());
+
+            String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(request);
+
+            return "Analyze these " + transactions.size() + " transactions and enrich each one:\n\n" + json;
+
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize transactions for enrichment prompt", e);
+            throw new RuntimeException("Failed to build enrichment prompt", e);
+        }
+    }
+
+    private Map<String, Object> transactionToMap(TransactionForEnrichment txn) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("rowIndex", txn.getRowIndex());
+        map.put("name", txn.getName() != null ? txn.getName() : "");
+        map.put("description", txn.getDescription() != null ? txn.getDescription() : "");
+        map.put("bankCategory", txn.getBankCategory() != null ? txn.getBankCategory() : "");
+        return map;
+    }
+}

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentPromptBuilder.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentPromptBuilder.java
@@ -11,11 +11,13 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Builds prompts for transaction enrichment.
+ * Builds prompts for transaction enrichment with classification.
  *
  * Enrichment extracts:
- * 1. MERCHANT - normalized business/person name (always)
- * 2. BANK_CATEGORY - only if original is empty (e.g., Nest Bank)
+ * 1. CLASSIFICATION - transaction type (MERCHANT, BANK_FEE, CASH_WITHDRAWAL, etc.)
+ * 2. MERCHANT - normalized business/person name (only for MERCHANT/UNKNOWN)
+ * 3. BANK_CATEGORY - only if original is empty (e.g., Nest Bank)
+ * 4. LOCATION - for ATM withdrawals and physical locations
  */
 @Slf4j
 @Component
@@ -25,36 +27,94 @@ public class EnrichmentPromptBuilder {
     private final ObjectMapper objectMapper;
 
     /**
-     * System prompt for enrichment.
-     * Contains rules for merchant extraction and category inference.
+     * System prompt for enrichment with classification.
+     * Contains rules for classification, merchant extraction, and category inference.
      */
     public String getSystemPrompt() {
         return """
-            You are a transaction data enrichment specialist for Polish bank statements.
+            You are a transaction data enrichment specialist for bank statements.
 
             ## YOUR TASK
 
-            For each transaction in the input, extract:
-            1. **merchant** - normalized business/person name (WHO the transaction is with)
-            2. **bankCategory** - ONLY if the original is empty, otherwise keep original
+            For each transaction in the input, determine:
 
-            ## MERCHANT EXTRACTION RULES
+            1. **classification** - transaction type (REQUIRED):
+               - MERCHANT: Payment to business/person (extract merchant name)
+               - BANK_FEE: Bank fee, commission, service charge (no merchant)
+               - CASH_WITHDRAWAL: ATM or bank withdrawal (no merchant)
+               - CASH_DEPOSIT: Cash deposit (no merchant)
+               - SELF_TRANSFER: Transfer between own accounts (no merchant)
+               - INTEREST: Interest payment (no merchant)
+               - UNKNOWN: Cannot determine (try to extract merchant anyway)
 
-            Extract the clean, human-recognizable entity name:
+            2. **merchant** - only if classification is MERCHANT or UNKNOWN:
+               - Extract clean, normalized business/person name
+               - UPPERCASE for consistency
+               - Remove legal suffixes (S.A., SP. Z O.O., etc.)
+               - Return null for non-merchant transactions
 
-            | Input name/description | Output merchant |
-            |------------------------|-----------------|
-            | "ŻABKA POLSKA 4521 WARSZAWA UL MARSZALKOWSKA" | "ŻABKA" |
-            | "BIEDRONKA SKLEP 1234 KRAKÓW" | "BIEDRONKA" |
-            | "BANK PEKAO S.A." + desc: "Badoo help@badoo.com Dublin" | "BADOO" |
-            | "Silva Silva, Warszawa" + desc: "czynsz" | "SILVA SILVA" |
+            3. **merchantConfidence** - only if merchant is provided (0.0 to 1.0)
+
+            4. **bankCategory** - only if original is empty, otherwise keep original
+
+            5. **classificationReason** - brief explanation of classification choice
+
+            6. **location** - extracted location info (for ATM, physical locations)
+
+            ## CLASSIFICATION RULES
+
+            ### BANK_FEE (language-agnostic indicators):
+            - Transaction is a fee/commission/charge from the bank itself
+            - No external counterparty - bank is charging the account holder
+            - Keywords: prowizja, opłata, fee, commission, Gebühr, charge
+            - Amount is typically small and negative (OUTFLOW)
+            - Often periodic (monthly, per-transaction)
+            - Examples: "Prowizja za przelew", "Opłata za kartę", "Monthly fee"
+
+            ### CASH_WITHDRAWAL:
+            - ATM terminal codes (numeric patterns like "00146 2703W250H")
+            - Withdrawal-related context
+            - No merchant name, just location/terminal info
+            - Keywords: wypłata, bankomat, ATM, withdrawal, Geldautomat
+            - Examples: "Wypłata z bankomatu", "ATM EURONET"
+
+            ### CASH_DEPOSIT:
+            - Deposit-related context
+            - Positive amount (INFLOW)
+            - No external sender
+            - Keywords: wpłata, deposit, Einzahlung
+            - Examples: "Wpłata gotówkowa", "Cash deposit"
+
+            ### SELF_TRANSFER:
+            - Transfer between own accounts (same owner)
+            - Keywords: przelew własny, own transfer, internal transfer
+            - Same name appears as sender/recipient
+            - Examples: "Przelew własny", "Transfer to savings"
+
+            ### INTEREST:
+            - Interest payment context
+            - From bank to account holder
+            - Keywords: odsetki, interest, Zinsen, kapitalizacja
+            - Examples: "Odsetki od lokaty", "Interest payment"
+
+            ### MERCHANT (default for payments):
+            - Payment to external business or person
+            - Has identifiable counterparty name
+            - Most card transactions, online payments, purchases
+            - Extract clean merchant name
+
+            ## MERCHANT EXTRACTION RULES (for MERCHANT and UNKNOWN only)
+
+            | Input | Output merchant |
+            |-------|-----------------|
+            | "ŻABKA POLSKA 4521 WARSZAWA" | "ŻABKA" |
             | "NETFLIX.COM 866-579-7172" | "NETFLIX" |
+            | "BANK PEKAO S.A." + desc: "Badoo help@badoo.com" | "BADOO" |
+            | "ALLEGRO.PL SP. Z O.O." | "ALLEGRO" |
+            | "BIEDRONKA SKLEP 1234 KRAKÓW" | "BIEDRONKA" |
             | "Przelew od Jan Kowalski" | "JAN KOWALSKI" |
             | "ZUS" | "ZUS" |
             | "SHIVAGO SPOLKA Z OGRANICZONA ODPOWIEDZIALNOSCIA" | "SHIVAGO" |
-            | "ALLEGRO.PL SP. Z O.O." | "ALLEGRO" |
-            | "ORLEN STACJA 1234 WARSZAWA" | "ORLEN" |
-            | "MINDBOX SP Z O O WARSZAWA" | "MINDBOX" |
 
             Rules:
             - UPPERCASE for consistency
@@ -78,7 +138,7 @@ public class EnrichmentPromptBuilder {
             | ZUS, podatek, US, składki, urząd skarbowy | "Podatki i składki" |
             | Netflix, Spotify, HBO, Disney, kino, bilety | "Rozrywka" |
             | Biedronka, Lidl, Żabka, Carrefour, Auchan, sklep | "Zakupy spożywcze" |
-            | prowizja, opłata, fee, bank | "Opłaty bankowe" |
+            | prowizja, opłata, fee, bank (for BANK_FEE) | "Opłaty bankowe" |
             | przelew przychodzący, wpływ, wynagrodzenie | "Przelewy przychodzące" |
             | przelew wychodzący, przelew do | "Przelewy wychodzące" |
             | BLIK | "Płatności BLIK" |
@@ -88,6 +148,9 @@ public class EnrichmentPromptBuilder {
             | apteka, lekarz, szpital, zdrowie | "Zdrowie" |
             | ubezpieczenie, PZU, polisa | "Ubezpieczenia" |
             | telefon, internet, abonament | "Telekomunikacja" |
+            | bankomat, wypłata, ATM (for CASH_WITHDRAWAL) | "Wypłata z bankomatu" |
+            | wpłata, deposit (for CASH_DEPOSIT) | "Wpłata gotówkowa" |
+            | odsetki, interest (for INTEREST) | "Odsetki" |
 
             If cannot determine category, use "Inne".
 
@@ -108,28 +171,46 @@ public class EnrichmentPromptBuilder {
               "enrichedTransactions": [
                 {
                   "rowIndex": 0,
-                  "merchant": "EXTRACTED_NAME",
+                  "classification": "MERCHANT",
+                  "merchant": "ŻABKA",
                   "merchantConfidence": 0.95,
-                  "bankCategory": "Category",
-                  "bankCategorySource": "ORIGINAL" or "AI_INFERRED" or "AI_FALLBACK"
+                  "bankCategory": "Zakupy spożywcze",
+                  "bankCategorySource": "AI_INFERRED",
+                  "classificationReason": "Card payment at grocery store chain",
+                  "location": null
+                },
+                {
+                  "rowIndex": 1,
+                  "classification": "BANK_FEE",
+                  "merchant": null,
+                  "merchantConfidence": null,
+                  "bankCategory": "Opłaty bankowe",
+                  "bankCategorySource": "AI_INFERRED",
+                  "classificationReason": "Express transfer commission - bank internal charge",
+                  "location": null
+                },
+                {
+                  "rowIndex": 2,
+                  "classification": "CASH_WITHDRAWAL",
+                  "merchant": null,
+                  "merchantConfidence": null,
+                  "bankCategory": "Wypłata z bankomatu",
+                  "bankCategorySource": "ORIGINAL",
+                  "classificationReason": "ATM terminal code pattern detected (00146 2703W250H)",
+                  "location": "WARSZAWA"
                 }
               ],
-              "processingNotes": "optional notes about ambiguous cases"
+              "processingNotes": "Processed 3 transactions: 1 merchant, 1 bank fee, 1 ATM withdrawal"
             }
 
             ## ERROR HANDLING
 
-            If you cannot determine merchant, use fallback:
-            - merchant: first recognizable word from name, uppercase
-            - merchantConfidence: 0.3
-            - Add note to processingNotes
-
-            If you cannot determine bankCategory (and original is empty):
-            - bankCategory: "Inne"
-            - bankCategorySource: "AI_FALLBACK"
-
-            NEVER return null or undefined values. Always return valid JSON.
-            ALWAYS include all transactions from input in output (same count).
+            - If cannot determine classification: use UNKNOWN
+            - If cannot determine merchant (for MERCHANT/UNKNOWN): use first recognizable word, confidence 0.3
+            - If cannot determine bankCategory (and original is empty): use "Inne"
+            - NEVER return null for classification - always choose a type
+            - ALWAYS include all transactions from input in output (same count)
+            - For BANK_FEE, CASH_WITHDRAWAL, CASH_DEPOSIT, SELF_TRANSFER, INTEREST: merchant MUST be null
             """;
     }
 
@@ -165,7 +246,7 @@ public class EnrichmentPromptBuilder {
 
             String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(request);
 
-            return "Analyze these " + transactions.size() + " transactions and enrich each one:\n\n" + json;
+            return "Analyze these " + transactions.size() + " transactions, classify each one, and enrich:\n\n" + json;
 
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize transactions for enrichment prompt", e);

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResponseProcessor.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResponseProcessor.java
@@ -2,6 +2,7 @@ package com.multi.vidulum.bank_data_adapter.app.enrichment;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.multi.vidulum.bank_data_adapter.domain.TransactionClassification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -222,10 +223,13 @@ public class EnrichmentResponseProcessor {
 
         return EnrichmentBatchResult.EnrichedTransactionJson.builder()
                 .rowIndex(original.getRowIndex())
+                .classification("UNKNOWN")  // Default classification for fallback
                 .merchant(fallbackMerchant)
                 .merchantConfidence(0.1)
                 .bankCategory(bankCategory)
                 .bankCategorySource(source)
+                .classificationReason("Fallback - AI processing failed")
+                .location(null)
                 .build();
     }
 
@@ -278,12 +282,19 @@ public class EnrichmentResponseProcessor {
         return batchResult.getEnrichedTransactions().stream()
                 .map(json -> EnrichedTransaction.builder()
                         .rowIndex(json.getRowIndex())
+                        .classification(parseClassification(json.getClassification()))
                         .merchant(json.getMerchant())
                         .merchantConfidence(json.getMerchantConfidence())
                         .bankCategory(json.getBankCategory())
                         .bankCategorySource(parseSource(json.getBankCategorySource()))
+                        .classificationReason(json.getClassificationReason())
+                        .location(json.getLocation())
                         .build())
                 .toList();
+    }
+
+    private TransactionClassification parseClassification(String classification) {
+        return TransactionClassification.fromString(classification);
     }
 
     private EnrichedTransaction.BankCategorySource parseSource(String source) {

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResponseProcessor.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResponseProcessor.java
@@ -1,0 +1,301 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Processes AI responses for enrichment.
+ * Handles parsing, validation, and fallback for malformed responses.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EnrichmentResponseProcessor {
+
+    private final ObjectMapper objectMapper;
+
+    // Pattern to extract JSON from markdown code blocks
+    private static final Pattern JSON_BLOCK_PATTERN = Pattern.compile(
+            "```(?:json)?\\s*\\n?([\\s\\S]*?)\\n?```",
+            Pattern.MULTILINE
+    );
+
+    // Pattern to find JSON object
+    private static final Pattern JSON_OBJECT_PATTERN = Pattern.compile(
+            "\\{[\\s\\S]*\\}",
+            Pattern.MULTILINE
+    );
+
+    /**
+     * Process AI response and extract enrichment results.
+     *
+     * @param aiResponse          Raw AI response text
+     * @param originalTransactions Original transactions for fallback
+     * @return Parsed batch result
+     */
+    public EnrichmentBatchResult process(String aiResponse, List<TransactionForEnrichment> originalTransactions) {
+        if (aiResponse == null || aiResponse.isBlank()) {
+            log.warn("Empty AI response, using fallback");
+            return createFallbackResult(originalTransactions, "Empty AI response");
+        }
+
+        // Try to extract JSON from response
+        String jsonContent = extractJson(aiResponse);
+
+        if (jsonContent == null) {
+            log.warn("Could not extract JSON from AI response, using fallback");
+            return createFallbackResult(originalTransactions, "Could not extract JSON from response");
+        }
+
+        try {
+            EnrichmentBatchResult result = objectMapper.readValue(jsonContent, EnrichmentBatchResult.class);
+
+            // Validate result
+            ValidationResult validation = validate(result, originalTransactions);
+            if (!validation.valid) {
+                log.warn("Validation failed: {}", validation.message);
+                return repairOrFallback(result, originalTransactions, validation.message);
+            }
+
+            return result;
+
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to parse AI response JSON: {}", e.getMessage());
+            return createFallbackResult(originalTransactions, "JSON parse error: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Extract JSON from AI response.
+     * Handles markdown code blocks and raw JSON.
+     */
+    private String extractJson(String response) {
+        // First, try to extract from markdown code block
+        Matcher blockMatcher = JSON_BLOCK_PATTERN.matcher(response);
+        if (blockMatcher.find()) {
+            return blockMatcher.group(1).trim();
+        }
+
+        // Try to find raw JSON object
+        Matcher objectMatcher = JSON_OBJECT_PATTERN.matcher(response);
+        if (objectMatcher.find()) {
+            return objectMatcher.group().trim();
+        }
+
+        // Response might be plain JSON
+        String trimmed = response.trim();
+        if (trimmed.startsWith("{")) {
+            return trimmed;
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate enrichment result.
+     * Uses global rowIndex values that match the original CSV positions.
+     */
+    private ValidationResult validate(EnrichmentBatchResult result, List<TransactionForEnrichment> originals) {
+        if (result == null) {
+            return new ValidationResult(false, "Result is null");
+        }
+
+        if (!result.isSuccess() && result.getErrorMessage() != null) {
+            return new ValidationResult(false, "AI reported error: " + result.getErrorMessage());
+        }
+
+        if (result.getEnrichedTransactions() == null) {
+            return new ValidationResult(false, "enrichedTransactions is null");
+        }
+
+        if (result.getEnrichedTransactions().size() != originals.size()) {
+            return new ValidationResult(false,
+                    String.format("Row count mismatch: expected %d, got %d",
+                            originals.size(), result.getEnrichedTransactions().size()));
+        }
+
+        // Build set of valid rowIndexes from original batch (these are GLOBAL indexes)
+        Set<Integer> validIndexes = originals.stream()
+                .map(TransactionForEnrichment::getRowIndex)
+                .collect(java.util.stream.Collectors.toSet());
+
+        // Check for valid and unique rowIndexes
+        Set<Integer> foundIndexes = new java.util.HashSet<>();
+        for (var txn : result.getEnrichedTransactions()) {
+            int idx = txn.getRowIndex();
+            if (!validIndexes.contains(idx)) {
+                return new ValidationResult(false, "Invalid rowIndex: " + idx +
+                        " (expected one of: " + validIndexes.stream().sorted().limit(3).toList() + "...)");
+            }
+            if (foundIndexes.contains(idx)) {
+                return new ValidationResult(false, "Duplicate rowIndex: " + idx);
+            }
+            foundIndexes.add(idx);
+        }
+
+        return new ValidationResult(true, "OK");
+    }
+
+    /**
+     * Try to repair partial results or fallback.
+     * Uses global rowIndex values that match the original CSV positions.
+     */
+    private EnrichmentBatchResult repairOrFallback(EnrichmentBatchResult partial,
+                                                    List<TransactionForEnrichment> originals,
+                                                    String validationMessage) {
+        if (partial == null || partial.getEnrichedTransactions() == null) {
+            return createFallbackResult(originals, validationMessage);
+        }
+
+        // Build map of valid rowIndex -> position in originals list
+        Map<Integer, Integer> indexToPosition = new java.util.HashMap<>();
+        for (int i = 0; i < originals.size(); i++) {
+            indexToPosition.put(originals.get(i).getRowIndex(), i);
+        }
+
+        // Try to repair by filling missing transactions
+        List<EnrichmentBatchResult.EnrichedTransactionJson> repaired = new ArrayList<>();
+        Set<Integer> processedIndexes = new java.util.HashSet<>();
+
+        // Add valid transactions from partial result
+        for (var txn : partial.getEnrichedTransactions()) {
+            int idx = txn.getRowIndex();
+            if (indexToPosition.containsKey(idx) && !processedIndexes.contains(idx)) {
+                repaired.add(txn);
+                processedIndexes.add(idx);
+            }
+        }
+
+        // Fill missing with fallback - use global rowIndex
+        for (var original : originals) {
+            if (!processedIndexes.contains(original.getRowIndex())) {
+                repaired.add(createFallbackTransaction(original));
+            }
+        }
+
+        return EnrichmentBatchResult.builder()
+                .success(true)
+                .enrichedTransactions(repaired)
+                .processingNotes("Repaired partial result: " + validationMessage)
+                .build();
+    }
+
+    /**
+     * Create complete fallback result when AI fails.
+     */
+    private EnrichmentBatchResult createFallbackResult(List<TransactionForEnrichment> originals, String reason) {
+        List<EnrichmentBatchResult.EnrichedTransactionJson> fallbacks = originals.stream()
+                .map(this::createFallbackTransaction)
+                .toList();
+
+        return EnrichmentBatchResult.builder()
+                .success(true) // Mark as success so processing continues
+                .enrichedTransactions(fallbacks)
+                .processingNotes("Fallback used: " + reason)
+                .build();
+    }
+
+    /**
+     * Create fallback for single transaction.
+     */
+    private EnrichmentBatchResult.EnrichedTransactionJson createFallbackTransaction(TransactionForEnrichment original) {
+        String fallbackMerchant = extractFallbackMerchant(original.getName());
+        String bankCategory = original.getBankCategory();
+        String source;
+
+        if (bankCategory == null || bankCategory.isBlank()) {
+            bankCategory = "Inne";
+            source = "FALLBACK_ERROR";
+        } else {
+            source = "ORIGINAL";
+        }
+
+        return EnrichmentBatchResult.EnrichedTransactionJson.builder()
+                .rowIndex(original.getRowIndex())
+                .merchant(fallbackMerchant)
+                .merchantConfidence(0.1)
+                .bankCategory(bankCategory)
+                .bankCategorySource(source)
+                .build();
+    }
+
+    /**
+     * Extract fallback merchant from name.
+     * Takes first word, cleans it, uppercases.
+     */
+    private String extractFallbackMerchant(String name) {
+        if (name == null || name.isBlank()) {
+            return "UNKNOWN";
+        }
+
+        // Clean and get first meaningful word
+        String cleaned = name.toUpperCase()
+                .replaceAll("[^A-ZĄĆĘŁŃÓŚŹŻ\\s]", " ")
+                .trim();
+
+        // Skip common prefixes
+        String[] skipPrefixes = {"PRZELEW", "OD", "DO", "NA", "BANK", "PŁATNOŚĆ", "KARTĄ", "BLIK"};
+        String[] words = cleaned.split("\\s+");
+
+        for (String word : words) {
+            if (word.length() < 2) continue;
+
+            boolean skip = false;
+            for (String prefix : skipPrefixes) {
+                if (word.equals(prefix)) {
+                    skip = true;
+                    break;
+                }
+            }
+
+            if (!skip) {
+                return word.length() > 30 ? word.substring(0, 30) : word;
+            }
+        }
+
+        // If nothing found, use first 30 chars
+        return cleaned.length() > 30 ? cleaned.substring(0, 30) : cleaned;
+    }
+
+    /**
+     * Convert batch result to domain objects.
+     */
+    public List<EnrichedTransaction> toDomainObjects(EnrichmentBatchResult batchResult) {
+        if (batchResult == null || batchResult.getEnrichedTransactions() == null) {
+            return List.of();
+        }
+
+        return batchResult.getEnrichedTransactions().stream()
+                .map(json -> EnrichedTransaction.builder()
+                        .rowIndex(json.getRowIndex())
+                        .merchant(json.getMerchant())
+                        .merchantConfidence(json.getMerchantConfidence())
+                        .bankCategory(json.getBankCategory())
+                        .bankCategorySource(parseSource(json.getBankCategorySource()))
+                        .build())
+                .toList();
+    }
+
+    private EnrichedTransaction.BankCategorySource parseSource(String source) {
+        if (source == null) {
+            return EnrichedTransaction.BankCategorySource.AI_FALLBACK;
+        }
+        try {
+            return EnrichedTransaction.BankCategorySource.valueOf(source);
+        } catch (IllegalArgumentException e) {
+            return EnrichedTransaction.BankCategorySource.AI_FALLBACK;
+        }
+    }
+
+    private record ValidationResult(boolean valid, String message) {}
+}

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResult.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResult.java
@@ -1,0 +1,108 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Final result of enrichment process for all transactions.
+ * Aggregates results from all batches.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EnrichmentResult {
+
+    /**
+     * Whether enrichment was applied.
+     * False if CSV already had all required fields filled.
+     */
+    private boolean enrichmentApplied;
+
+    /**
+     * Enriched CSV content (with merchant and bankCategory filled).
+     */
+    private String enrichedCsvContent;
+
+    /**
+     * Total number of transactions processed.
+     */
+    private int totalTransactions;
+
+    /**
+     * Number of merchants extracted by AI.
+     */
+    private int merchantsExtracted;
+
+    /**
+     * Number of bankCategories inferred by AI (were empty before).
+     */
+    private int bankCategoriesInferred;
+
+    /**
+     * Number of bankCategories kept from original (were already filled).
+     */
+    private int bankCategoriesKept;
+
+    /**
+     * Number of transactions where enrichment failed and fallback was used.
+     */
+    private int fallbackCount;
+
+    /**
+     * List of all enriched transactions.
+     */
+    private List<EnrichedTransaction> enrichedTransactions;
+
+    /**
+     * Warnings generated during enrichment.
+     */
+    private List<String> warnings;
+
+    /**
+     * Processing time in milliseconds.
+     */
+    private long processingTimeMs;
+
+    /**
+     * Number of AI calls made (batches).
+     */
+    private int aiCallCount;
+
+    /**
+     * Total input tokens used across all batches.
+     */
+    private int totalInputTokens;
+
+    /**
+     * Total output tokens used across all batches.
+     */
+    private int totalOutputTokens;
+
+    /**
+     * Processing notes from AI (aggregated from all batches).
+     */
+    private String processingNotes;
+
+    /**
+     * Creates a "no enrichment needed" result.
+     */
+    public static EnrichmentResult noEnrichmentNeeded(String csvContent, int rowCount) {
+        return EnrichmentResult.builder()
+                .enrichmentApplied(false)
+                .enrichedCsvContent(csvContent)
+                .totalTransactions(rowCount)
+                .merchantsExtracted(0)
+                .bankCategoriesInferred(0)
+                .bankCategoriesKept(rowCount)
+                .fallbackCount(0)
+                .warnings(List.of())
+                .processingTimeMs(0)
+                .aiCallCount(0)
+                .build();
+    }
+}

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
@@ -11,9 +11,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -40,6 +45,9 @@ public class TransactionEnrichmentService {
 
     @Value("${bank-data-adapter.enrichment.enabled:true}")
     private boolean enrichmentEnabled;
+
+    @Value("${bank-data-adapter.enrichment.max-parallelism:4}")
+    private int maxParallelism;
 
     /**
      * Check if enrichment is needed for the CSV.
@@ -100,41 +108,24 @@ public class TransactionEnrichmentService {
 
         // Split representatives into batches (not all transactions)
         List<List<TransactionForEnrichment>> batches = partition(representatives, batchSize);
-        log.info("Split into {} batches of up to {} representatives each", batches.size(), batchSize);
+        log.info("Split into {} batches of up to {} representatives each (parallelism: {})",
+                batches.size(), batchSize, maxParallelism);
 
-        // Process each batch (only representatives)
-        List<EnrichedTransaction> enrichedRepresentatives = new ArrayList<>();
-        List<String> allWarnings = new ArrayList<>();
+        // Process batches in parallel
+        List<EnrichedTransaction> enrichedRepresentatives = Collections.synchronizedList(new ArrayList<>());
+        List<String> allWarnings = Collections.synchronizedList(new ArrayList<>());
         StringBuilder processingNotes = new StringBuilder();
         int totalInputTokens = 0;
         int totalOutputTokens = 0;
 
-        for (int i = 0; i < batches.size(); i++) {
-            List<TransactionForEnrichment> batch = batches.get(i);
-            log.info("Processing batch {}/{} ({} representatives)", i + 1, batches.size(), batch.size());
-
-            try {
-                EnrichmentBatchResult batchResult = processBatch(
-                        batch, i + 1, batches.size(), bankName, language);
-
-                List<EnrichedTransaction> enriched = responseProcessor.toDomainObjects(batchResult);
-                enrichedRepresentatives.addAll(enriched);
-
-                if (batchResult.getProcessingNotes() != null && !batchResult.getProcessingNotes().isBlank()) {
-                    processingNotes.append("Batch ").append(i + 1).append(": ")
-                            .append(batchResult.getProcessingNotes()).append("\n");
-                }
-
-                // TODO: Extract token usage from ChatResponse when available
-
-            } catch (Exception e) {
-                log.error("Failed to process batch {}", i + 1, e);
-                allWarnings.add("Batch " + (i + 1) + " failed: " + e.getMessage());
-
-                // Use fallback for failed batch
-                EnrichmentBatchResult fallback = responseProcessor.process(null, batch);
-                enrichedRepresentatives.addAll(responseProcessor.toDomainObjects(fallback));
-            }
+        if (batches.size() == 1) {
+            // Single batch - no parallelism needed
+            processSingleBatch(batches.get(0), 1, 1, bankName, language,
+                    enrichedRepresentatives, allWarnings, processingNotes);
+        } else {
+            // Multiple batches - process in parallel
+            processInParallel(batches, bankName, language,
+                    enrichedRepresentatives, allWarnings, processingNotes);
         }
 
         // Propagate results from representatives to all transactions (with selective bankCategory)
@@ -182,6 +173,111 @@ public class TransactionEnrichmentService {
                 .totalOutputTokens(totalOutputTokens)
                 .processingNotes(processingNotes.toString().trim())
                 .build();
+    }
+
+    /**
+     * Process a single batch synchronously (used when only 1 batch).
+     */
+    private void processSingleBatch(List<TransactionForEnrichment> batch,
+                                     int batchNumber,
+                                     int totalBatches,
+                                     String bankName,
+                                     String language,
+                                     List<EnrichedTransaction> results,
+                                     List<String> warnings,
+                                     StringBuilder notes) {
+        log.info("Processing single batch ({} representatives)", batch.size());
+        try {
+            EnrichmentBatchResult batchResult = processBatch(batch, batchNumber, totalBatches, bankName, language);
+            results.addAll(responseProcessor.toDomainObjects(batchResult));
+            if (batchResult.getProcessingNotes() != null && !batchResult.getProcessingNotes().isBlank()) {
+                synchronized (notes) {
+                    notes.append("Batch 1: ").append(batchResult.getProcessingNotes()).append("\n");
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to process batch", e);
+            warnings.add("Batch 1 failed: " + e.getMessage());
+            EnrichmentBatchResult fallback = responseProcessor.process(null, batch);
+            results.addAll(responseProcessor.toDomainObjects(fallback));
+        }
+    }
+
+    /**
+     * Process multiple batches in parallel using CompletableFuture.
+     */
+    private void processInParallel(List<List<TransactionForEnrichment>> batches,
+                                    String bankName,
+                                    String language,
+                                    List<EnrichedTransaction> results,
+                                    List<String> warnings,
+                                    StringBuilder notes) {
+        int effectiveParallelism = Math.min(maxParallelism, batches.size());
+        ExecutorService executor = Executors.newFixedThreadPool(effectiveParallelism);
+
+        log.info("Processing {} batches in parallel (threads: {})", batches.size(), effectiveParallelism);
+        long parallelStart = System.currentTimeMillis();
+
+        try {
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+            for (int i = 0; i < batches.size(); i++) {
+                final int batchIndex = i;
+                final List<TransactionForEnrichment> batch = batches.get(i);
+
+                CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+                    log.info("Processing batch {}/{} ({} representatives) [thread: {}]",
+                            batchIndex + 1, batches.size(), batch.size(), Thread.currentThread().getName());
+
+                    try {
+                        EnrichmentBatchResult batchResult = processBatch(
+                                batch, batchIndex + 1, batches.size(), bankName, language);
+
+                        results.addAll(responseProcessor.toDomainObjects(batchResult));
+
+                        if (batchResult.getProcessingNotes() != null && !batchResult.getProcessingNotes().isBlank()) {
+                            synchronized (notes) {
+                                notes.append("Batch ").append(batchIndex + 1).append(": ")
+                                        .append(batchResult.getProcessingNotes()).append("\n");
+                            }
+                        }
+
+                        log.info("Batch {}/{} completed", batchIndex + 1, batches.size());
+
+                    } catch (Exception e) {
+                        log.error("Failed to process batch {}", batchIndex + 1, e);
+                        warnings.add("Batch " + (batchIndex + 1) + " failed: " + e.getMessage());
+
+                        // Use fallback for failed batch
+                        EnrichmentBatchResult fallback = responseProcessor.process(null, batch);
+                        results.addAll(responseProcessor.toDomainObjects(fallback));
+                    }
+                }, executor);
+
+                futures.add(future);
+            }
+
+            // Wait for all batches to complete
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .get(5, TimeUnit.MINUTES); // Timeout after 5 minutes
+
+            long parallelTime = System.currentTimeMillis() - parallelStart;
+            log.info("All {} batches completed in {}ms (parallel)", batches.size(), parallelTime);
+
+        } catch (Exception e) {
+            log.error("Parallel batch processing failed", e);
+            warnings.add("Parallel processing error: " + e.getMessage());
+        } finally {
+            executor.shutdown();
+            try {
+                if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                    executor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
@@ -148,7 +148,7 @@ public class TransactionEnrichmentService {
                 .count();
 
         int fallbackCount = (int) allEnriched.stream()
-                .filter(e -> e.getMerchantConfidence() < 0.3)
+                .filter(e -> e.getMerchantConfidence() != null && e.getMerchantConfidence() < 0.3)
                 .count();
 
         long processingTimeMs = System.currentTimeMillis() - startTime;
@@ -356,6 +356,7 @@ public class TransactionEnrichmentService {
 
     /**
      * Apply enrichment results to CSV.
+     * Adds/updates: merchant, merchantConfidence, bankCategory, classification, classificationReason, location
      */
     private String applyCsvEnrichment(String csvContent, List<EnrichedTransaction> enriched) {
         String[] lines = csvContent.split("\n");
@@ -370,13 +371,28 @@ public class TransactionEnrichmentService {
         int merchantIdx = findIndex(headers, "merchant");
         int merchantConfIdx = findIndex(headers, "merchantConfidence");
         int bankCatIdx = findIndex(headers, "bankCategory");
+        int classificationIdx = findIndex(headers, "classification");
+        int classificationReasonIdx = findIndex(headers, "classificationReason");
+        int locationIdx = findIndex(headers, "location");
+
+        // Check if we need to add new columns to header
+        boolean needsNewColumns = classificationIdx < 0;
+        String newHeaderLine = headerLine;
+
+        if (needsNewColumns) {
+            // Add new columns to header
+            newHeaderLine = headerLine + ",classification,classificationReason,location";
+            classificationIdx = headers.length;
+            classificationReasonIdx = headers.length + 1;
+            locationIdx = headers.length + 2;
+        }
 
         // Build index map for quick lookup
         java.util.Map<Integer, EnrichedTransaction> enrichmentMap = enriched.stream()
                 .collect(Collectors.toMap(EnrichedTransaction::getRowIndex, e -> e));
 
         StringBuilder result = new StringBuilder();
-        result.append(headerLine).append("\n");
+        result.append(newHeaderLine).append("\n");
 
         for (int i = 1; i < lines.length; i++) {
             String line = lines[i].trim();
@@ -388,14 +404,25 @@ public class TransactionEnrichmentService {
             if (enrichment != null) {
                 String[] values = parseRow(line);
 
-                // Update merchant
+                // Expand array if we added new columns
+                if (needsNewColumns) {
+                    String[] expanded = new String[values.length + 3];
+                    System.arraycopy(values, 0, expanded, 0, values.length);
+                    expanded[values.length] = "";
+                    expanded[values.length + 1] = "";
+                    expanded[values.length + 2] = "";
+                    values = expanded;
+                }
+
+                // Update merchant (null for non-merchant classifications)
                 if (merchantIdx >= 0 && merchantIdx < values.length) {
-                    values[merchantIdx] = enrichment.getMerchant();
+                    values[merchantIdx] = enrichment.getMerchant() != null ? enrichment.getMerchant() : "";
                 }
 
                 // Update merchantConfidence
                 if (merchantConfIdx >= 0 && merchantConfIdx < values.length) {
-                    values[merchantConfIdx] = String.valueOf(enrichment.getMerchantConfidence());
+                    values[merchantConfIdx] = enrichment.getMerchantConfidence() != null
+                            ? String.valueOf(enrichment.getMerchantConfidence()) : "";
                 }
 
                 // Update bankCategory only if it was inferred (original was empty)
@@ -405,9 +432,30 @@ public class TransactionEnrichmentService {
                     }
                 }
 
+                // Update classification
+                if (classificationIdx >= 0 && classificationIdx < values.length) {
+                    values[classificationIdx] = enrichment.effectiveClassification().name();
+                }
+
+                // Update classificationReason
+                if (classificationReasonIdx >= 0 && classificationReasonIdx < values.length) {
+                    values[classificationReasonIdx] = enrichment.getClassificationReason() != null
+                            ? enrichment.getClassificationReason() : "";
+                }
+
+                // Update location
+                if (locationIdx >= 0 && locationIdx < values.length) {
+                    values[locationIdx] = enrichment.getLocation() != null ? enrichment.getLocation() : "";
+                }
+
                 result.append(formatRow(values)).append("\n");
             } else {
-                result.append(line).append("\n");
+                // No enrichment for this row - still need to add empty columns if new
+                if (needsNewColumns) {
+                    result.append(line).append(",,,").append("\n");
+                } else {
+                    result.append(line).append("\n");
+                }
             }
         }
 
@@ -567,18 +615,24 @@ public class TransactionEnrichmentService {
                 log.warn("No enrichment result for group: {}", groupKey);
                 allEnriched.add(EnrichedTransaction.builder()
                         .rowIndex(txn.getRowIndex())
+                        .classification(com.multi.vidulum.bank_data_adapter.domain.TransactionClassification.UNKNOWN)
                         .merchant(txn.getName())
                         .merchantConfidence(0.1)
                         .bankCategory(txn.getBankCategory() != null && !txn.getBankCategory().isBlank()
                                 ? txn.getBankCategory() : "Inne")
                         .bankCategorySource(EnrichedTransaction.BankCategorySource.AI_FALLBACK)
+                        .classificationReason("Fallback - no group result")
+                        .location(null)
                         .build());
                 continue;
             }
 
-            // Propagate merchant (always)
+            // Propagate classification, merchant, location (always from representative)
+            var classification = representativeResult.getClassification();
             String merchant = representativeResult.getMerchant();
-            double merchantConfidence = representativeResult.getMerchantConfidence();
+            Double merchantConfidence = representativeResult.getMerchantConfidence();
+            String classificationReason = representativeResult.getClassificationReason();
+            String location = representativeResult.getLocation();
 
             // Selective propagation for bankCategory
             String bankCategory;
@@ -596,10 +650,13 @@ public class TransactionEnrichmentService {
 
             allEnriched.add(EnrichedTransaction.builder()
                     .rowIndex(txn.getRowIndex())
+                    .classification(classification)
                     .merchant(merchant)
                     .merchantConfidence(merchantConfidence)
                     .bankCategory(bankCategory)
                     .bankCategorySource(bankCategorySource)
+                    .classificationReason(classificationReason)
+                    .location(location)
                     .build());
         }
 

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
@@ -11,7 +11,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -87,15 +89,21 @@ public class TransactionEnrichmentService {
             return EnrichmentResult.noEnrichmentNeeded(csvContent, 0);
         }
 
-        log.info("Starting enrichment for {} transactions (bank: {}, language: {})",
-                transactions.size(), bankName, language);
+        // Group transactions by exact match on name (reduces AI calls)
+        Map<String, TransactionGroup> groups = groupTransactions(transactions);
+        List<TransactionForEnrichment> representatives = groups.values().stream()
+                .map(TransactionGroup::getRepresentative)
+                .toList();
 
-        // Split into batches
-        List<List<TransactionForEnrichment>> batches = partition(transactions, batchSize);
-        log.info("Split into {} batches of up to {} transactions each", batches.size(), batchSize);
+        log.info("Starting enrichment for {} transactions ({} unique groups, bank: {}, language: {})",
+                transactions.size(), groups.size(), bankName, language);
 
-        // Process each batch
-        List<EnrichedTransaction> allEnriched = new ArrayList<>();
+        // Split representatives into batches (not all transactions)
+        List<List<TransactionForEnrichment>> batches = partition(representatives, batchSize);
+        log.info("Split into {} batches of up to {} representatives each", batches.size(), batchSize);
+
+        // Process each batch (only representatives)
+        List<EnrichedTransaction> enrichedRepresentatives = new ArrayList<>();
         List<String> allWarnings = new ArrayList<>();
         StringBuilder processingNotes = new StringBuilder();
         int totalInputTokens = 0;
@@ -103,14 +111,14 @@ public class TransactionEnrichmentService {
 
         for (int i = 0; i < batches.size(); i++) {
             List<TransactionForEnrichment> batch = batches.get(i);
-            log.info("Processing batch {}/{} ({} transactions)", i + 1, batches.size(), batch.size());
+            log.info("Processing batch {}/{} ({} representatives)", i + 1, batches.size(), batch.size());
 
             try {
                 EnrichmentBatchResult batchResult = processBatch(
                         batch, i + 1, batches.size(), bankName, language);
 
                 List<EnrichedTransaction> enriched = responseProcessor.toDomainObjects(batchResult);
-                allEnriched.addAll(enriched);
+                enrichedRepresentatives.addAll(enriched);
 
                 if (batchResult.getProcessingNotes() != null && !batchResult.getProcessingNotes().isBlank()) {
                     processingNotes.append("Batch ").append(i + 1).append(": ")
@@ -125,9 +133,12 @@ public class TransactionEnrichmentService {
 
                 // Use fallback for failed batch
                 EnrichmentBatchResult fallback = responseProcessor.process(null, batch);
-                allEnriched.addAll(responseProcessor.toDomainObjects(fallback));
+                enrichedRepresentatives.addAll(responseProcessor.toDomainObjects(fallback));
             }
         }
+
+        // Propagate results from representatives to all transactions (with selective bankCategory)
+        List<EnrichedTransaction> allEnriched = propagateResults(enrichedRepresentatives, groups, transactions);
 
         // Apply enrichment to CSV
         String enrichedCsv = applyCsvEnrichment(csvContent, allEnriched);
@@ -151,8 +162,9 @@ public class TransactionEnrichmentService {
 
         long processingTimeMs = System.currentTimeMillis() - startTime;
 
-        log.info("Enrichment completed: {} merchants extracted, {} categories inferred, {} kept, {} fallbacks, {}ms",
-                merchantsExtracted, bankCategoriesInferred, bankCategoriesKept, fallbackCount, processingTimeMs);
+        log.info("Enrichment completed: {} transactions, {} groups, {} merchants, {} inferred, {} kept, {} fallbacks, {}ms",
+                transactions.size(), groups.size(), merchantsExtracted, bankCategoriesInferred,
+                bankCategoriesKept, fallbackCount, processingTimeMs);
 
         return EnrichmentResult.builder()
                 .enrichmentApplied(true)
@@ -382,5 +394,119 @@ public class TransactionEnrichmentService {
             partitions.add(list.subList(i, Math.min(i + size, list.size())));
         }
         return partitions;
+    }
+
+    /**
+     * Group transactions by exact match on normalized name.
+     * This reduces AI calls by processing only unique transaction patterns.
+     *
+     * @param transactions All transactions to enrich
+     * @return Map of group key to TransactionGroup
+     */
+    Map<String, TransactionGroup> groupTransactions(List<TransactionForEnrichment> transactions) {
+        Map<String, TransactionGroup> groups = new HashMap<>();
+
+        for (TransactionForEnrichment txn : transactions) {
+            String groupKey = normalizeGroupKey(txn.getName());
+
+            TransactionGroup group = groups.computeIfAbsent(groupKey, key ->
+                    TransactionGroup.builder()
+                            .groupKey(key)
+                            .build()
+            );
+
+            group.addTransaction(txn);
+        }
+
+        return groups;
+    }
+
+    /**
+     * Normalize name for grouping (exact match, case-insensitive).
+     */
+    private String normalizeGroupKey(String name) {
+        if (name == null) {
+            return "";
+        }
+        return name.toUpperCase().trim();
+    }
+
+    /**
+     * Propagate enrichment results from representatives to all transactions in groups.
+     * Uses selective propagation for bankCategory (only if original was empty).
+     *
+     * @param enrichedRepresentatives List of enriched representative transactions
+     * @param groups                  Map of group key to TransactionGroup
+     * @param allTransactions         All original transactions
+     * @return List of enriched transactions for all rows
+     */
+    List<EnrichedTransaction> propagateResults(
+            List<EnrichedTransaction> enrichedRepresentatives,
+            Map<String, TransactionGroup> groups,
+            List<TransactionForEnrichment> allTransactions) {
+
+        // Build map of representative rowIndex -> enriched result
+        Map<Integer, EnrichedTransaction> representativeResults = enrichedRepresentatives.stream()
+                .collect(Collectors.toMap(EnrichedTransaction::getRowIndex, e -> e));
+
+        // Build map of groupKey -> representative rowIndex for lookup
+        Map<String, Integer> groupKeyToRepresentativeIdx = new HashMap<>();
+        for (TransactionGroup group : groups.values()) {
+            groupKeyToRepresentativeIdx.put(
+                    group.getGroupKey(),
+                    group.getRepresentative().getRowIndex()
+            );
+        }
+
+        List<EnrichedTransaction> allEnriched = new ArrayList<>();
+
+        for (TransactionForEnrichment txn : allTransactions) {
+            String groupKey = normalizeGroupKey(txn.getName());
+            TransactionGroup group = groups.get(groupKey);
+            Integer representativeIdx = groupKeyToRepresentativeIdx.get(groupKey);
+            EnrichedTransaction representativeResult = representativeResults.get(representativeIdx);
+
+            if (representativeResult == null) {
+                // Fallback: no result for this group (shouldn't happen, but defensive)
+                log.warn("No enrichment result for group: {}", groupKey);
+                allEnriched.add(EnrichedTransaction.builder()
+                        .rowIndex(txn.getRowIndex())
+                        .merchant(txn.getName())
+                        .merchantConfidence(0.1)
+                        .bankCategory(txn.getBankCategory() != null && !txn.getBankCategory().isBlank()
+                                ? txn.getBankCategory() : "Inne")
+                        .bankCategorySource(EnrichedTransaction.BankCategorySource.AI_FALLBACK)
+                        .build());
+                continue;
+            }
+
+            // Propagate merchant (always)
+            String merchant = representativeResult.getMerchant();
+            double merchantConfidence = representativeResult.getMerchantConfidence();
+
+            // Selective propagation for bankCategory
+            String bankCategory;
+            EnrichedTransaction.BankCategorySource bankCategorySource;
+
+            if (group.hadEmptyBankCategory(txn.getRowIndex())) {
+                // Original was empty - use AI result
+                bankCategory = representativeResult.getBankCategory();
+                bankCategorySource = representativeResult.getBankCategorySource();
+            } else {
+                // Original had value - keep it
+                bankCategory = txn.getBankCategory();
+                bankCategorySource = EnrichedTransaction.BankCategorySource.ORIGINAL;
+            }
+
+            allEnriched.add(EnrichedTransaction.builder()
+                    .rowIndex(txn.getRowIndex())
+                    .merchant(merchant)
+                    .merchantConfidence(merchantConfidence)
+                    .bankCategory(bankCategory)
+                    .bankCategorySource(bankCategorySource)
+                    .build());
+        }
+
+        return allEnriched;
     }
 }

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
@@ -1,0 +1,386 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Service for enriching transactions with merchant and bankCategory.
+ *
+ * Architecture:
+ * 1. Parse canonical CSV to transactions
+ * 2. Check if enrichment is needed (any empty merchant or bankCategory)
+ * 3. Batch transactions (default 50 per batch)
+ * 4. Call AI for each batch
+ * 5. Merge results and update CSV
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TransactionEnrichmentService {
+
+    private final ChatModel chatModel;
+    private final EnrichmentPromptBuilder promptBuilder;
+    private final EnrichmentResponseProcessor responseProcessor;
+
+    @Value("${bank-data-adapter.enrichment.batch-size:50}")
+    private int batchSize;
+
+    @Value("${bank-data-adapter.enrichment.enabled:true}")
+    private boolean enrichmentEnabled;
+
+    /**
+     * Check if enrichment is needed for the CSV.
+     * Returns true if any transaction has empty merchant or bankCategory.
+     */
+    public boolean needsEnrichment(String csvContent) {
+        if (!enrichmentEnabled) {
+            log.debug("Enrichment disabled by configuration");
+            return false;
+        }
+
+        List<TransactionForEnrichment> transactions = parseCsv(csvContent);
+
+        // Count transactions needing enrichment
+        long emptyMerchants = transactions.stream()
+                .filter(t -> t.getName() == null || t.getName().isBlank())
+                .count();
+
+        // We always need enrichment because merchant field is always empty in current system
+        // Also check bankCategory for banks like Nest that don't provide it
+        long emptyBankCategories = transactions.stream()
+                .filter(TransactionForEnrichment::needsBankCategoryInference)
+                .count();
+
+        log.info("Enrichment check: {} transactions, {} need merchant extraction, {} need bankCategory inference",
+                transactions.size(), transactions.size(), emptyBankCategories);
+
+        // Always enrich - we need merchant for all transactions
+        return !transactions.isEmpty();
+    }
+
+    /**
+     * Enrich transactions in the CSV.
+     *
+     * @param csvContent Canonical CSV content
+     * @param bankName   Detected bank name
+     * @param language   Detected language
+     * @return Enrichment result with updated CSV
+     */
+    public EnrichmentResult enrich(String csvContent, String bankName, String language) {
+        long startTime = System.currentTimeMillis();
+
+        List<TransactionForEnrichment> transactions = parseCsv(csvContent);
+
+        if (transactions.isEmpty()) {
+            log.info("No transactions to enrich");
+            return EnrichmentResult.noEnrichmentNeeded(csvContent, 0);
+        }
+
+        log.info("Starting enrichment for {} transactions (bank: {}, language: {})",
+                transactions.size(), bankName, language);
+
+        // Split into batches
+        List<List<TransactionForEnrichment>> batches = partition(transactions, batchSize);
+        log.info("Split into {} batches of up to {} transactions each", batches.size(), batchSize);
+
+        // Process each batch
+        List<EnrichedTransaction> allEnriched = new ArrayList<>();
+        List<String> allWarnings = new ArrayList<>();
+        StringBuilder processingNotes = new StringBuilder();
+        int totalInputTokens = 0;
+        int totalOutputTokens = 0;
+
+        for (int i = 0; i < batches.size(); i++) {
+            List<TransactionForEnrichment> batch = batches.get(i);
+            log.info("Processing batch {}/{} ({} transactions)", i + 1, batches.size(), batch.size());
+
+            try {
+                EnrichmentBatchResult batchResult = processBatch(
+                        batch, i + 1, batches.size(), bankName, language);
+
+                List<EnrichedTransaction> enriched = responseProcessor.toDomainObjects(batchResult);
+                allEnriched.addAll(enriched);
+
+                if (batchResult.getProcessingNotes() != null && !batchResult.getProcessingNotes().isBlank()) {
+                    processingNotes.append("Batch ").append(i + 1).append(": ")
+                            .append(batchResult.getProcessingNotes()).append("\n");
+                }
+
+                // TODO: Extract token usage from ChatResponse when available
+
+            } catch (Exception e) {
+                log.error("Failed to process batch {}", i + 1, e);
+                allWarnings.add("Batch " + (i + 1) + " failed: " + e.getMessage());
+
+                // Use fallback for failed batch
+                EnrichmentBatchResult fallback = responseProcessor.process(null, batch);
+                allEnriched.addAll(responseProcessor.toDomainObjects(fallback));
+            }
+        }
+
+        // Apply enrichment to CSV
+        String enrichedCsv = applyCsvEnrichment(csvContent, allEnriched);
+
+        // Calculate statistics
+        int merchantsExtracted = (int) allEnriched.stream()
+                .filter(e -> e.getMerchant() != null && !e.getMerchant().isBlank())
+                .count();
+
+        int bankCategoriesInferred = (int) allEnriched.stream()
+                .filter(e -> e.getBankCategorySource() == EnrichedTransaction.BankCategorySource.AI_INFERRED)
+                .count();
+
+        int bankCategoriesKept = (int) allEnriched.stream()
+                .filter(e -> e.getBankCategorySource() == EnrichedTransaction.BankCategorySource.ORIGINAL)
+                .count();
+
+        int fallbackCount = (int) allEnriched.stream()
+                .filter(e -> e.getMerchantConfidence() < 0.3)
+                .count();
+
+        long processingTimeMs = System.currentTimeMillis() - startTime;
+
+        log.info("Enrichment completed: {} merchants extracted, {} categories inferred, {} kept, {} fallbacks, {}ms",
+                merchantsExtracted, bankCategoriesInferred, bankCategoriesKept, fallbackCount, processingTimeMs);
+
+        return EnrichmentResult.builder()
+                .enrichmentApplied(true)
+                .enrichedCsvContent(enrichedCsv)
+                .totalTransactions(transactions.size())
+                .merchantsExtracted(merchantsExtracted)
+                .bankCategoriesInferred(bankCategoriesInferred)
+                .bankCategoriesKept(bankCategoriesKept)
+                .fallbackCount(fallbackCount)
+                .enrichedTransactions(allEnriched)
+                .warnings(allWarnings)
+                .processingTimeMs(processingTimeMs)
+                .aiCallCount(batches.size())
+                .totalInputTokens(totalInputTokens)
+                .totalOutputTokens(totalOutputTokens)
+                .processingNotes(processingNotes.toString().trim())
+                .build();
+    }
+
+    /**
+     * Process a single batch of transactions.
+     */
+    private EnrichmentBatchResult processBatch(List<TransactionForEnrichment> batch,
+                                                int batchNumber,
+                                                int totalBatches,
+                                                String bankName,
+                                                String language) {
+        String systemPrompt = promptBuilder.getSystemPrompt();
+        String userPrompt = promptBuilder.buildUserPrompt(batch, batchNumber, totalBatches, bankName, language);
+
+        Prompt prompt = new Prompt(List.of(
+                new SystemMessage(systemPrompt),
+                new UserMessage(userPrompt)
+        ));
+
+        ChatResponse response = chatModel.call(prompt);
+        String aiOutput = response.getResult().getOutput().getText();
+
+        log.debug("AI response for batch {}: {} chars", batchNumber, aiOutput.length());
+
+        return responseProcessor.process(aiOutput, batch);
+    }
+
+    /**
+     * Parse canonical CSV to transactions for enrichment.
+     */
+    private List<TransactionForEnrichment> parseCsv(String csvContent) {
+        if (csvContent == null || csvContent.isBlank()) {
+            return List.of();
+        }
+
+        String[] lines = csvContent.split("\n");
+        if (lines.length < 2) {
+            return List.of();
+        }
+
+        // Parse header
+        String headerLine = lines[0];
+        String[] headers = parseRow(headerLine);
+        int nameIdx = findIndex(headers, "name");
+        int descIdx = findIndex(headers, "description");
+        int bankCatIdx = findIndex(headers, "bankCategory");
+
+        if (nameIdx < 0) {
+            log.warn("Missing required column in CSV header: name={}", nameIdx);
+            return List.of();
+        }
+
+        List<TransactionForEnrichment> transactions = new ArrayList<>();
+
+        for (int i = 1; i < lines.length; i++) {
+            String line = lines[i].trim();
+            if (line.isEmpty()) continue;
+
+            String[] values = parseRow(line);
+
+            try {
+                TransactionForEnrichment txn = TransactionForEnrichment.builder()
+                        .rowIndex(i - 1) // 0-based index after header
+                        .name(getValueSafe(values, nameIdx))
+                        .description(getValueSafe(values, descIdx))
+                        .bankCategory(getValueSafe(values, bankCatIdx))
+                        .build();
+
+                transactions.add(txn);
+            } catch (Exception e) {
+                log.warn("Failed to parse row {}: {}", i, e.getMessage());
+            }
+        }
+
+        return transactions;
+    }
+
+    /**
+     * Apply enrichment results to CSV.
+     */
+    private String applyCsvEnrichment(String csvContent, List<EnrichedTransaction> enriched) {
+        String[] lines = csvContent.split("\n");
+        if (lines.length < 2) {
+            return csvContent;
+        }
+
+        // Parse header and find column indexes
+        String headerLine = lines[0];
+        String[] headers = parseRow(headerLine);
+
+        int merchantIdx = findIndex(headers, "merchant");
+        int merchantConfIdx = findIndex(headers, "merchantConfidence");
+        int bankCatIdx = findIndex(headers, "bankCategory");
+
+        // Build index map for quick lookup
+        java.util.Map<Integer, EnrichedTransaction> enrichmentMap = enriched.stream()
+                .collect(Collectors.toMap(EnrichedTransaction::getRowIndex, e -> e));
+
+        StringBuilder result = new StringBuilder();
+        result.append(headerLine).append("\n");
+
+        for (int i = 1; i < lines.length; i++) {
+            String line = lines[i].trim();
+            if (line.isEmpty()) continue;
+
+            int rowIndex = i - 1;
+            EnrichedTransaction enrichment = enrichmentMap.get(rowIndex);
+
+            if (enrichment != null) {
+                String[] values = parseRow(line);
+
+                // Update merchant
+                if (merchantIdx >= 0 && merchantIdx < values.length) {
+                    values[merchantIdx] = enrichment.getMerchant();
+                }
+
+                // Update merchantConfidence
+                if (merchantConfIdx >= 0 && merchantConfIdx < values.length) {
+                    values[merchantConfIdx] = String.valueOf(enrichment.getMerchantConfidence());
+                }
+
+                // Update bankCategory only if it was inferred (original was empty)
+                if (bankCatIdx >= 0 && bankCatIdx < values.length) {
+                    if (enrichment.getBankCategorySource() != EnrichedTransaction.BankCategorySource.ORIGINAL) {
+                        values[bankCatIdx] = enrichment.getBankCategory();
+                    }
+                }
+
+                result.append(formatRow(values)).append("\n");
+            } else {
+                result.append(line).append("\n");
+            }
+        }
+
+        return result.toString().trim();
+    }
+
+    /**
+     * Parse a CSV row handling quoted values.
+     */
+    private String[] parseRow(String line) {
+        List<String> values = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+
+            if (c == '"') {
+                if (inQuotes && i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                    current.append('"');
+                    i++; // Skip next quote
+                } else {
+                    inQuotes = !inQuotes;
+                }
+            } else if (c == ',' && !inQuotes) {
+                values.add(current.toString().trim());
+                current = new StringBuilder();
+            } else {
+                current.append(c);
+            }
+        }
+        values.add(current.toString().trim());
+
+        return values.toArray(new String[0]);
+    }
+
+    /**
+     * Format values back to CSV row.
+     */
+    private String formatRow(String[] values) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < values.length; i++) {
+            if (i > 0) sb.append(",");
+            String value = values[i];
+            if (value == null) {
+                value = "";
+            }
+            // Quote if contains comma, quote, or newline
+            if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+                sb.append("\"").append(value.replace("\"", "\"\"")).append("\"");
+            } else {
+                sb.append(value);
+            }
+        }
+        return sb.toString();
+    }
+
+    private int findIndex(String[] headers, String name) {
+        for (int i = 0; i < headers.length; i++) {
+            if (headers[i].equalsIgnoreCase(name)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private String getValueSafe(String[] values, int index) {
+        if (index < 0 || index >= values.length) {
+            return "";
+        }
+        return values[index];
+    }
+
+    /**
+     * Partition list into batches.
+     */
+    private <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> partitions = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            partitions.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return partitions;
+    }
+}

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionForEnrichment.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionForEnrichment.java
@@ -1,0 +1,51 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a transaction prepared for enrichment.
+ * Contains only fields needed by AI for merchant extraction and category inference.
+ *
+ * Note: amount and type are NOT included as they don't help with merchant extraction
+ * or category inference - those are determined from name and description only.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionForEnrichment {
+
+    /**
+     * Row index from CSV (0-based, after header).
+     */
+    private int rowIndex;
+
+    /**
+     * Transaction name (primary identifier).
+     * Examples: "ŻABKA POLSKA 4521 WARSZAWA", "Przelew od Jan Kowalski"
+     */
+    private String name;
+
+    /**
+     * Additional description.
+     * May contain merchant info, reference numbers, etc.
+     */
+    private String description;
+
+    /**
+     * Original bank category (may be empty for some banks like Nest).
+     * If non-empty, AI should keep it unchanged.
+     */
+    private String bankCategory;
+
+    /**
+     * Returns true if bankCategory is empty or null.
+     * AI should infer category only for these transactions.
+     */
+    public boolean needsBankCategoryInference() {
+        return bankCategory == null || bankCategory.isBlank();
+    }
+}

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionGroup.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionGroup.java
@@ -1,0 +1,96 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a group of transactions with the same name (exact match).
+ * Used to reduce AI calls by enriching only unique transaction patterns.
+ */
+@Data
+@Builder
+public class TransactionGroup {
+
+    /**
+     * Normalized group key (name.toUpperCase().trim()).
+     */
+    private String groupKey;
+
+    /**
+     * Representative transaction to send to AI.
+     * Selected based on best available bankCategory.
+     */
+    private TransactionForEnrichment representative;
+
+    /**
+     * All row indexes belonging to this group.
+     */
+    @Builder.Default
+    private List<Integer> rowIndexes = new ArrayList<>();
+
+    /**
+     * Original bankCategory values for each row (for selective propagation).
+     * Maps rowIndex -> original bankCategory.
+     */
+    @Builder.Default
+    private java.util.Map<Integer, String> originalBankCategories = new java.util.HashMap<>();
+
+    /**
+     * Add a transaction to this group.
+     */
+    public void addTransaction(TransactionForEnrichment txn) {
+        rowIndexes.add(txn.getRowIndex());
+        originalBankCategories.put(txn.getRowIndex(), txn.getBankCategory());
+
+        // Update representative if this one has better bankCategory
+        if (representative == null) {
+            representative = txn;
+        } else if (isBetterBankCategory(txn.getBankCategory(), representative.getBankCategory())) {
+            // Keep the rowIndex of the first transaction, but use better bankCategory
+            representative = TransactionForEnrichment.builder()
+                    .rowIndex(representative.getRowIndex())
+                    .name(representative.getName())
+                    .description(representative.getDescription())
+                    .bankCategory(txn.getBankCategory())
+                    .build();
+        }
+    }
+
+    /**
+     * Check if category1 is better than category2.
+     * Priority: specific category > "Inne" > empty
+     */
+    private boolean isBetterBankCategory(String category1, String category2) {
+        int score1 = scoreBankCategory(category1);
+        int score2 = scoreBankCategory(category2);
+        return score1 > score2;
+    }
+
+    private int scoreBankCategory(String category) {
+        if (category == null || category.isBlank()) {
+            return 0; // Empty - worst
+        }
+        if ("Inne".equalsIgnoreCase(category)) {
+            return 1; // "Inne" - better than empty
+        }
+        return 2; // Specific category - best
+    }
+
+    /**
+     * Get the number of transactions in this group.
+     */
+    public int size() {
+        return rowIndexes.size();
+    }
+
+    /**
+     * Check if original bankCategory was empty for given rowIndex.
+     */
+    public boolean hadEmptyBankCategory(int rowIndex) {
+        String original = originalBankCategories.get(rowIndex);
+        return original == null || original.isBlank();
+    }
+}

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/domain/AiCsvTransformationDocument.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/domain/AiCsvTransformationDocument.java
@@ -102,6 +102,17 @@ public class AiCsvTransformationDocument {
     private int monthsOfData;                       // Number of distinct months covered
     private List<String> monthsCovered;             // List of "YYYY-MM" strings in order
 
+    // ========== ENRICHMENT (ETAP 2) ==========
+    private boolean enrichmentApplied;              // Whether enrichment was applied
+    private Date enrichedAt;                        // When enrichment was applied
+    private long enrichmentTimeMs;                  // Enrichment processing time
+    private int enrichmentAiCalls;                  // Number of AI calls for enrichment (batches)
+    private int merchantsExtracted;                 // Number of merchants extracted
+    private int bankCategoriesInferred;             // Number of bank categories inferred (were empty)
+    private int bankCategoriesKept;                 // Number of bank categories kept (were filled)
+    private int enrichmentFallbackCount;            // Number of transactions using fallback
+    private String enrichmentNotes;                 // Processing notes from enrichment
+
     // ========== HELPER METHODS FOR ZONEDDATETIME CONVERSION ==========
 
     public ZonedDateTime getCreatedAtZoned() {
@@ -118,6 +129,14 @@ public class AiCsvTransformationDocument {
 
     public void setImportedAtFromZoned(ZonedDateTime zdt) {
         this.importedAt = zdt != null ? Date.from(zdt.toInstant()) : null;
+    }
+
+    public ZonedDateTime getEnrichedAtZoned() {
+        return enrichedAt != null ? ZonedDateTime.ofInstant(enrichedAt.toInstant(), ZoneOffset.UTC) : null;
+    }
+
+    public void setEnrichedAtFromZoned(ZonedDateTime zdt) {
+        this.enrichedAt = zdt != null ? Date.from(zdt.toInstant()) : null;
     }
 
     public static Date toDate(ZonedDateTime zdt) {

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/domain/TransactionClassification.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/domain/TransactionClassification.java
@@ -1,0 +1,142 @@
+package com.multi.vidulum.bank_data_adapter.domain;
+
+/**
+ * Classification of transaction type determined by AI enrichment.
+ *
+ * This classification helps:
+ * 1. Determine if merchant extraction makes sense
+ * 2. Enable auto-categorization for non-merchant transactions
+ * 3. Improve AI categorization by filtering out non-categorizable transactions
+ */
+public enum TransactionClassification {
+
+    /**
+     * Payment to a merchant/business/person.
+     * Merchant extraction is meaningful.
+     * Should be categorized by AI categorization.
+     *
+     * Examples:
+     * - "ŻABKA POLSKA 4521 WARSZAWA" → merchant: ŻABKA
+     * - "NETFLIX.COM" → merchant: NETFLIX
+     * - "Jan Kowalski" (personal transfer) → merchant: JAN KOWALSKI
+     */
+    MERCHANT,
+
+    /**
+     * Bank fee, commission, or service charge.
+     * No meaningful merchant (the bank itself is not a merchant).
+     * Auto-category: "Bank fees" / "Opłaty bankowe"
+     *
+     * Examples:
+     * - "Prowizja za przelew natychmiastowy wychodzący KIR"
+     * - "Opłata za obsługę karty MasterCard"
+     * - "Monthly account fee"
+     * - "Wire transfer commission"
+     */
+    BANK_FEE,
+
+    /**
+     * Cash withdrawal from ATM or bank branch.
+     * No merchant (ATM terminal is not a merchant).
+     * Auto-category: "Cash" / "Gotówka"
+     *
+     * Examples:
+     * - "00146 2703W250H WARSZAWA" (ATM terminal code)
+     * - "Wypłata z bankomatu"
+     * - "ATM withdrawal"
+     * - "EURONET 12345"
+     */
+    CASH_WITHDRAWAL,
+
+    /**
+     * Cash deposit at ATM or bank branch.
+     * No merchant.
+     * Auto-category: "Cash" / "Gotówka"
+     *
+     * Examples:
+     * - "Wpłata gotówkowa"
+     * - "Cash deposit"
+     * - "Wpłata we wpłatomacie"
+     */
+    CASH_DEPOSIT,
+
+    /**
+     * Transfer between own accounts (same owner).
+     * No merchant (self-transfer).
+     * Auto-category: "Internal transfer" / "Przelew wewnętrzny"
+     * Should be excluded from budget calculations.
+     *
+     * Examples:
+     * - Transfer from checking to savings
+     * - "Przelew własny"
+     * - Same name appears as sender and in account owner
+     */
+    SELF_TRANSFER,
+
+    /**
+     * Interest payment (credit or debit).
+     * No merchant.
+     * Auto-category: "Interest" / "Odsetki"
+     *
+     * Examples:
+     * - "Odsetki od lokaty"
+     * - "Interest payment"
+     * - "Kapitalizacja odsetek"
+     */
+    INTEREST,
+
+    /**
+     * Cannot determine transaction type.
+     * Fallback - try to extract merchant anyway.
+     * Should be categorized by AI categorization.
+     *
+     * Examples:
+     * - Ambiguous transaction descriptions
+     * - Unknown patterns
+     */
+    UNKNOWN;
+
+    /**
+     * Whether this classification type has a meaningful merchant.
+     * Only MERCHANT and UNKNOWN should have merchant extracted.
+     */
+    public boolean hasMerchant() {
+        return this == MERCHANT || this == UNKNOWN;
+    }
+
+    /**
+     * Whether this classification should be auto-categorized
+     * (skipped in AI categorization phase).
+     * These transactions already have bankCategory from enrichment.
+     */
+    public boolean isAutoCategorizeable() {
+        return this == BANK_FEE ||
+               this == CASH_WITHDRAWAL ||
+               this == CASH_DEPOSIT ||
+               this == SELF_TRANSFER ||
+               this == INTEREST;
+    }
+
+    /**
+     * Whether this classification should be included in budget/expense analysis.
+     * Self-transfers should be excluded as they don't represent real income/expense.
+     */
+    public boolean includeInBudget() {
+        return this != SELF_TRANSFER;
+    }
+
+    /**
+     * Parse classification from string (case-insensitive).
+     * Returns UNKNOWN for null or unrecognized values.
+     */
+    public static TransactionClassification fromString(String value) {
+        if (value == null || value.isBlank()) {
+            return UNKNOWN;
+        }
+        try {
+            return valueOf(value.toUpperCase().trim());
+        } catch (IllegalArgumentException e) {
+            return UNKNOWN;
+        }
+    }
+}

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/AiMappingRulesPromptBuilder.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/AiMappingRulesPromptBuilder.java
@@ -5,16 +5,20 @@ import org.springframework.stereotype.Component;
 /**
  * Builds prompts for AI to generate mapping rules from bank CSV samples.
  *
- * AI analyzes the sample and returns reusable mapping rules.
- * Only delimiter is pre-detected (statistically) and passed as hint.
- * AI determines everything else: headerRowIndex, dateFormat, column mappings.
+ * Uses SCHEMA-FIRST approach: AI analyzes DATA CONTENT in columns (not column names)
+ * to find the best match for each BankCsvRow field.
+ *
+ * This approach is more universal and works for any bank without hardcoding column names.
  */
 @Component
 public class AiMappingRulesPromptBuilder {
 
     private static final String SYSTEM_PROMPT = """
-        You are a bank CSV format analyzer. Analyze the CSV sample and return mapping rules as JSON.
-        Your task is to understand the structure and return rules for LOCAL transformation.
+        You are a bank CSV format analyzer using SCHEMA-FIRST approach.
+
+        Your task: Analyze the DATA CONTENT in each column (not just column names) to determine
+        what BankCsvRow field it should map to.
+
         Return ONLY valid JSON - no markdown, no code blocks, no explanations.
 
         IMPORTANT: You may receive a pre-detected delimiter value.
@@ -61,278 +65,196 @@ public class AiMappingRulesPromptBuilder {
           "sampleOutputRow": "example output row"
         }
 
-        ## EXAMPLES (showing different bank formats):
+        ═══════════════════════════════════════════════════════════════════════════════
+        ██  SCHEMA-FIRST APPROACH - ANALYZE DATA CONTENT, NOT COLUMN NAMES!  ██
+        ═══════════════════════════════════════════════════════════════════════════════
 
-        ### Example 1: Polish bank with SEMICOLON delimiter
-        CSV sample: "Data księgowania;Data waluty;Nadawca;Kwota operacji;Waluta"
-        {
-          "bankName": "Bank Pekao",
-          "delimiter": ";",
-          "headerRowIndex": 0,
-          "dateFormat": "dd.MM.yyyy",
-          "columnMappings": [...]
-        }
+        For each BankCsvRow field below, analyze the ACTUAL DATA VALUES in each column
+        to find the best match. Do NOT rely only on column names - look at what the data
+        looks like!
 
-        ### Example 2: International bank with COMMA delimiter
-        CSV sample: "Date,Description,Amount,Currency"
-        {
-          "bankName": "Revolut",
-          "delimiter": ",",
-          "headerRowIndex": 0,
-          "dateFormat": "yyyy-MM-dd",
-          "columnMappings": [...]
-        }
+        ┌─────────────────────────────────────────────────────────────────────────────┐
+        │  operationDate (REQUIRED)                                                   │
+        │  Find column containing DATE values                                         │
+        │                                                                             │
+        │  DATA PATTERNS to look for:                                                 │
+        │  - "31-12-2025", "2025-12-31", "31.12.2025", "12/31/2025"                   │
+        │  - Values that look like dates with day, month, year                        │
+        │                                                                             │
+        │  Use: DATE_PARSE transformation                                             │
+        └─────────────────────────────────────────────────────────────────────────────┘
 
-        ### Example 3: Bank with metadata rows before header
-        CSV has metadata lines (account info, date range, etc.) before header:
-        {
-          "bankName": "mBank",
-          "delimiter": ";",
-          "headerRowIndex": 3,
-          "metadataRows": 3,
-          "dateFormat": "dd.MM.yyyy",
-          "columnMappings": [...]
-        }
+        ┌─────────────────────────────────────────────────────────────────────────────┐
+        │  amount (REQUIRED)                                                          │
+        │  Find column containing MONETARY VALUES                                     │
+        │                                                                             │
+        │  DATA PATTERNS to look for:                                                 │
+        │  - "-3000", "1234.56", "-1 234,56", "5000 PLN"                              │
+        │  - Numeric values, possibly with minus sign, decimal separator              │
+        │  - May have spaces as thousands separators                                  │
+        │                                                                             │
+        │  Use: AMOUNT_PARSE transformation                                           │
+        └─────────────────────────────────────────────────────────────────────────────┘
+
+        ┌─────────────────────────────────────────────────────────────────────────────┐
+        │  name (REQUIRED) - WHO                                                      │
+        │  Find column containing COUNTERPARTY NAMES                                  │
+        │                                                                             │
+        │  DATA PATTERNS to look for:                                                 │
+        │  - "Jan Kowalski", "Netflix Inc", "ZUS", "Urząd Skarbowy"                  │
+        │  - Names of PEOPLE, COMPANIES, INSTITUTIONS                                 │
+        │  - Proper nouns, organization names                                         │
+        │                                                                             │
+        │  ⚠️ This is WHO you paid / WHO paid you                                    │
+        │  ⚠️ NOT transaction descriptions or purposes!                              │
+        │                                                                             │
+        │  Use: DIRECT transformation                                                 │
+        └─────────────────────────────────────────────────────────────────────────────┘
+
+        ┌─────────────────────────────────────────────────────────────────────────────┐
+        │  description (REQUIRED if column exists) - WHY/WHAT                         │
+        │  Find column containing TRANSACTION PURPOSE / TITLE                         │
+        │                                                                             │
+        │  DATA PATTERNS to look for:                                                 │
+        │  - "czynsz za styczeń", "faktura 123", "składki ZUS", "rata kredytu"       │
+        │  - "Invoice #12345", "Monthly rent", "Subscription fee"                     │
+        │  - Reasons, references, invoice numbers, payment purposes                   │
+        │                                                                             │
+        │  ⚠️ This is WHY/WHAT the payment is for                                    │
+        │  ⚠️ CRITICAL for AI categorization - ALWAYS map if exists!                 │
+        │                                                                             │
+        │  Use: DIRECT transformation                                                 │
+        └─────────────────────────────────────────────────────────────────────────────┘
+
+        ┌─────────────────────────────────────────────────────────────────────────────┐
+        │  ⚠️⚠️⚠️  CRITICAL: bankCategory vs paymentMethod DISTINCTION  ⚠️⚠️⚠️       │
+        │                                                                             │
+        │  Banks often have TWO different classification columns:                     │
+        │                                                                             │
+        │  1) bankCategory = WHAT was purchased (SEMANTIC CATEGORY)                   │
+        │     DATA PATTERNS to look for:                                              │
+        │     - "Zakupy", "Rozrywka", "Sport", "Jedzenie", "Transport", "Medyczna"   │
+        │     - "Shopping", "Entertainment", "Food", "Health", "Travel"               │
+        │     - Single-word or short category labels describing spending type         │
+        │                                                                             │
+        │     Use: DIRECT transformation                                              │
+        │                                                                             │
+        │  2) paymentMethod = HOW the payment was made (TECHNICAL METHOD)             │
+        │     DATA PATTERNS to look for:                                              │
+        │     - "Płatność kartą", "Przelew wychodzący", "BLIK", "Zlecenie stałe"     │
+        │     - "Polecenie zapłaty", "Wypłata gotówkowa", "Wpłata gotówkowa"         │
+        │     - "Card payment", "Transfer", "Direct debit", "Standing order"          │
+        │     - Phrases describing payment mechanism                                  │
+        │                                                                             │
+        │     Use: PAYMENT_METHOD_NORMALIZE transformation                            │
+        │                                                                             │
+        │  ════════════════════════════════════════════════════════════════════════  │
+        │  EXAMPLE - Pekao Bank has BOTH columns:                                     │
+        │                                                                             │
+        │  Column "Typ operacji": "Płatność kartą"  → paymentMethod (HOW)            │
+        │  Column "Kategoria": "Sport"               → bankCategory (WHAT)            │
+        │                                                                             │
+        │  WRONG: mapping "Płatność kartą" to bankCategory                           │
+        │  RIGHT: mapping "Sport" to bankCategory, "Płatność kartą" to paymentMethod │
+        │  ════════════════════════════════════════════════════════════════════════  │
+        │                                                                             │
+        │  HOW TO DISTINGUISH by looking at DATA:                                     │
+        │  - If value is like "Zakupy", "Sport", "Jedzenie" → bankCategory           │
+        │  - If value is like "Przelew", "Płatność kartą" → paymentMethod            │
+        └─────────────────────────────────────────────────────────────────────────────┘
+
+        ┌─────────────────────────────────────────────────────────────────────────────┐
+        │  type (REQUIRED)                                                            │
+        │  Determine INFLOW or OUTFLOW based on amount SIGN                          │
+        │                                                                             │
+        │  ALWAYS use TYPE_DETECT with amountColumn parameter!                        │
+        │  - Negative amount (-100) = OUTFLOW                                         │
+        │  - Positive amount (100) = INFLOW                                           │
+        │                                                                             │
+        │  ⚠️ NEVER map Polish transaction types to this field!                      │
+        │  ⚠️ NEVER use DIRECT transformation for type!                              │
+        │                                                                             │
+        │  Example mapping:                                                           │
+        │  {                                                                          │
+        │    "sourceColumn": "Kwota",                                                 │
+        │    "sourceIndex": 3,                                                        │
+        │    "targetField": "type",                                                   │
+        │    "transformationType": "TYPE_DETECT",                                     │
+        │    "transformationParams": {"amountColumn": "3"}                            │
+        │  }                                                                          │
+        └─────────────────────────────────────────────────────────────────────────────┘
+
+        ┌─────────────────────────────────────────────────────────────────────────────┐
+        │  currency (REQUIRED)                                                        │
+        │  Find column or extract from amount                                         │
+        │                                                                             │
+        │  DATA PATTERNS to look for:                                                 │
+        │  - "PLN", "EUR", "USD", "GBP"                                              │
+        │  - Or embedded in amount: "5000 PLN"                                        │
+        │                                                                             │
+        │  Use: CURRENCY_EXTRACT transformation                                       │
+        │  If no currency column, set default based on country (PL → PLN)            │
+        └─────────────────────────────────────────────────────────────────────────────┘
+
+        ┌─────────────────────────────────────────────────────────────────────────────┐
+        │  sourceAccountNumber / targetAccountNumber (if columns exist)              │
+        │  Find columns with ACCOUNT NUMBERS (IBAN)                                  │
+        │                                                                             │
+        │  DATA PATTERNS to look for:                                                 │
+        │  - "PL61109010140000071219812874" (full IBAN)                              │
+        │  - "61109010140000071219812874" (26 digits without prefix)                 │
+        │  - "'61109010140000071219812874" (with Excel apostrophe)                   │
+        │                                                                             │
+        │  - sourceAccountNumber = account that SENT money (for INFLOW)              │
+        │  - targetAccountNumber = account that RECEIVED money (for OUTFLOW)         │
+        │                                                                             │
+        │  If only ONE counterparty account column exists, map to BOTH fields.       │
+        │                                                                             │
+        │  Use: IBAN_NORMALIZE transformation                                         │
+        └─────────────────────────────────────────────────────────────────────────────┘
+
+        ┌─────────────────────────────────────────────────────────────────────────────┐
+        │  merchant / merchantConfidence (for CARD transactions)                     │
+        │                                                                             │
+        │  When name column contains BANK INTERMEDIARY like:                          │
+        │  - "BANK PEKAO S.A.", "mBank S.A.", "ING BANK ŚLĄSKI"                      │
+        │  The REAL merchant is hidden in description column:                         │
+        │  - "ROZLICZENIE... Badoo help@badoo.com Dublin" → merchant: "BADOO"        │
+        │                                                                             │
+        │  Use: MERCHANT_EXTRACT and MERCHANT_CONFIDENCE transformations              │
+        │  Set params: {"nameColumn": "X", "descriptionColumn": "Y"}                 │
+        └─────────────────────────────────────────────────────────────────────────────┘
 
         ## TRANSFORMATION TYPES:
         - DIRECT: copy value as-is
         - DATE_PARSE: parse date using format in params
         - AMOUNT_PARSE: parse Polish/European number format (1 234,56)
-        - TYPE_DETECT: determine INFLOW/OUTFLOW from amount sign or text
+        - TYPE_DETECT: determine INFLOW/OUTFLOW from amount sign
         - CURRENCY_EXTRACT: extract currency code
         - IBAN_NORMALIZE: normalize account number to full IBAN
-        - CONCAT: combine multiple columns (indices in params)
+        - CONCAT: combine multiple columns
         - REGEX_EXTRACT: extract part using regex pattern
         - VALUE_MAP: map values using lookup table
         - ID_GENERATE: generate transaction ID
         - SKIP: ignore this column
         - MERCHANT_EXTRACT: extract merchant name from description
-        - MERCHANT_CONFIDENCE: calculate confidence score for merchant extraction (0.0-1.0)
-        - PAYMENT_METHOD_NORMALIZE: normalize payment method (CARD, TRANSFER, BLIK, DIRECT_DEBIT, STANDING_ORDER, CASH, OTHER)
-
-        ## RULES FOR MAPPING:
-        1. sourceIndex is 0-based column index
-        2. All dates must output as YYYY-MM-DD
-        3. Amount must be POSITIVE decimal (type handles direction)
-        4. Account numbers without country prefix get PL prefix if 26 digits
-        5. If no description column, concatenate merchant info columns
-        6. bankTransactionId can use ID_GENERATE if bank doesn't provide
-        7. CURRENCY IS REQUIRED - always include currency mapping:
-           - If CSV has currency column → use CURRENCY_EXTRACT
-           - If currency is embedded in amount (e.g., "5000 PLN") → use CURRENCY_EXTRACT with regex
-           - If no currency column → use CURRENCY_EXTRACT with default based on country
-
-        8. CRITICAL - TYPE FIELD MAPPING:
-           - The "type" field MUST be either "INFLOW" or "OUTFLOW" - never Polish transaction types!
-           - ALWAYS use "transformationType": "TYPE_DETECT" for the type field
-           - ALWAYS include "amountColumn" parameter pointing to the amount column index
-           - The TYPE_DETECT will determine INFLOW/OUTFLOW based on the SIGN of the amount:
-             * Negative amounts (-100.00) = OUTFLOW (expenses, payments)
-             * Positive amounts (100.00) = INFLOW (income, deposits)
-           - NEVER use "DIRECT" for type field
-           - Example:
-             {
-               "sourceColumn": "Kwota",
-               "sourceIndex": 3,
-               "targetField": "type",
-               "transformationType": "TYPE_DETECT",
-               "transformationParams": {"amountColumn": "3"},
-               "required": true
-             }
-
-        9. CRITICAL - NAME vs DESCRIPTION DISTINCTION:
-
-           Bank CSVs typically have TWO different text columns that must be mapped correctly:
-
-           "name" = WHO (counterparty)
-           - The person, company, or entity you transacted with
-           - Answer the question: "Who did I pay?" or "Who paid me?"
-           - Examples: "John Smith", "Netflix", "Tax Office", "Landlord LLC"
-
-           "description" = WHY/WHAT (transaction purpose)
-           - The reason, purpose, or reference for the payment
-           - Answer the question: "What is this payment for?"
-           - Examples: "Monthly rent", "Invoice #12345", "Salary January", "Loan payment"
-
-           EXAMPLES OF CORRECT MAPPING:
-           | name (WHO)              | description (WHY/WHAT)                    |
-           |-------------------------|-------------------------------------------|
-           | "John Smith"            | "Rent payment January 2025"               |
-           | "Social Insurance"      | "Monthly contribution"                    |
-           | "Netflix"               | "Subscription fee"                        |
-           | "Tax Authority"         | "Income tax Q4 2024"                      |
-           | "Electric Company"      | "Invoice 2025/01/1234"                    |
-
-           HOW TO IDENTIFY EACH COLUMN:
-           - name column: contains names of people, companies, institutions
-           - description column: contains purposes, references, invoice numbers, payment reasons
-             Look for column names with words like: title, purpose, reference, description, memo, reason
-
-        10. DESCRIPTION FIELD (CRITICAL FOR CATEGORIZATION):
-
-            ⚠️ The description field is ESSENTIAL for AI transaction categorization!
-
-            WITHOUT description, the system cannot distinguish between:
-            - Different types of payments to the same recipient
-            - The actual purpose of generic bank transfers
-            - Subcategories within the same expense type
-
-            EXAMPLE: Two payments to "Social Insurance Office":
-            - description: "retirement contribution" → Category: Retirement
-            - description: "health insurance" → Category: Healthcare
-            Without description, both would go to generic "Other expenses"!
-
-            ALWAYS map the transaction purpose/title/reference column to description.
-            If the CSV has such a column, you MUST include it in columnMappings.
+        - MERCHANT_CONFIDENCE: calculate confidence score (0.0-1.0)
+        - PAYMENT_METHOD_NORMALIZE: normalize to CARD, TRANSFER, BLIK, DIRECT_DEBIT, STANDING_ORDER, CASH, OTHER
 
         ## REQUIRED MAPPINGS CHECKLIST:
-        You MUST include mappings for ALL of these fields:
-        - ✓ operationDate (REQUIRED) - use DATE_PARSE
-        - ✓ name (REQUIRED) - WHO you transacted with - use DIRECT or CONCAT
-        - ✓ amount (REQUIRED) - use AMOUNT_PARSE
-        - ✓ currency (REQUIRED) - use CURRENCY_EXTRACT
-        - ✓ type (REQUIRED) - use TYPE_DETECT with amountColumn param
-        - ✓ bankCategory (REQUIRED if exists) - use DIRECT - WHAT was purchased (category column)
-        - ✓ paymentMethod (REQUIRED if exists) - use PAYMENT_METHOD_NORMALIZE - HOW payment was made
-        - ✓ description (REQUIRED if exists) - WHY/WHAT the payment is for - use DIRECT
-        - ○ bookingDate (optional) - use DATE_PARSE
-        - ✓ sourceAccountNumber (REQUIRED if exists) - use IBAN_NORMALIZE - sender account for grouping
-        - ✓ targetAccountNumber (REQUIRED if exists) - use IBAN_NORMALIZE - recipient account for grouping
-        - ✓ merchant (REQUIRED for card transactions) - use MERCHANT_EXTRACT
-        - ✓ merchantConfidence (REQUIRED when merchant is mapped) - use MERCHANT_CONFIDENCE
-
-        ⚠️ If the CSV has a column with transaction purpose/title/reference, you MUST map it to description!
-
-        14. ACCOUNT NUMBER MAPPING (IMPORTANT FOR TRANSACTION GROUPING):
-
-            Account numbers help identify unique counterparties for pattern matching.
-            If CSV has columns with account numbers, you MUST map them:
-
-            - sourceAccountNumber: Account that SENT money (for INFLOW transactions)
-              Common column names: "Rachunek źródłowy", "Source Account", "Sender Account", "From Account"
-
-            - targetAccountNumber: Account that RECEIVED money (for OUTFLOW transactions)
-              Common column names: "Rachunek docelowy", "Target Account", "Beneficiary Account", "To Account"
-
-            Note: Some banks use a single "counterparty account" column for both.
-            In that case, map it to BOTH sourceAccountNumber and targetAccountNumber -
-            the system will use the correct one based on transaction type.
-
-            IMPORTANT: Account numbers may have leading apostrophe (') in CSV - this is Excel formatting.
-            Use IBAN_NORMALIZE transformation to clean and normalize account numbers.
-
-        15. BANK CATEGORY MAPPING vs PAYMENT METHOD (CRITICAL DISTINCTION):
-
-            ⚠️ Banks often have TWO different classification columns. You MUST map them correctly:
-
-            a) bankCategory = WHAT was purchased (transaction category)
-               - Describes the purpose or category of the transaction
-               - Examples: "Zakupy", "Rozrywka", "Rachunki", "Jedzenie", "Transport"
-               - Common column names: "Kategoria", "Category"
-               - This helps AI categorize to user's budget categories
-
-            b) paymentMethod = HOW the payment was made (payment method)
-               - Describes the technical method of payment
-               - Examples: "Płatność kartą", "Przelew", "BLIK", "Zlecenie stałe", "Polecenie zapłaty"
-               - Common column names: "Rodzaj operacji", "Typ operacji", "Operation Type", "Transaction Type"
-               - This does NOT determine categories!
-
-            EXAMPLES OF CORRECT MAPPING:
-            | Column Value            | Maps To       | Reason                          |
-            |-------------------------|---------------|---------------------------------|
-            | "Płatność kartą"        | paymentMethod | HOW - card payment              |
-            | "Przelew wychodzący"    | paymentMethod | HOW - outgoing transfer         |
-            | "BLIK"                  | paymentMethod | HOW - BLIK payment              |
-            | "Zlecenie stałe"        | paymentMethod | HOW - standing order            |
-            | "Polecenie zapłaty"     | paymentMethod | HOW - direct debit              |
-            | "Zakupy"                | bankCategory  | WHAT - shopping                 |
-            | "Rozrywka"              | bankCategory  | WHAT - entertainment            |
-            | "Rachunki"              | bankCategory  | WHAT - bills                    |
-            | "Jedzenie"              | bankCategory  | WHAT - food                     |
-
-            PAYMENT_METHOD_NORMALIZE transformation will convert Polish/other languages to English:
-            - "Płatność kartą" → CARD
-            - "Przelew" / "Przelew wychodzący" / "Przelew przychodzący" → TRANSFER
-            - "BLIK" → BLIK
-            - "Polecenie zapłaty" → DIRECT_DEBIT
-            - "Zlecenie stałe" → STANDING_ORDER
-            - "Wypłata gotówkowa" / "Wpłata gotówkowa" → CASH
-            - Unknown → OTHER
-
-            If bank has separate columns for both, map BOTH fields:
-            {
-              "sourceColumn": "Rodzaj operacji",
-              "sourceIndex": 2,
-              "targetField": "paymentMethod",
-              "transformationType": "PAYMENT_METHOD_NORMALIZE",
-              "required": false
-            },
-            {
-              "sourceColumn": "Kategoria",
-              "sourceIndex": 11,
-              "targetField": "bankCategory",
-              "transformationType": "DIRECT",
-              "required": false
-            }
-
-        13. MERCHANT EXTRACTION (CRITICAL FOR CARD TRANSACTIONS):
-
-            ⚠️ THIS IS EXTREMELY IMPORTANT FOR ACCURATE CATEGORIZATION!
-
-            Bank card transactions often show the BANK as the counterparty (name column),
-            while the REAL MERCHANT is hidden in the description/title column.
-
-            EXAMPLES OF BANK INTERMEDIARY PATTERNS (in name column):
-            - "BANK PEKAO S.A." → Card transaction processed by Pekao bank
-            - "BANK MILLENNIUM S.A." → Card transaction processed by Millennium
-            - "BNP PARIBAS BANK POLSKA" → Card transaction processed by BNP
-            - "SANTANDER BANK POLSKA" → Card transaction processed by Santander
-            - "ING BANK ŚLĄSKI" → Card transaction processed by ING
-            - "mBank S.A." → Card transaction processed by mBank
-            - Any pattern containing "ROZLICZENIE TRANSAKCJI" or "TRANSAKCJA KARTĄ"
-
-            WHEN YOU SEE BANK INTERMEDIARY IN NAME COLUMN, YOU MUST:
-            1. Add merchant mapping with MERCHANT_EXTRACT transformation
-            2. Add merchantConfidence mapping with MERCHANT_CONFIDENCE transformation
-            3. Set nameColumn parameter pointing to the name column index
-
-            MERCHANT EXTRACTION EXAMPLE:
-            If CSV has:
-            - Column 2: "Nadawca / Odbiorca" = "BANK PEKAO S.A."
-            - Column 6: "Tytułem" = "ROZLICZENIE... Badoo help@badoo.com Dublin"
-
-            You MUST add these mappings:
-            {
-              "sourceColumn": "Tytułem",
-              "sourceIndex": 6,
-              "targetField": "merchant",
-              "transformationType": "MERCHANT_EXTRACT",
-              "transformationParams": {"nameColumn": "2", "descriptionColumn": "6"},
-              "required": false
-            },
-            {
-              "sourceColumn": "Tytułem",
-              "sourceIndex": 6,
-              "targetField": "merchantConfidence",
-              "transformationType": "MERCHANT_CONFIDENCE",
-              "transformationParams": {"nameColumn": "2", "descriptionColumn": "6"},
-              "required": false
-            }
-
-            The MERCHANT_EXTRACT transformer will:
-            - Check if name column contains bank intermediary
-            - Extract real merchant from description (e.g., "BADOO", "NETFLIX", "UBER")
-            - Return empty if name is already the real merchant
-
-            WITHOUT MERCHANT EXTRACTION:
-            - All card transactions will be grouped under "BANK PEKAO S.A." pattern
-            - System will categorize them ALL as "Other expenses"
-            - User loses visibility into BADOO, NETFLIX, UBER, etc. spending
-
-            WITH MERCHANT EXTRACTION:
-            - Each merchant (BADOO, NETFLIX, UBER) becomes a separate pattern
-            - System can categorize BADOO → Dating, NETFLIX → Streaming, UBER → Transport
-            - User gets accurate spending breakdown by actual merchant
+        ✓ operationDate (REQUIRED) - DATE_PARSE
+        ✓ name (REQUIRED) - DIRECT - WHO you transacted with
+        ✓ amount (REQUIRED) - AMOUNT_PARSE
+        ✓ currency (REQUIRED) - CURRENCY_EXTRACT
+        ✓ type (REQUIRED) - TYPE_DETECT with amountColumn param
+        ✓ description (REQUIRED if exists) - DIRECT - WHY/WHAT payment is for
+        ✓ bankCategory (REQUIRED if exists) - DIRECT - WHAT was purchased (semantic category)
+        ✓ paymentMethod (REQUIRED if exists) - PAYMENT_METHOD_NORMALIZE - HOW payment was made
+        ○ bookingDate (optional) - DATE_PARSE
+        ✓ sourceAccountNumber (if exists) - IBAN_NORMALIZE
+        ✓ targetAccountNumber (if exists) - IBAN_NORMALIZE
+        ✓ merchant (for card transactions) - MERCHANT_EXTRACT
+        ✓ merchantConfidence (when merchant mapped) - MERCHANT_CONFIDENCE
 
         ## ERROR FORMAT (if cannot parse):
         {

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/rest/AiBankCsvController.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/rest/AiBankCsvController.java
@@ -205,7 +205,14 @@ public class AiBankCsvController {
         // Detection info (for UI feedback)
         String detectionResult,         // CANONICAL, CACHED, AI_TRANSFORMED
         boolean fromCache,              // Whether cached mapping rules were used
-        long processingTimeMs           // Processing time in milliseconds
+        long processingTimeMs,          // Processing time in milliseconds
+        // Enrichment stats (Phase 2: merchant extraction + bankCategory inference)
+        boolean enrichmentApplied,      // Whether enrichment was performed
+        int merchantsExtracted,         // Number of merchants extracted by AI
+        int bankCategoriesInferred,     // Number of bankCategories inferred by AI (for banks without categories)
+        int bankCategoriesKept,         // Number of original bankCategories kept
+        long enrichmentTimeMs,          // Time spent on enrichment in milliseconds
+        int enrichmentAiCalls           // Number of AI calls made for enrichment
     ) {}
 
     public record PreviewResponse(
@@ -259,7 +266,14 @@ public class AiBankCsvController {
             // Detection info
             doc.getDetectionResult() != null ? doc.getDetectionResult().name() : null,
             doc.isFromCache(),
-            doc.getProcessingTimeMs()
+            doc.getProcessingTimeMs(),
+            // Enrichment stats
+            doc.isEnrichmentApplied(),
+            doc.getMerchantsExtracted(),
+            doc.getBankCategoriesInferred(),
+            doc.getBankCategoriesKept(),
+            doc.getEnrichmentTimeMs(),
+            doc.getEnrichmentAiCalls()
         );
     }
 

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/CsvParserService.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/CsvParserService.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.bank_data_ingestion.app;
 
+import com.multi.vidulum.bank_data_adapter.domain.TransactionClassification;
 import com.multi.vidulum.bank_data_ingestion.domain.BankCsvRow;
 import com.multi.vidulum.bank_data_ingestion.domain.PaymentMethod;
 import com.multi.vidulum.cashflow.domain.Type;
@@ -45,7 +46,10 @@ public class CsvParserService {
             "targetAccountNumber",
             "merchant",
             "merchantConfidence",
-            "paymentMethod"
+            "paymentMethod",
+            "classification",
+            "classificationReason",
+            "location"
     };
 
     private static final List<DateTimeFormatter> DATE_FORMATTERS = List.of(
@@ -149,8 +153,16 @@ public class CsvParserService {
                 normalizeIban(getOptionalString(record, "targetAccountNumber"), currency),
                 getOptionalString(record, "merchant"),
                 getOptionalDouble(record, "merchantConfidence"),
-                getOptionalPaymentMethod(record, "paymentMethod")
+                getOptionalPaymentMethod(record, "paymentMethod"),
+                getOptionalClassification(record, "classification"),
+                getOptionalString(record, "classificationReason"),
+                getOptionalString(record, "location")
         );
+    }
+
+    private TransactionClassification getOptionalClassification(CSVRecord record, String header) {
+        String value = getOptionalString(record, header);
+        return TransactionClassification.fromString(value);
     }
 
     private void validateRow(BankCsvRow row, int rowNumber) {

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/app/categorization/AiCategorizationPromptBuilder.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/app/categorization/AiCategorizationPromptBuilder.java
@@ -276,21 +276,45 @@ public class AiCategorizationPromptBuilder {
         if (!uniqueBankCategories.isEmpty()) {
             sb.append("""
 
-                ⚠️ WARNING ABOUT BANK CATEGORIES:
-                The following are ACTUAL bankCategory values from the bank's CSV export.
-                Most Polish banks use GENERIC categories that are NOT useful for categorization:
-                - "TRANSAKCJA KARTĄ PŁATNICZĄ" = card payment (covers 60%+ of all transactions!)
-                - "PRZELEW" / "PRZELEW WYCHODZĄCY" = wire transfer
-                - "PŁATNOŚĆ BLIK" = BLIK payment
+                ⚠️ BANK CATEGORY CLASSIFICATION - CRITICAL:
 
-                DO NOT create bankCategoryMappings for these generic categories!
-                Instead, focus on creating patternMappings for each merchant pattern shown above.
+                Polish banks use TWO types of categories. You MUST handle them differently:
 
-                REMEMBER: bankCategory values are shown in "bank:" field of each pattern above.
-                Only values from that field can be used in bankCategoryMappings!
+                TYPE 1: GENERIC categories (describe HOW payment was made):
+                  Examples: "TRANSAKCJA KARTĄ PŁATNICZĄ", "PRZELEW WYCHODZĄCY",
+                            "PŁATNOŚĆ BLIK", "Przelewy wychodzące", "Przelewy przychodzące",
+                            "Opłaty i prowizje", "Płatności kartą"
+
+                  These are USELESS for categorization - many different purchases share the same category!
+                  → DO NOT create bankCategoryMapping for these
+                  → Use patternMappings based on merchant name instead
+
+                TYPE 2: SEMANTIC categories (describe WHAT was purchased):
+                  Examples: "Artykuły spożywcze", "Restauracje i kawiarnie", "Sport",
+                            "Paliwo", "Transport publiczny", "Opieka medyczna", "Hobby",
+                            "Kino i teatr", "Kosmetyki", "Lekarstwa", "Zakupy przez internet"
+
+                  These are VALUABLE - they tell you exactly what the transaction is for!
+                  → MUST create bankCategoryMapping for EACH semantic category
+                  → Map to matching CashFlow category or suggest creating new one
+
+                HOW TO DETECT:
+                - GENERIC = describes PAYMENT METHOD (card, transfer, BLIK, fees) → IGNORE
+                - SEMANTIC = describes PURCHASE TYPE (food, sport, fuel, healthcare) → MAP IT!
+
+                EXAMPLES:
+                - "Przelewy wychodzące" = GENERIC (just says "outgoing transfer") → NO mapping
+                - "Artykuły spożywcze" = SEMANTIC (means "groceries") → CREATE mapping!
+                - "TRANSAKCJA KARTĄ" = GENERIC (just says "card transaction") → NO mapping
+                - "Restauracje i kawiarnie" = SEMANTIC (means "dining") → CREATE mapping!
+                - "Sport" = SEMANTIC → CREATE mapping!
+                - "Paliwo" = SEMANTIC (means "fuel") → CREATE mapping!
+
+                IMPORTANT: You MUST create a bankCategoryMapping for EVERY semantic category listed below!
+                If you see 30 semantic categories, you should return ~30 bankCategoryMappings.
 
                 """);
-            sb.append("UNIQUE BANK CATEGORIES (create mappings for those not matching existing categories):\n");
+            sb.append("UNIQUE BANK CATEGORIES:\n");
             for (String bankCategory : uniqueBankCategories) {
                 Type categoryType = patternGroups.stream()
                         .filter(pg -> bankCategory.equals(pg.bankCategory()))
@@ -301,10 +325,15 @@ public class AiCategorizationPromptBuilder {
                 boolean directMatch = categoryStructure != null &&
                         categoryStructure.containsCategoryIgnoreCase(bankCategory);
 
+                // Detect if category is GENERIC or SEMANTIC
+                boolean isGeneric = isGenericBankCategory(bankCategory);
+
                 if (directMatch) {
                     sb.append("  - ").append(bankCategory).append(" [").append(categoryType).append("] → DIRECT MATCH (no mapping needed)\n");
+                } else if (isGeneric) {
+                    sb.append("  - ").append(bankCategory).append(" [").append(categoryType).append("] → GENERIC (use patternMappings instead)\n");
                 } else {
-                    sb.append("  - ").append(bankCategory).append(" [").append(categoryType).append("] → NEEDS MAPPING to existing category\n");
+                    sb.append("  - ").append(bankCategory).append(" [").append(categoryType).append("] → SEMANTIC - MUST CREATE bankCategoryMapping!\n");
                 }
             }
             sb.append("\n");
@@ -497,5 +526,43 @@ public class AiCategorizationPromptBuilder {
         if (s == null) return "";
         if (s.length() <= maxLen) return s;
         return s.substring(0, maxLen - 3) + "...";
+    }
+
+    /**
+     * Detects if a bank category is GENERIC (describes payment method) vs SEMANTIC (describes purchase type).
+     * Generic categories are useless for categorization - they should be ignored in favor of pattern matching.
+     * Semantic categories are valuable and should be mapped to CashFlow categories.
+     */
+    private boolean isGenericBankCategory(String bankCategory) {
+        if (bankCategory == null || bankCategory.isBlank()) {
+            return true;
+        }
+
+        String normalized = bankCategory.toUpperCase().trim();
+
+        // List of known GENERIC categories (payment method descriptions)
+        Set<String> genericCategories = Set.of(
+                // Nest Bank style
+                "PRZELEWY WYCHODZĄCE",
+                "PRZELEWY PRZYCHODZĄCE",
+                "OPŁATY I PROWIZJE",
+                "PŁATNOŚCI KARTĄ",
+                // Common generic Polish bank categories
+                "TRANSAKCJA KARTĄ PŁATNICZĄ",
+                "TRANSAKCJA KARTĄ",
+                "PŁATNOŚĆ KARTĄ",
+                "PRZELEW",
+                "PRZELEW WYCHODZĄCY",
+                "PRZELEW PRZYCHODZĄCY",
+                "PRZELEW WEWNĘTRZNY",
+                "PŁATNOŚĆ BLIK",
+                "BLIK",
+                "WYPŁATA Z BANKOMATU",
+                "WPŁATA GOTÓWKI",
+                "ZLECENIE STAŁE",
+                "POLECENIE ZAPŁATY"
+        );
+
+        return genericCategories.contains(normalized);
     }
 }

--- a/src/main/java/com/multi/vidulum/bank_data_ingestion/domain/BankCsvRow.java
+++ b/src/main/java/com/multi/vidulum/bank_data_ingestion/domain/BankCsvRow.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.bank_data_ingestion.domain;
 
+import com.multi.vidulum.bank_data_adapter.domain.TransactionClassification;
 import com.multi.vidulum.cashflow.domain.Type;
 
 import java.math.BigDecimal;
@@ -81,6 +82,7 @@ public record BankCsvRow(
          * Extracted merchant name (from description for bank intermediary transactions).
          * OPTIONAL - AI extracts this when name is "BANK PEKAO S.A." etc.
          * Examples: "BADOO", "NETFLIX", "OPENAI", "CLAUDE"
+         * Null for non-merchant transactions (BANK_FEE, CASH_WITHDRAWAL, etc.)
          */
         String merchant,
 
@@ -97,7 +99,28 @@ public record BankCsvRow(
          * This is separate from bankCategory which describes WHAT was purchased.
          * Examples: CARD, TRANSFER, BLIK, DIRECT_DEBIT
          */
-        PaymentMethod paymentMethod
+        PaymentMethod paymentMethod,
+
+        /**
+         * Transaction classification determined by AI enrichment.
+         * Indicates the type of transaction: MERCHANT, BANK_FEE, CASH_WITHDRAWAL, etc.
+         * OPTIONAL - null defaults to UNKNOWN.
+         */
+        TransactionClassification classification,
+
+        /**
+         * Reason why AI chose this classification.
+         * OPTIONAL - useful for debugging and UI display.
+         * Examples: "Card payment at grocery store", "ATM terminal code pattern detected"
+         */
+        String classificationReason,
+
+        /**
+         * Location extracted from transaction (for ATM, physical locations).
+         * OPTIONAL - null if no location detected.
+         * Examples: "WARSZAWA", "KRAKÓW", "UL. MARSZAŁKOWSKA 10"
+         */
+        String location
 
 ) {
     /**
@@ -142,6 +165,38 @@ public record BankCsvRow(
      */
     public PaymentMethod effectivePaymentMethod() {
         return paymentMethod != null ? paymentMethod : PaymentMethod.OTHER;
+    }
+
+    /**
+     * Returns effective classification (UNKNOWN if null).
+     */
+    public TransactionClassification effectiveClassification() {
+        return classification != null ? classification : TransactionClassification.UNKNOWN;
+    }
+
+    /**
+     * Returns true if this transaction should be auto-categorized.
+     * Auto-categorizable transactions (BANK_FEE, CASH_WITHDRAWAL, etc.) already have
+     * their bankCategory from enrichment and should skip AI categorization.
+     */
+    public boolean isAutoCategorizeable() {
+        return effectiveClassification().isAutoCategorizeable();
+    }
+
+    /**
+     * Returns true if this transaction should be included in budget analysis.
+     * Self-transfers should be excluded as they don't represent real income/expense.
+     */
+    public boolean includeInBudget() {
+        return effectiveClassification().includeInBudget();
+    }
+
+    /**
+     * Returns true if this transaction has a meaningful merchant.
+     * Non-merchant transactions (BANK_FEE, CASH_WITHDRAWAL, etc.) have null merchant.
+     */
+    public boolean hasMerchant() {
+        return effectiveClassification().hasMerchant() && merchant != null && !merchant.isBlank();
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,9 @@ vidulum:
 bank-data-adapter:
   max-file-size-bytes: 5242880  # 5MB
   max-retries: 2
+  enrichment:
+    enabled: true            # Enable enrichment (fills merchant + bankCategory)
+    batch-size: 50           # Transactions per AI call
 
 # Bank Data Ingestion REST client
 bank-data-ingestion:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,7 @@ bank-data-adapter:
   enrichment:
     enabled: true            # Enable enrichment (fills merchant + bankCategory)
     batch-size: 50           # Transactions per AI call
+    max-parallelism: 4       # Max concurrent AI calls (avoid rate limiting)
 
 # Bank Data Ingestion REST client
 bank-data-ingestion:

--- a/src/test/java/com/multi/vidulum/bank_data_adapter/app/CanonicalCsvDetectionTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_adapter/app/CanonicalCsvDetectionTest.java
@@ -1,5 +1,6 @@
 package com.multi.vidulum.bank_data_adapter.app;
 
+import com.multi.vidulum.bank_data_adapter.app.enrichment.TransactionEnrichmentService;
 import com.multi.vidulum.bank_data_adapter.domain.AiCsvTransformationDocument;
 import com.multi.vidulum.bank_data_adapter.domain.AiCsvTransformationRepository;
 import com.multi.vidulum.bank_data_adapter.domain.DetectionResult;
@@ -10,6 +11,7 @@ import com.multi.vidulum.bank_data_adapter.infrastructure.AiResponseProcessor;
 import com.multi.vidulum.bank_data_adapter.infrastructure.CsvAnonymizer;
 import com.multi.vidulum.bank_data_adapter.infrastructure.CsvFormatDetector;
 import com.multi.vidulum.bank_data_adapter.infrastructure.LocalCsvTransformer;
+import com.multi.vidulum.bank_data_adapter.app.enrichment.TransactionEnrichmentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -68,6 +70,9 @@ class CanonicalCsvDetectionTest {
     @Mock
     private CsvFormatDetector csvFormatDetector;
 
+    @Mock
+    private TransactionEnrichmentService enrichmentService;
+
     private AiBankCsvTransformService service;
 
     private static final Clock FIXED_CLOCK = Clock.fixed(
@@ -87,6 +92,7 @@ class CanonicalCsvDetectionTest {
             mappingRulesCacheService,
             transformationRepository,
             csvFormatDetector,
+            enrichmentService,
             FIXED_CLOCK
         );
         // Set @Value fields via reflection since they're not injected in unit tests

--- a/src/test/java/com/multi/vidulum/bank_data_adapter/app/DateRangeExtractionTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_adapter/app/DateRangeExtractionTest.java
@@ -3,6 +3,7 @@ package com.multi.vidulum.bank_data_adapter.app;
 import com.multi.vidulum.bank_data_adapter.domain.AiCsvTransformationDocument;
 import com.multi.vidulum.bank_data_adapter.domain.AiCsvTransformationRepository;
 import com.multi.vidulum.bank_data_adapter.infrastructure.*;
+import com.multi.vidulum.bank_data_adapter.app.enrichment.TransactionEnrichmentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -59,6 +60,9 @@ class DateRangeExtractionTest {
     @Mock
     private CsvFormatDetector csvFormatDetector;
 
+    @Mock
+    private TransactionEnrichmentService enrichmentService;
+
     private AiBankCsvTransformService service;
 
     private static final Clock FIXED_CLOCK = Clock.fixed(
@@ -79,6 +83,7 @@ class DateRangeExtractionTest {
             mappingRulesCacheService,
             transformationRepository,
             csvFormatDetector,
+            enrichmentService,
             FIXED_CLOCK
         );
     }

--- a/src/test/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentPromptBuilderTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentPromptBuilderTest.java
@@ -1,0 +1,181 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnrichmentPromptBuilderTest {
+
+    private EnrichmentPromptBuilder promptBuilder;
+
+    @BeforeEach
+    void setUp() {
+        promptBuilder = new EnrichmentPromptBuilder(new ObjectMapper());
+    }
+
+    @Test
+    void shouldBuildSystemPrompt() {
+        // when
+        String systemPrompt = promptBuilder.getSystemPrompt();
+
+        // then
+        assertThat(systemPrompt)
+                .contains("transaction data enrichment specialist")
+                .contains("MERCHANT EXTRACTION RULES")
+                .contains("BANK_CATEGORY RULES")
+                .contains("MERCHANT_CONFIDENCE")
+                .contains("OUTPUT FORMAT")
+                .contains("ERROR HANDLING")
+                .contains("ŻABKA")
+                .contains("NETFLIX")
+                .contains("bankCategorySource");
+    }
+
+    @Test
+    void shouldBuildUserPromptWithBatchInfo() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "ŻABKA POLSKA 4521", "Nr karty", ""),
+                createTransaction(1, "Netflix.com", "Subscription", "Rozrywka")
+        );
+
+        // when
+        String userPrompt = promptBuilder.buildUserPrompt(
+                transactions, 1, 3, "Nest Bank", "pl");
+
+        // then
+        assertThat(userPrompt)
+                .contains("Analyze these 2 transactions")
+                .containsPattern("\"batchNumber\"\\s*:\\s*1")
+                .containsPattern("\"totalBatches\"\\s*:\\s*3")
+                .containsPattern("\"transactionsInBatch\"\\s*:\\s*2")
+                .containsPattern("\"bankName\"\\s*:\\s*\"Nest Bank\"")
+                .containsPattern("\"language\"\\s*:\\s*\"pl\"")
+                .containsPattern("\"rowIndex\"\\s*:\\s*0")
+                .containsPattern("\"rowIndex\"\\s*:\\s*1")
+                .contains("ŻABKA POLSKA 4521")
+                .contains("Netflix.com")
+                .containsPattern("\"bankCategory\"\\s*:\\s*\"\"")  // Empty for first
+                .containsPattern("\"bankCategory\"\\s*:\\s*\"Rozrywka\"");  // Filled for second
+    }
+
+    @Test
+    void shouldHandleEmptyDescriptions() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "BIEDRONKA", null, ""),
+                createTransaction(1, "ZUS", "", "")
+        );
+
+        // when
+        String userPrompt = promptBuilder.buildUserPrompt(
+                transactions, 1, 1, "Unknown", "pl");
+
+        // then
+        assertThat(userPrompt)
+                .containsPattern("\"description\"\\s*:\\s*\"\"")
+                .doesNotContain("null");
+    }
+
+    @Test
+    void shouldHandlePolishCharacters() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "ŻABKA ĆWICZENIA ŁÓDŹ", "Płatność kartą", ""),
+                createTransaction(1, "ŹRÓDŁO ŚWIĘTOŚĆ", "Przelew", "")
+        );
+
+        // when
+        String userPrompt = promptBuilder.buildUserPrompt(
+                transactions, 1, 1, "Test Bank", "pl");
+
+        // then
+        assertThat(userPrompt)
+                .contains("ŻABKA ĆWICZENIA ŁÓDŹ")
+                .contains("Płatność kartą")
+                .contains("ŹRÓDŁO ŚWIĘTOŚĆ");
+    }
+
+    @Test
+    void shouldNotIncludeAmountAndType() {
+        // given - amount and type were removed from enrichment as they don't help
+        // with merchant extraction or category inference
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "Employer", "Salary", ""),
+                createTransaction(1, "Shop", "Purchase", "")
+        );
+
+        // when
+        String userPrompt = promptBuilder.buildUserPrompt(
+                transactions, 1, 1, "Bank", "pl");
+
+        // then - verify amount and type are NOT in the prompt
+        assertThat(userPrompt)
+                .doesNotContain("\"type\"")
+                .doesNotContain("\"amount\"")
+                .doesNotContain("INFLOW")
+                .doesNotContain("OUTFLOW");
+    }
+
+    @Test
+    void shouldHandleNullBankNameAndLanguage() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "Test", "desc", "")
+        );
+
+        // when
+        String userPrompt = promptBuilder.buildUserPrompt(
+                transactions, 1, 1, null, null);
+
+        // then
+        assertThat(userPrompt)
+                .containsPattern("\"bankName\"\\s*:\\s*\"Unknown\"")
+                .containsPattern("\"language\"\\s*:\\s*\"pl\"");
+    }
+
+    @Test
+    void systemPromptShouldContainJsonOutputInstructions() {
+        // when
+        String systemPrompt = promptBuilder.getSystemPrompt();
+
+        // then
+        assertThat(systemPrompt)
+                .contains("Return ONLY valid JSON")
+                .contains("No markdown")
+                .contains("\"success\": true")
+                .contains("\"enrichedTransactions\"")
+                .contains("\"rowIndex\"")
+                .contains("\"merchant\"")
+                .contains("\"merchantConfidence\"")
+                .contains("\"bankCategory\"")
+                .contains("\"bankCategorySource\"");
+    }
+
+    @Test
+    void systemPromptShouldContainFallbackInstructions() {
+        // when
+        String systemPrompt = promptBuilder.getSystemPrompt();
+
+        // then
+        assertThat(systemPrompt)
+                .contains("If you cannot determine merchant")
+                .contains("fallback")
+                .contains("NEVER return null")
+                .contains("AI_FALLBACK");
+    }
+
+    private TransactionForEnrichment createTransaction(int rowIndex, String name,
+                                                        String description, String bankCategory) {
+        return TransactionForEnrichment.builder()
+                .rowIndex(rowIndex)
+                .name(name)
+                .description(description)
+                .bankCategory(bankCategory)
+                .build();
+    }
+}

--- a/src/test/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResponseProcessorTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResponseProcessorTest.java
@@ -1,0 +1,272 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnrichmentResponseProcessorTest {
+
+    private EnrichmentResponseProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new EnrichmentResponseProcessor(new ObjectMapper());
+    }
+
+    @Test
+    void shouldParseValidJsonResponse() {
+        // given
+        String aiResponse = """
+            {
+              "success": true,
+              "enrichedTransactions": [
+                {
+                  "rowIndex": 0,
+                  "merchant": "ŻABKA",
+                  "merchantConfidence": 0.95,
+                  "bankCategory": "Zakupy spożywcze",
+                  "bankCategorySource": "AI_INFERRED"
+                },
+                {
+                  "rowIndex": 1,
+                  "merchant": "NETFLIX",
+                  "merchantConfidence": 0.98,
+                  "bankCategory": "Rozrywka",
+                  "bankCategorySource": "ORIGINAL"
+                }
+              ],
+              "processingNotes": "All transactions processed successfully"
+            }
+            """;
+
+        List<TransactionForEnrichment> originals = List.of(
+                createTransaction(0, "ŻABKA POLSKA 4521 WARSZAWA", "", ""),
+                createTransaction(1, "NETFLIX.COM", "", "Inne")
+        );
+
+        // when
+        EnrichmentBatchResult result = processor.process(aiResponse, originals);
+
+        // then
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getEnrichedTransactions()).hasSize(2);
+        assertThat(result.getEnrichedTransactions().get(0).getMerchant()).isEqualTo("ŻABKA");
+        assertThat(result.getEnrichedTransactions().get(0).getMerchantConfidence()).isEqualTo(0.95);
+        assertThat(result.getEnrichedTransactions().get(1).getMerchant()).isEqualTo("NETFLIX");
+        assertThat(result.getProcessingNotes()).isEqualTo("All transactions processed successfully");
+    }
+
+    @Test
+    void shouldExtractJsonFromMarkdownCodeBlock() {
+        // given
+        String aiResponse = """
+            Here is the enrichment result:
+
+            ```json
+            {
+              "success": true,
+              "enrichedTransactions": [
+                {
+                  "rowIndex": 0,
+                  "merchant": "ZUS",
+                  "merchantConfidence": 0.98,
+                  "bankCategory": "Podatki i składki",
+                  "bankCategorySource": "AI_INFERRED"
+                }
+              ]
+            }
+            ```
+
+            The transaction was identified as ZUS payment.
+            """;
+
+        List<TransactionForEnrichment> originals = List.of(
+                createTransaction(0, "ZUS", "składki ZUS", "")
+        );
+
+        // when
+        EnrichmentBatchResult result = processor.process(aiResponse, originals);
+
+        // then
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getEnrichedTransactions()).hasSize(1);
+        assertThat(result.getEnrichedTransactions().get(0).getMerchant()).isEqualTo("ZUS");
+    }
+
+    @Test
+    void shouldUseFallbackForEmptyResponse() {
+        // given
+        String aiResponse = "";
+        List<TransactionForEnrichment> originals = List.of(
+                createTransaction(0, "Some Transaction", "desc", "Inne")
+        );
+
+        // when
+        EnrichmentBatchResult result = processor.process(aiResponse, originals);
+
+        // then
+        assertThat(result.isSuccess()).isTrue(); // Fallback is still "success" for flow continuation
+        assertThat(result.getEnrichedTransactions()).hasSize(1);
+        assertThat(result.getEnrichedTransactions().get(0).getMerchantConfidence()).isLessThan(0.5);
+        assertThat(result.getProcessingNotes()).contains("Fallback");
+    }
+
+    @Test
+    void shouldUseFallbackForInvalidJson() {
+        // given
+        String aiResponse = "This is not JSON at all!";
+        List<TransactionForEnrichment> originals = List.of(
+                createTransaction(0, "Transaction", "desc", "")
+        );
+
+        // when
+        EnrichmentBatchResult result = processor.process(aiResponse, originals);
+
+        // then
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getEnrichedTransactions()).hasSize(1);
+        assertThat(result.getProcessingNotes()).contains("Fallback");
+    }
+
+    @Test
+    void shouldRepairPartialResult() {
+        // given - AI returned only 1 of 2 transactions
+        String aiResponse = """
+            {
+              "success": true,
+              "enrichedTransactions": [
+                {
+                  "rowIndex": 0,
+                  "merchant": "ALLEGRO",
+                  "merchantConfidence": 0.95,
+                  "bankCategory": "Zakupy",
+                  "bankCategorySource": "AI_INFERRED"
+                }
+              ]
+            }
+            """;
+
+        List<TransactionForEnrichment> originals = List.of(
+                createTransaction(0, "ALLEGRO.PL", "", ""),
+                createTransaction(1, "Missing Transaction", "", "Inne")
+        );
+
+        // when
+        EnrichmentBatchResult result = processor.process(aiResponse, originals);
+
+        // then
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getEnrichedTransactions()).hasSize(2);
+
+        // First one from AI
+        assertThat(result.getEnrichedTransactions().get(0).getMerchant()).isEqualTo("ALLEGRO");
+        assertThat(result.getEnrichedTransactions().get(0).getMerchantConfidence()).isEqualTo(0.95);
+
+        // Second one filled with fallback
+        var secondTxn = result.getEnrichedTransactions().stream()
+                .filter(t -> t.getRowIndex() == 1)
+                .findFirst()
+                .orElseThrow();
+        assertThat(secondTxn.getMerchantConfidence()).isLessThan(0.5);
+    }
+
+    @Test
+    void shouldKeepOriginalBankCategoryWhenMarkedAsOriginal() {
+        // given
+        String aiResponse = """
+            {
+              "success": true,
+              "enrichedTransactions": [
+                {
+                  "rowIndex": 0,
+                  "merchant": "BIEDRONKA",
+                  "merchantConfidence": 0.95,
+                  "bankCategory": "Zakupy spożywcze",
+                  "bankCategorySource": "ORIGINAL"
+                }
+              ]
+            }
+            """;
+
+        List<TransactionForEnrichment> originals = List.of(
+                createTransaction(0, "BIEDRONKA SKLEP", "", "Zakupy spożywcze")
+        );
+
+        // when
+        EnrichmentBatchResult result = processor.process(aiResponse, originals);
+        List<EnrichedTransaction> domain = processor.toDomainObjects(result);
+
+        // then
+        assertThat(domain).hasSize(1);
+        assertThat(domain.get(0).getBankCategorySource())
+                .isEqualTo(EnrichedTransaction.BankCategorySource.ORIGINAL);
+    }
+
+    @Test
+    void shouldConvertToDomainObjects() {
+        // given
+        String aiResponse = """
+            {
+              "success": true,
+              "enrichedTransactions": [
+                {
+                  "rowIndex": 0,
+                  "merchant": "ORLEN",
+                  "merchantConfidence": 0.92,
+                  "bankCategory": "Transport",
+                  "bankCategorySource": "AI_INFERRED"
+                }
+              ]
+            }
+            """;
+
+        List<TransactionForEnrichment> originals = List.of(
+                createTransaction(0, "ORLEN STACJA 123", "Paliwo", "")
+        );
+
+        EnrichmentBatchResult batchResult = processor.process(aiResponse, originals);
+
+        // when
+        List<EnrichedTransaction> domain = processor.toDomainObjects(batchResult);
+
+        // then
+        assertThat(domain).hasSize(1);
+        EnrichedTransaction txn = domain.get(0);
+        assertThat(txn.getRowIndex()).isEqualTo(0);
+        assertThat(txn.getMerchant()).isEqualTo("ORLEN");
+        assertThat(txn.getMerchantConfidence()).isEqualTo(0.92);
+        assertThat(txn.getBankCategory()).isEqualTo("Transport");
+        assertThat(txn.getBankCategorySource())
+                .isEqualTo(EnrichedTransaction.BankCategorySource.AI_INFERRED);
+    }
+
+    @Test
+    void shouldHandleNullResponse() {
+        // given
+        List<TransactionForEnrichment> originals = List.of(
+                createTransaction(0, "Test", "", "")
+        );
+
+        // when
+        EnrichmentBatchResult result = processor.process(null, originals);
+
+        // then
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getEnrichedTransactions()).hasSize(1);
+        assertThat(result.getProcessingNotes()).contains("Empty AI response");
+    }
+
+    private TransactionForEnrichment createTransaction(int rowIndex, String name,
+                                                        String description, String bankCategory) {
+        return TransactionForEnrichment.builder()
+                .rowIndex(rowIndex)
+                .name(name)
+                .description(description)
+                .bankCategory(bankCategory)
+                .build();
+    }
+}

--- a/src/test/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentServiceGroupingTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentServiceGroupingTest.java
@@ -1,0 +1,302 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.model.ChatModel;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionEnrichmentServiceGroupingTest {
+
+    private TransactionEnrichmentService service;
+
+    @Mock
+    private ChatModel chatModel;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        EnrichmentPromptBuilder promptBuilder = new EnrichmentPromptBuilder(objectMapper);
+        EnrichmentResponseProcessor responseProcessor = new EnrichmentResponseProcessor(objectMapper);
+        service = new TransactionEnrichmentService(chatModel, promptBuilder, responseProcessor);
+    }
+
+    @Test
+    void shouldGroupTransactionsByExactName() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "ŻABKA POLSKA", "", ""),
+                createTransaction(1, "BIEDRONKA", "", ""),
+                createTransaction(2, "ŻABKA POLSKA", "", ""),
+                createTransaction(3, "BIEDRONKA", "", ""),
+                createTransaction(4, "ŻABKA POLSKA", "", "")
+        );
+
+        // when
+        Map<String, TransactionGroup> groups = service.groupTransactions(transactions);
+
+        // then
+        assertThat(groups).hasSize(2);
+        assertThat(groups.get("ŻABKA POLSKA").size()).isEqualTo(3);
+        assertThat(groups.get("BIEDRONKA").size()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldNormalizeCaseForGrouping() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "Netflix", "", ""),
+                createTransaction(1, "NETFLIX", "", ""),
+                createTransaction(2, "netflix", "", "")
+        );
+
+        // when
+        Map<String, TransactionGroup> groups = service.groupTransactions(transactions);
+
+        // then
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get("NETFLIX").size()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldTrimWhitespaceForGrouping() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "ZUS", "", ""),
+                createTransaction(1, " ZUS ", "", ""),
+                createTransaction(2, "  ZUS", "", "")
+        );
+
+        // when
+        Map<String, TransactionGroup> groups = service.groupTransactions(transactions);
+
+        // then
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get("ZUS").size()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldSelectBestRepresentativeWithCategory() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "PROWIZJA", "", ""),         // empty
+                createTransaction(1, "PROWIZJA", "", "Inne"),     // Inne
+                createTransaction(2, "PROWIZJA", "", "Opłaty bankowe") // specific
+        );
+
+        // when
+        Map<String, TransactionGroup> groups = service.groupTransactions(transactions);
+
+        // then - representative should have the best bankCategory
+        TransactionGroup group = groups.get("PROWIZJA");
+        assertThat(group.getRepresentative().getBankCategory()).isEqualTo("Opłaty bankowe");
+        // but rowIndex should be from first transaction
+        assertThat(group.getRepresentative().getRowIndex()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldPropagateMerchantToAllTransactions() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "ŻABKA POLSKA 123", "", ""),
+                createTransaction(1, "ŻABKA POLSKA 123", "", ""),
+                createTransaction(2, "ŻABKA POLSKA 123", "", "")
+        );
+
+        Map<String, TransactionGroup> groups = service.groupTransactions(transactions);
+
+        // Simulate AI result for representative
+        List<EnrichedTransaction> enrichedRepresentatives = List.of(
+                EnrichedTransaction.builder()
+                        .rowIndex(0)
+                        .merchant("ŻABKA")
+                        .merchantConfidence(0.95)
+                        .bankCategory("Zakupy spożywcze")
+                        .bankCategorySource(EnrichedTransaction.BankCategorySource.AI_INFERRED)
+                        .build()
+        );
+
+        // when
+        List<EnrichedTransaction> allEnriched = service.propagateResults(
+                enrichedRepresentatives, groups, transactions);
+
+        // then
+        assertThat(allEnriched).hasSize(3);
+        assertThat(allEnriched).allMatch(e -> e.getMerchant().equals("ŻABKA"));
+        assertThat(allEnriched).allMatch(e -> e.getMerchantConfidence() == 0.95);
+    }
+
+    @Test
+    void shouldSelectivelyPropagateBankCategory() {
+        // given - PROWIZJA with mixed original categories
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "PROWIZJA", "", ""),              // empty → should get AI result
+                createTransaction(1, "PROWIZJA", "", "Opłaty bankowe"), // has value → should keep
+                createTransaction(2, "PROWIZJA", "", ""),              // empty → should get AI result
+                createTransaction(3, "PROWIZJA", "", "Inne")           // has value → should keep
+        );
+
+        Map<String, TransactionGroup> groups = service.groupTransactions(transactions);
+
+        // AI returns category for representative
+        List<EnrichedTransaction> enrichedRepresentatives = List.of(
+                EnrichedTransaction.builder()
+                        .rowIndex(0)
+                        .merchant("PROWIZJA BANKOWA")
+                        .merchantConfidence(0.8)
+                        .bankCategory("Opłaty bankowe")  // AI inferred this
+                        .bankCategorySource(EnrichedTransaction.BankCategorySource.AI_INFERRED)
+                        .build()
+        );
+
+        // when
+        List<EnrichedTransaction> allEnriched = service.propagateResults(
+                enrichedRepresentatives, groups, transactions);
+
+        // then
+        assertThat(allEnriched).hasSize(4);
+
+        // All should have same merchant
+        assertThat(allEnriched).allMatch(e -> e.getMerchant().equals("PROWIZJA BANKOWA"));
+
+        // Row 0: had empty → should get AI category
+        EnrichedTransaction row0 = findByRowIndex(allEnriched, 0);
+        assertThat(row0.getBankCategory()).isEqualTo("Opłaty bankowe");
+        assertThat(row0.getBankCategorySource()).isEqualTo(EnrichedTransaction.BankCategorySource.AI_INFERRED);
+
+        // Row 1: had "Opłaty bankowe" → should keep original
+        EnrichedTransaction row1 = findByRowIndex(allEnriched, 1);
+        assertThat(row1.getBankCategory()).isEqualTo("Opłaty bankowe");
+        assertThat(row1.getBankCategorySource()).isEqualTo(EnrichedTransaction.BankCategorySource.ORIGINAL);
+
+        // Row 2: had empty → should get AI category
+        EnrichedTransaction row2 = findByRowIndex(allEnriched, 2);
+        assertThat(row2.getBankCategory()).isEqualTo("Opłaty bankowe");
+        assertThat(row2.getBankCategorySource()).isEqualTo(EnrichedTransaction.BankCategorySource.AI_INFERRED);
+
+        // Row 3: had "Inne" → should keep original
+        EnrichedTransaction row3 = findByRowIndex(allEnriched, 3);
+        assertThat(row3.getBankCategory()).isEqualTo("Inne");
+        assertThat(row3.getBankCategorySource()).isEqualTo(EnrichedTransaction.BankCategorySource.ORIGINAL);
+    }
+
+    @Test
+    void shouldHandleMultipleGroupsWithDifferentCategories() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "NETFLIX", "", ""),
+                createTransaction(1, "SPOTIFY", "", "Rozrywka"),
+                createTransaction(2, "NETFLIX", "", "Inne"),
+                createTransaction(3, "SPOTIFY", "", "")
+        );
+
+        Map<String, TransactionGroup> groups = service.groupTransactions(transactions);
+
+        // AI results for both representatives
+        List<EnrichedTransaction> enrichedRepresentatives = List.of(
+                EnrichedTransaction.builder()
+                        .rowIndex(0)
+                        .merchant("NETFLIX")
+                        .merchantConfidence(0.98)
+                        .bankCategory("Rozrywka")
+                        .bankCategorySource(EnrichedTransaction.BankCategorySource.AI_INFERRED)
+                        .build(),
+                EnrichedTransaction.builder()
+                        .rowIndex(1)
+                        .merchant("SPOTIFY")
+                        .merchantConfidence(0.97)
+                        .bankCategory("Rozrywka")
+                        .bankCategorySource(EnrichedTransaction.BankCategorySource.ORIGINAL)
+                        .build()
+        );
+
+        // when
+        List<EnrichedTransaction> allEnriched = service.propagateResults(
+                enrichedRepresentatives, groups, transactions);
+
+        // then
+        assertThat(allEnriched).hasSize(4);
+
+        // NETFLIX group
+        EnrichedTransaction netflix0 = findByRowIndex(allEnriched, 0);
+        assertThat(netflix0.getMerchant()).isEqualTo("NETFLIX");
+        assertThat(netflix0.getBankCategory()).isEqualTo("Rozrywka");
+        assertThat(netflix0.getBankCategorySource()).isEqualTo(EnrichedTransaction.BankCategorySource.AI_INFERRED);
+
+        EnrichedTransaction netflix2 = findByRowIndex(allEnriched, 2);
+        assertThat(netflix2.getMerchant()).isEqualTo("NETFLIX");
+        assertThat(netflix2.getBankCategory()).isEqualTo("Inne"); // kept original
+        assertThat(netflix2.getBankCategorySource()).isEqualTo(EnrichedTransaction.BankCategorySource.ORIGINAL);
+
+        // SPOTIFY group
+        EnrichedTransaction spotify1 = findByRowIndex(allEnriched, 1);
+        assertThat(spotify1.getMerchant()).isEqualTo("SPOTIFY");
+        assertThat(spotify1.getBankCategory()).isEqualTo("Rozrywka"); // kept original
+        assertThat(spotify1.getBankCategorySource()).isEqualTo(EnrichedTransaction.BankCategorySource.ORIGINAL);
+
+        EnrichedTransaction spotify3 = findByRowIndex(allEnriched, 3);
+        assertThat(spotify3.getMerchant()).isEqualTo("SPOTIFY");
+        assertThat(spotify3.getBankCategory()).isEqualTo("Rozrywka"); // propagated from AI
+        assertThat(spotify3.getBankCategorySource()).isEqualTo(EnrichedTransaction.BankCategorySource.ORIGINAL);
+    }
+
+    @Test
+    void shouldHandleNullName() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, null, "", ""),
+                createTransaction(1, "", "", ""),
+                createTransaction(2, null, "", "")
+        );
+
+        // when
+        Map<String, TransactionGroup> groups = service.groupTransactions(transactions);
+
+        // then - all should be in same group (empty key)
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get("").size()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldProvideCorrectRowIndexesForGroup() {
+        // given
+        List<TransactionForEnrichment> transactions = List.of(
+                createTransaction(0, "ZUS", "", ""),
+                createTransaction(5, "BIEDRONKA", "", ""),
+                createTransaction(10, "ZUS", "", ""),
+                createTransaction(15, "ZUS", "", "")
+        );
+
+        // when
+        Map<String, TransactionGroup> groups = service.groupTransactions(transactions);
+
+        // then
+        assertThat(groups.get("ZUS").getRowIndexes()).containsExactly(0, 10, 15);
+        assertThat(groups.get("BIEDRONKA").getRowIndexes()).containsExactly(5);
+    }
+
+    private EnrichedTransaction findByRowIndex(List<EnrichedTransaction> list, int rowIndex) {
+        return list.stream()
+                .filter(e -> e.getRowIndex() == rowIndex)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No transaction with rowIndex " + rowIndex));
+    }
+
+    private TransactionForEnrichment createTransaction(int rowIndex, String name,
+                                                        String description, String bankCategory) {
+        return TransactionForEnrichment.builder()
+                .rowIndex(rowIndex)
+                .name(name)
+                .description(description)
+                .bankCategory(bankCategory)
+                .build();
+    }
+}

--- a/src/test/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionGroupTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionGroupTest.java
@@ -1,0 +1,195 @@
+package com.multi.vidulum.bank_data_adapter.app.enrichment;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransactionGroupTest {
+
+    @Test
+    void shouldAddTransactionAndTrackRowIndex() {
+        // given
+        TransactionGroup group = TransactionGroup.builder()
+                .groupKey("ŻABKA")
+                .build();
+
+        TransactionForEnrichment txn1 = createTransaction(0, "ŻABKA", "", "");
+        TransactionForEnrichment txn2 = createTransaction(5, "ŻABKA", "", "");
+        TransactionForEnrichment txn3 = createTransaction(10, "ŻABKA", "", "");
+
+        // when
+        group.addTransaction(txn1);
+        group.addTransaction(txn2);
+        group.addTransaction(txn3);
+
+        // then
+        assertThat(group.size()).isEqualTo(3);
+        assertThat(group.getRowIndexes()).containsExactly(0, 5, 10);
+    }
+
+    @Test
+    void shouldSelectFirstTransactionAsRepresentativeWhenAllHaveSameCategory() {
+        // given
+        TransactionGroup group = TransactionGroup.builder()
+                .groupKey("BIEDRONKA")
+                .build();
+
+        // All have empty category
+        TransactionForEnrichment txn1 = createTransaction(0, "BIEDRONKA", "", "");
+        TransactionForEnrichment txn2 = createTransaction(1, "BIEDRONKA", "", "");
+
+        // when
+        group.addTransaction(txn1);
+        group.addTransaction(txn2);
+
+        // then
+        assertThat(group.getRepresentative().getRowIndex()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldPreferSpecificCategoryOverEmpty() {
+        // given
+        TransactionGroup group = TransactionGroup.builder()
+                .groupKey("NETFLIX")
+                .build();
+
+        TransactionForEnrichment txnEmpty = createTransaction(0, "NETFLIX", "", "");
+        TransactionForEnrichment txnSpecific = createTransaction(1, "NETFLIX", "", "Rozrywka");
+
+        // when
+        group.addTransaction(txnEmpty);
+        group.addTransaction(txnSpecific);
+
+        // then - representative should use specific category
+        assertThat(group.getRepresentative().getBankCategory()).isEqualTo("Rozrywka");
+        // but rowIndex should be from first transaction
+        assertThat(group.getRepresentative().getRowIndex()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldPreferSpecificCategoryOverInne() {
+        // given
+        TransactionGroup group = TransactionGroup.builder()
+                .groupKey("ORLEN")
+                .build();
+
+        TransactionForEnrichment txnInne = createTransaction(0, "ORLEN", "", "Inne");
+        TransactionForEnrichment txnSpecific = createTransaction(1, "ORLEN", "", "Transport");
+
+        // when
+        group.addTransaction(txnInne);
+        group.addTransaction(txnSpecific);
+
+        // then
+        assertThat(group.getRepresentative().getBankCategory()).isEqualTo("Transport");
+    }
+
+    @Test
+    void shouldPreferInneOverEmpty() {
+        // given
+        TransactionGroup group = TransactionGroup.builder()
+                .groupKey("ZUS")
+                .build();
+
+        TransactionForEnrichment txnEmpty = createTransaction(0, "ZUS", "", "");
+        TransactionForEnrichment txnInne = createTransaction(1, "ZUS", "", "Inne");
+
+        // when
+        group.addTransaction(txnEmpty);
+        group.addTransaction(txnInne);
+
+        // then
+        assertThat(group.getRepresentative().getBankCategory()).isEqualTo("Inne");
+    }
+
+    @Test
+    void shouldTrackOriginalBankCategories() {
+        // given
+        TransactionGroup group = TransactionGroup.builder()
+                .groupKey("PROWIZJA")
+                .build();
+
+        TransactionForEnrichment txn1 = createTransaction(0, "PROWIZJA", "", "");
+        TransactionForEnrichment txn2 = createTransaction(1, "PROWIZJA", "", "Opłaty bankowe");
+        TransactionForEnrichment txn3 = createTransaction(2, "PROWIZJA", "", "Inne");
+
+        // when
+        group.addTransaction(txn1);
+        group.addTransaction(txn2);
+        group.addTransaction(txn3);
+
+        // then
+        assertThat(group.getOriginalBankCategories())
+                .containsEntry(0, "")
+                .containsEntry(1, "Opłaty bankowe")
+                .containsEntry(2, "Inne");
+    }
+
+    @Test
+    void shouldIdentifyEmptyBankCategory() {
+        // given
+        TransactionGroup group = TransactionGroup.builder()
+                .groupKey("TEST")
+                .build();
+
+        group.addTransaction(createTransaction(0, "TEST", "", ""));
+        group.addTransaction(createTransaction(1, "TEST", "", "Kategoria"));
+        group.addTransaction(createTransaction(2, "TEST", "", null));
+        group.addTransaction(createTransaction(3, "TEST", "", "   "));
+
+        // when/then
+        assertThat(group.hadEmptyBankCategory(0)).isTrue();
+        assertThat(group.hadEmptyBankCategory(1)).isFalse();
+        assertThat(group.hadEmptyBankCategory(2)).isTrue();
+        assertThat(group.hadEmptyBankCategory(3)).isTrue();
+    }
+
+    @Test
+    void shouldKeepRepresentativeNameAndDescriptionFromFirst() {
+        // given
+        TransactionGroup group = TransactionGroup.builder()
+                .groupKey("ALLEGRO")
+                .build();
+
+        TransactionForEnrichment txn1 = createTransaction(0, "ALLEGRO SP ZOO", "zakupy", "");
+        TransactionForEnrichment txn2 = createTransaction(1, "ALLEGRO SP ZOO", "inne zakupy", "Zakupy");
+
+        // when
+        group.addTransaction(txn1);
+        group.addTransaction(txn2);
+
+        // then - name and description from first, category from second
+        assertThat(group.getRepresentative().getName()).isEqualTo("ALLEGRO SP ZOO");
+        assertThat(group.getRepresentative().getDescription()).isEqualTo("zakupy");
+        assertThat(group.getRepresentative().getBankCategory()).isEqualTo("Zakupy");
+    }
+
+    @Test
+    void shouldHandleCaseInsensitiveInneComparison() {
+        // given
+        TransactionGroup group = TransactionGroup.builder()
+                .groupKey("TEST")
+                .build();
+
+        // "inne" lowercase vs "Inne" titlecase - both should be treated as "Inne"
+        TransactionForEnrichment txnLower = createTransaction(0, "TEST", "", "inne");
+        TransactionForEnrichment txnSpecific = createTransaction(1, "TEST", "", "Zakupy");
+
+        // when
+        group.addTransaction(txnLower);
+        group.addTransaction(txnSpecific);
+
+        // then - specific category should be preferred
+        assertThat(group.getRepresentative().getBankCategory()).isEqualTo("Zakupy");
+    }
+
+    private TransactionForEnrichment createTransaction(int rowIndex, String name,
+                                                        String description, String bankCategory) {
+        return TransactionForEnrichment.builder()
+                .rowIndex(rowIndex)
+                .name(name)
+                .description(description)
+                .bankCategory(bankCategory)
+                .build();
+    }
+}

--- a/src/test/java/com/multi/vidulum/bank_data_adapter/infrastructure/LocalCsvTransformerTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_adapter/infrastructure/LocalCsvTransformerTest.java
@@ -1007,4 +1007,280 @@ class LocalCsvTransformerTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("Schema-First: bankCategory vs paymentMethod Distinction")
+    class BankCategoryVsPaymentMethod {
+
+        @Test
+        @DisplayName("Should correctly map Pekao-style CSV with both Kategoria and Typ operacji columns")
+        void shouldCorrectlyMapPekaoStyleCsv() {
+            // given - Pekao-style CSV with both category types:
+            // "Typ operacji" = HOW (payment method) - e.g., "Płatność kartą"
+            // "Kategoria" = WHAT (semantic category) - e.g., "Sport", "Zakupy"
+            String csv = """
+                Data księgowania;Data waluty;Nadawca / Odbiorca;Kwota operacji;Waluta;Typ operacji;Kategoria
+                15.12.2025;15.12.2025;Decathlon Polska;-199.99;PLN;Płatność kartą;Sport
+                16.12.2025;16.12.2025;Biedronka;-85.50;PLN;Płatność kartą;Zakupy
+                17.12.2025;17.12.2025;ZUS;-1200.00;PLN;Przelew wychodzący;Rachunki
+                """;
+
+            // Schema-First approach should produce these mappings:
+            // - Column 5 "Typ operacji" → paymentMethod (PAYMENT_METHOD_NORMALIZE)
+            // - Column 6 "Kategoria" → bankCategory (DIRECT)
+            MappingRules rules = MappingRules.builder()
+                .bankName("Bank Pekao")
+                .bankCountry("PL")
+                .language("pl")
+                .dateFormat("dd.MM.yyyy")
+                .delimiter(";")
+                .headerRowIndex(0)
+                .columnMappings(List.of(
+                    ColumnMapping.builder()
+                        .sourceColumn("Data księgowania")
+                        .sourceIndex(0)
+                        .targetField("operationDate")
+                        .transformationType(TransformationType.DATE_PARSE)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Nadawca / Odbiorca")
+                        .sourceIndex(2)
+                        .targetField("name")
+                        .transformationType(TransformationType.DIRECT)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Kwota operacji")
+                        .sourceIndex(3)
+                        .targetField("amount")
+                        .transformationType(TransformationType.AMOUNT_PARSE)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Waluta")
+                        .sourceIndex(4)
+                        .targetField("currency")
+                        .transformationType(TransformationType.CURRENCY_EXTRACT)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Kwota operacji")
+                        .sourceIndex(3)
+                        .targetField("type")
+                        .transformationType(TransformationType.TYPE_DETECT)
+                        .transformationParams(Map.of("amountColumn", "3"))
+                        .build(),
+                    // THIS IS THE KEY DISTINCTION - Schema-First should produce:
+                    ColumnMapping.builder()
+                        .sourceColumn("Typ operacji")
+                        .sourceIndex(5)
+                        .targetField("paymentMethod")  // HOW payment was made
+                        .transformationType(TransformationType.PAYMENT_METHOD_NORMALIZE)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Kategoria")
+                        .sourceIndex(6)
+                        .targetField("bankCategory")  // WHAT was purchased
+                        .transformationType(TransformationType.DIRECT)
+                        .build()
+                ))
+                .build();
+
+            // when
+            LocalCsvTransformer.TransformResult result = transformer.transform(csv, rules);
+
+            // then
+            assertThat(result.success()).isTrue();
+            assertThat(result.rowCount()).isEqualTo(3);
+
+            String[] lines = result.csvContent().split("\n");
+            assertThat(lines).hasSize(4); // header + 3 data rows
+
+            // Verify header contains all expected columns
+            String header = lines[0];
+            assertThat(header).contains("bankCategory");
+            assertThat(header).contains("paymentMethod");
+
+            // Row 1: Decathlon - Sport category, Card payment
+            String row1 = lines[1];
+            assertThat(row1).contains("Decathlon Polska");  // name
+            assertThat(row1).contains("Sport");              // bankCategory = semantic category
+            assertThat(row1).contains("CARD");               // paymentMethod normalized from "Płatność kartą"
+
+            // Row 2: Biedronka - Zakupy category, Card payment
+            String row2 = lines[2];
+            assertThat(row2).contains("Biedronka");
+            assertThat(row2).contains("Zakupy");             // bankCategory = semantic category
+            assertThat(row2).contains("CARD");               // paymentMethod normalized
+
+            // Row 3: ZUS - Rachunki category, Transfer payment
+            String row3 = lines[3];
+            assertThat(row3).contains("ZUS");
+            assertThat(row3).contains("Rachunki");           // bankCategory = semantic category
+            assertThat(row3).contains("TRANSFER");           // paymentMethod normalized from "Przelew wychodzący"
+        }
+
+        @Test
+        @DisplayName("Should correctly map Nest Bank CSV without Kategoria column (only paymentMethod)")
+        void shouldCorrectlyMapNestBankCsv() {
+            // given - Nest Bank CSV without "Kategoria" column
+            // "Rodzaj operacji" = payment method like "Przelewy wychodzące"
+            String csv = """
+                Data księgowania,Data operacji,Rodzaj operacji,Kwota,Waluta,Dane kontrahenta,Tytuł operacji
+                31-12-2025,31-12-2025,Przelewy wychodzące,-3000,PLN,Jan Kowalski,czynsz za mieszkanie
+                30-12-2025,30-12-2025,Przelewy przychodzące,5000,PLN,Firma XYZ,wyplata pensji
+                """;
+
+            MappingRules rules = MappingRules.builder()
+                .bankName("Nest Bank")
+                .bankCountry("PL")
+                .language("pl")
+                .dateFormat("dd-MM-yyyy")
+                .delimiter(",")
+                .headerRowIndex(0)
+                .columnMappings(List.of(
+                    ColumnMapping.builder()
+                        .sourceColumn("Data operacji")
+                        .sourceIndex(1)
+                        .targetField("operationDate")
+                        .transformationType(TransformationType.DATE_PARSE)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Dane kontrahenta")
+                        .sourceIndex(5)
+                        .targetField("name")
+                        .transformationType(TransformationType.DIRECT)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Tytuł operacji")
+                        .sourceIndex(6)
+                        .targetField("description")
+                        .transformationType(TransformationType.DIRECT)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Kwota")
+                        .sourceIndex(3)
+                        .targetField("amount")
+                        .transformationType(TransformationType.AMOUNT_PARSE)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Waluta")
+                        .sourceIndex(4)
+                        .targetField("currency")
+                        .transformationType(TransformationType.CURRENCY_EXTRACT)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Kwota")
+                        .sourceIndex(3)
+                        .targetField("type")
+                        .transformationType(TransformationType.TYPE_DETECT)
+                        .transformationParams(Map.of("amountColumn", "3"))
+                        .build(),
+                    // Nest Bank: "Rodzaj operacji" is payment method (not category!)
+                    ColumnMapping.builder()
+                        .sourceColumn("Rodzaj operacji")
+                        .sourceIndex(2)
+                        .targetField("paymentMethod")
+                        .transformationType(TransformationType.PAYMENT_METHOD_NORMALIZE)
+                        .build()
+                    // Note: NO bankCategory mapping - Nest Bank doesn't have it
+                ))
+                .build();
+
+            // when
+            LocalCsvTransformer.TransformResult result = transformer.transform(csv, rules);
+
+            // then
+            assertThat(result.success()).isTrue();
+            assertThat(result.rowCount()).isEqualTo(2);
+
+            String[] lines = result.csvContent().split("\n");
+
+            // Row 1: Jan Kowalski - no bankCategory, Transfer payment method
+            String row1 = lines[1];
+            assertThat(row1).contains("Jan Kowalski");       // name
+            assertThat(row1).contains("czynsz za mieszkanie"); // description
+            assertThat(row1).contains("TRANSFER");            // paymentMethod from "Przelewy wychodzące"
+            assertThat(row1).contains(",OUTFLOW,");           // type from negative amount
+
+            // Row 2: Firma XYZ - Transfer payment, INFLOW
+            String row2 = lines[2];
+            assertThat(row2).contains("Firma XYZ");
+            assertThat(row2).contains("wyplata pensji");
+            assertThat(row2).contains("TRANSFER");            // paymentMethod from "Przelewy przychodzące"
+            assertThat(row2).contains(",INFLOW,");            // type from positive amount
+        }
+
+        @Test
+        @DisplayName("PAYMENT_METHOD_NORMALIZE should correctly normalize Polish payment methods")
+        void shouldNormalizePolishPaymentMethods() {
+            // given - CSV with various Polish payment method names
+            String csv = """
+                Data,Kwota,Typ,Nazwa
+                2023-06-15,-100.00,Płatność kartą,Test1
+                2023-06-16,-200.00,BLIK,Test2
+                2023-06-17,-300.00,Przelew wychodzący,Test3
+                2023-06-18,-400.00,Polecenie zapłaty,Test4
+                2023-06-19,-500.00,Zlecenie stałe,Test5
+                2023-06-20,-600.00,Wypłata gotówkowa,Test6
+                2023-06-21,-700.00,Unknown Payment Type,Test7
+                """;
+
+            MappingRules rules = MappingRules.builder()
+                .bankName("Test Bank")
+                .bankCountry("PL")
+                .dateFormat("yyyy-MM-dd")
+                .delimiter(",")
+                .headerRowIndex(0)
+                .columnMappings(List.of(
+                    ColumnMapping.builder()
+                        .sourceColumn("Data")
+                        .sourceIndex(0)
+                        .targetField("operationDate")
+                        .transformationType(TransformationType.DATE_PARSE)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Kwota")
+                        .sourceIndex(1)
+                        .targetField("amount")
+                        .transformationType(TransformationType.AMOUNT_PARSE)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Kwota")
+                        .sourceIndex(1)
+                        .targetField("type")
+                        .transformationType(TransformationType.TYPE_DETECT)
+                        .transformationParams(Map.of("amountColumn", "1"))
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Typ")
+                        .sourceIndex(2)
+                        .targetField("paymentMethod")
+                        .transformationType(TransformationType.PAYMENT_METHOD_NORMALIZE)
+                        .build(),
+                    ColumnMapping.builder()
+                        .sourceColumn("Nazwa")
+                        .sourceIndex(3)
+                        .targetField("name")
+                        .transformationType(TransformationType.DIRECT)
+                        .build()
+                ))
+                .build();
+
+            // when
+            LocalCsvTransformer.TransformResult result = transformer.transform(csv, rules);
+
+            // then
+            assertThat(result.success()).isTrue();
+            String[] lines = result.csvContent().split("\n");
+            assertThat(lines).hasSize(8); // header + 7 data rows
+
+            // Verify each payment method normalization
+            // paymentMethod is the LAST column, so it ends the line (no trailing comma)
+            assertThat(lines[1]).endsWith(",CARD");           // "Płatność kartą" → CARD
+            assertThat(lines[2]).endsWith(",BLIK");           // "BLIK" → BLIK
+            assertThat(lines[3]).endsWith(",TRANSFER");       // "Przelew wychodzący" → TRANSFER
+            assertThat(lines[4]).endsWith(",DIRECT_DEBIT");   // "Polecenie zapłaty" → DIRECT_DEBIT
+            assertThat(lines[5]).endsWith(",STANDING_ORDER"); // "Zlecenie stałe" → STANDING_ORDER
+            assertThat(lines[6]).endsWith(",CASH");           // "Wypłata gotówkowa" → CASH
+            assertThat(lines[7]).endsWith(",OTHER");          // "Unknown Payment Type" → OTHER
+        }
+    }
 }

--- a/src/test/java/com/multi/vidulum/bank_data_ingestion/app/CsvParserServiceTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_ingestion/app/CsvParserServiceTest.java
@@ -375,12 +375,14 @@ class CsvParserServiceTest {
         // given
         BankCsvRow rowWithNulls = new BankCsvRow(
                 null, "Test", null, null, BigDecimal.TEN, "PLN",
-                Type.OUTFLOW, LocalDate.now(), null, null, null, null, null, null
+                Type.OUTFLOW, LocalDate.now(), null, null, null, null, null, null,
+                null, null, null
         );
 
         BankCsvRow rowWithValues = new BankCsvRow(
                 "TXN1", "Test", "Desc", "Category", BigDecimal.TEN, "PLN",
-                Type.OUTFLOW, LocalDate.now(), LocalDate.now().plusDays(1), "ACC1", "ACC2", "NETFLIX", 0.95, null
+                Type.OUTFLOW, LocalDate.now(), LocalDate.now().plusDays(1), "ACC1", "ACC2", "NETFLIX", 0.95, null,
+                null, null, null
         );
 
         // then
@@ -403,7 +405,8 @@ class CsvParserServiceTest {
         // given
         BankCsvRow row = new BankCsvRow(
                 null, "Test", null, "   ", BigDecimal.TEN, "PLN",
-                Type.OUTFLOW, LocalDate.now(), null, null, null, null, null, null
+                Type.OUTFLOW, LocalDate.now(), null, null, null, null, null, null,
+                null, null, null
         );
 
         // then


### PR DESCRIPTION
  ## Summary

  - Implements a new enrichment pipeline that processes bank CSV transactions after transformation
  - Adds AI-powered merchant extraction from transaction names and descriptions
  - Introduces `TransactionClassification` enum (MERCHANT, BANK_FEE, CASH_WITHDRAWAL, SELF_TRANSFER, UNKNOWN) for automatic categorization
  - Extracts and normalizes merchant names with confidence scores (0.0-1.0)
  - Infers `bankCategory` for banks that don't provide it (e.g., Nest Bank)

