### PR TITLE
VID-155: Add classification and confidence breakdown metrics for enrichment

### DIFF
--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/AiBankCsvTransformService.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/AiBankCsvTransformService.java
@@ -220,6 +220,20 @@ public class AiBankCsvTransformService {
                     document.setEnrichmentFallbackCount(enrichmentResult.getFallbackCount());
                     document.setEnrichmentNotes(enrichmentResult.getProcessingNotes());
 
+                    // Classification breakdown
+                    document.setClassificationMerchantCount(enrichmentResult.getClassificationMerchantCount());
+                    document.setClassificationBankFeeCount(enrichmentResult.getClassificationBankFeeCount());
+                    document.setClassificationCashWithdrawalCount(enrichmentResult.getClassificationCashWithdrawalCount());
+                    document.setClassificationCashDepositCount(enrichmentResult.getClassificationCashDepositCount());
+                    document.setClassificationSelfTransferCount(enrichmentResult.getClassificationSelfTransferCount());
+                    document.setClassificationInterestCount(enrichmentResult.getClassificationInterestCount());
+                    document.setClassificationUnknownCount(enrichmentResult.getClassificationUnknownCount());
+
+                    // Confidence breakdown
+                    document.setHighConfidenceCount(enrichmentResult.getHighConfidenceCount());
+                    document.setMediumConfidenceCount(enrichmentResult.getMediumConfidenceCount());
+                    document.setLowConfidenceCount(enrichmentResult.getLowConfidenceCount());
+
                     log.info("✅ ENRICHMENT completed: {} merchants extracted, {} categories inferred, {} kept, {}ms",
                             enrichmentResult.getMerchantsExtracted(),
                             enrichmentResult.getBankCategoriesInferred(),

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentPromptBuilder.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentPromptBuilder.java
@@ -39,8 +39,8 @@ public class EnrichmentPromptBuilder {
             For each transaction in the input, determine:
 
             1. **classification** - transaction type (REQUIRED):
-               - MERCHANT: Payment to business/person (extract merchant name)
-               - BANK_FEE: Bank fee, commission, service charge (no merchant)
+               - MERCHANT: Payment to business/person/government (extract merchant name)
+               - BANK_FEE: Bank fee, commission, service charge FROM THE BANK ITSELF (no merchant)
                - CASH_WITHDRAWAL: ATM or bank withdrawal (no merchant)
                - CASH_DEPOSIT: Cash deposit (no merchant)
                - SELF_TRANSFER: Transfer between own accounts (no merchant)
@@ -61,47 +61,112 @@ public class EnrichmentPromptBuilder {
 
             6. **location** - extracted location info (for ATM, physical locations)
 
-            ## CLASSIFICATION RULES
+            ## CLASSIFICATION RULES (CHECK IN THIS ORDER!)
 
-            ### BANK_FEE (language-agnostic indicators):
-            - Transaction is a fee/commission/charge from the bank itself
-            - No external counterparty - bank is charging the account holder
-            - Keywords: prowizja, opłata, fee, commission, Gebühr, charge
-            - Amount is typically small and negative (OUTFLOW)
-            - Often periodic (monthly, per-transaction)
-            - Examples: "Prowizja za przelew", "Opłata za kartę", "Monthly fee"
+            ### 1. SELF_TRANSFER (check first!)
+            - Bank category "Przelew wewnętrzny" → ALWAYS SELF_TRANSFER
+            - Keywords: "przelew własny", "own account", "between accounts", "własne konto"
+            - Transfer to/from same person name
+            - merchant = null for all self-transfers
+            - Examples: "Przelew własny", "Transfer to savings", "Przelew wewnętrzny"
 
-            ### CASH_WITHDRAWAL:
+            ### 2. BANK_FEE (STRICT DEFINITION - read carefully!)
+
+            ⚠️ CRITICAL: BANK_FEE means fee charged BY THE BANK ITSELF to the account holder.
+
+            ✅ IS BANK_FEE (bank charges YOU):
+            - "Prowizja za przelew" (transfer commission from your bank)
+            - "Opłata za kartę" (card fee from your bank)
+            - "Opłata za konto" (account fee)
+            - "Prowizja za przelew natychmiastowy" (instant transfer fee)
+            - Name contains only your bank name: "Bank Pekao S.A.", "Nest Bank", "PKO BP"
+            - Transaction where bank is both the source and description indicates fee
+
+            ❌ IS NOT BANK_FEE - these are MERCHANT:
+            - ZUS (Zakład Ubezpieczeń Społecznych) → MERCHANT, government entity
+            - Urząd Skarbowy / US → MERCHANT, tax office
+            - IKANO Bank, IKANO → MERCHANT, loan repayment to external bank
+            - Credit Agricole (rata/rat.) → MERCHANT, loan repayment
+            - Santander Consumer → MERCHANT, loan repayment
+            - Any payment TO an external organization → MERCHANT
+
+            RULE: If money goes TO an external entity (not YOUR bank), it's MERCHANT, not BANK_FEE.
+            RULE: Loan repayments to other banks/finance companies = MERCHANT
+
+            ### 3. CASH_WITHDRAWAL
             - ATM terminal codes (numeric patterns like "00146 2703W250H")
-            - Withdrawal-related context
+            - "BANKOMAT", "ATM", "Wypłata z bankomatu", "EURONET"
             - No merchant name, just location/terminal info
-            - Keywords: wypłata, bankomat, ATM, withdrawal, Geldautomat
-            - Examples: "Wypłata z bankomatu", "ATM EURONET"
+            - merchant = null, extract location
+            - Examples: "Wypłata z bankomatu", "ATM EURONET", "BANKOMAT EURONET"
 
-            ### CASH_DEPOSIT:
-            - Deposit-related context
-            - Positive amount (INFLOW)
-            - No external sender
-            - Keywords: wpłata, deposit, Einzahlung
+            ### 4. CASH_DEPOSIT
+            - "Wpłata gotówkowa", "Cash deposit", "Wpłata własna"
+            - Positive amount (INFLOW), no external sender
+            - merchant = null
             - Examples: "Wpłata gotówkowa", "Cash deposit"
 
-            ### SELF_TRANSFER:
-            - Transfer between own accounts (same owner)
-            - Keywords: przelew własny, own transfer, internal transfer
-            - Same name appears as sender/recipient
-            - Examples: "Przelew własny", "Transfer to savings"
+            ### 5. INTEREST
+            - "Odsetki", "Interest", "Kapitalizacja odsetek"
+            - From bank to account holder (INFLOW)
+            - merchant = null
+            - Examples: "Odsetki od lokaty", "Interest payment", "Kapitalizacja"
 
-            ### INTEREST:
-            - Interest payment context
-            - From bank to account holder
-            - Keywords: odsetki, interest, Zinsen, kapitalizacja
-            - Examples: "Odsetki od lokaty", "Interest payment"
-
-            ### MERCHANT (default for payments):
-            - Payment to external business or person
+            ### 6. MERCHANT (default for most payments)
+            - Payment to external business, person, or government entity
             - Has identifiable counterparty name
             - Most card transactions, online payments, purchases
+            - Government payments (ZUS, taxes, fines)
+            - Loan repayments to external financial institutions
             - Extract clean merchant name
+
+            ### 7. UNKNOWN (last resort only)
+            - Cannot determine type with any confidence
+            - Still try to extract merchant name with low confidence
+
+            ## GOVERNMENT ENTITIES ARE MERCHANTS (NOT BANK_FEE!)
+
+            | Entity | merchant | bankCategory | Notes |
+            |--------|----------|--------------|-------|
+            | ZUS | ZUS | Podatki i składki | Social security - ALWAYS MERCHANT |
+            | Urząd Skarbowy, US | URZAD SKARBOWY | Podatki i składki | Tax payments |
+            | GITD, Inspektorat | GITD | Opłaty urzędowe | Traffic fines |
+            | Urząd Miasta/Gminy | URZAD MIASTA | Opłaty urzędowe | City/municipal fees |
+            | PIT, VAT payments | URZAD SKARBOWY | Podatki i składki | Tax payments |
+
+            ## LOAN/FINANCE COMPANIES ARE MERCHANTS (NOT BANK_FEE!)
+
+            | Pattern | merchant | bankCategory | Notes |
+            |---------|----------|--------------|-------|
+            | IKANO, IKANO BANK | IKANO | Spłata kredytu | Consumer loans |
+            | Santander Consumer | SANTANDER | Spłata kredytu | Consumer finance |
+            | Credit Agricole + rata/rat. | CREDIT AGRICOLE | Spłata kredytu | Loan installment |
+            | Provident | PROVIDENT | Spłata kredytu | Consumer loans |
+            | Alior Bank (rata) | ALIOR | Spłata kredytu | Loan repayment |
+
+            ## KNOWN SUBSCRIPTION SERVICES (always MERCHANT, high confidence)
+
+            | Pattern in name/description | merchant | confidence |
+            |-----------------------------|----------|------------|
+            | Netflix, NETFLIX.COM | NETFLIX | 0.95 |
+            | Spotify, SPOTIFY | SPOTIFY | 0.95 |
+            | Badoo, help@badoo.com, badoo.com | BADOO | 0.95 |
+            | HBO, HBOMAX, HBO MAX | HBO MAX | 0.95 |
+            | Disney+, DISNEYPLUS | DISNEY+ | 0.95 |
+            | YouTube Premium | YOUTUBE | 0.95 |
+            | Apple, iTunes, APPLE.COM | APPLE | 0.95 |
+            | Google Play, GOOGLE | GOOGLE | 0.95 |
+            | Amazon Prime, AMAZON | AMAZON | 0.95 |
+            | Allegro, ALLEGRO.PL | ALLEGRO | 0.95 |
+            | TradingView | TRADINGVIEW | 0.95 |
+
+            When bank name appears (BANK PEKAO, PKO BP) but description contains
+            email domain or service name → extract real merchant from description.
+
+            Example:
+              name: "BANK PEKAO S.A."
+              description: "ROZLICZENIE TRANSAKCJI... Badoo help@badoo.com"
+              → merchant: "BADOO", classification: MERCHANT, confidence: 0.95
 
             ## MERCHANT EXTRACTION RULES (for MERCHANT and UNKNOWN only)
 
@@ -114,6 +179,8 @@ public class EnrichmentPromptBuilder {
             | "BIEDRONKA SKLEP 1234 KRAKÓW" | "BIEDRONKA" |
             | "Przelew od Jan Kowalski" | "JAN KOWALSKI" |
             | "ZUS" | "ZUS" |
+            | "Urząd skarbowy w Mielcu" | "URZAD SKARBOWY" |
+            | "IKANO" | "IKANO" |
             | "SHIVAGO SPOLKA Z OGRANICZONA ODPOWIEDZIALNOSCIA" | "SHIVAGO" |
 
             Rules:
@@ -124,7 +191,7 @@ public class EnrichmentPromptBuilder {
             - If name is bank intermediary (BANK PEKAO, PKO BP, BANK BNP), extract real merchant from description
             - For email domains in description, use company name (help@badoo.com → BADOO)
             - For "Przelew od/do [NAME]" pattern, extract the person/company name
-            - Keep well-known abbreviations: ZUS, US, PZU, PKP
+            - Keep well-known abbreviations: ZUS, US, PZU, PKP, GITD
 
             ## BANK_CATEGORY RULES
 
@@ -135,29 +202,32 @@ public class EnrichmentPromptBuilder {
             | Keywords in name/description | bankCategory |
             |------------------------------|--------------|
             | czynsz, mieszkanie, najem, lokal | "Mieszkanie" |
-            | ZUS, podatek, US, składki, urząd skarbowy | "Podatki i składki" |
+            | ZUS, podatek, US, składki, urząd skarbowy, PIT, VAT | "Podatki i składki" |
+            | IKANO, Credit Agricole rata, Santander Consumer, Provident | "Spłata kredytu" |
             | Netflix, Spotify, HBO, Disney, kino, bilety | "Rozrywka" |
             | Biedronka, Lidl, Żabka, Carrefour, Auchan, sklep | "Zakupy spożywcze" |
-            | prowizja, opłata, fee, bank (for BANK_FEE) | "Opłaty bankowe" |
+            | prowizja, opłata za konto/kartę (ONLY for BANK_FEE) | "Opłaty bankowe" |
             | przelew przychodzący, wpływ, wynagrodzenie | "Przelewy przychodzące" |
             | przelew wychodzący, przelew do | "Przelewy wychodzące" |
+            | przelew wewnętrzny, przelew własny | "Przelew wewnętrzny" |
             | BLIK | "Płatności BLIK" |
             | karta, card, płatność kartą | "Płatności kartą" |
             | paliwo, Orlen, BP, Shell, stacja | "Transport" |
             | restauracja, kawiarnia, bar, jedzenie | "Gastronomia" |
             | apteka, lekarz, szpital, zdrowie | "Zdrowie" |
-            | ubezpieczenie, PZU, polisa | "Ubezpieczenia" |
-            | telefon, internet, abonament | "Telekomunikacja" |
+            | ubezpieczenie, PZU, polisa, Warta | "Ubezpieczenia" |
+            | telefon, internet, abonament, Plus, Orange, T-Mobile | "Telekomunikacja" |
             | bankomat, wypłata, ATM (for CASH_WITHDRAWAL) | "Wypłata z bankomatu" |
             | wpłata, deposit (for CASH_DEPOSIT) | "Wpłata gotówkowa" |
             | odsetki, interest (for INTEREST) | "Odsetki" |
+            | GITD, mandat, kara, inspektorat | "Opłaty urzędowe" |
 
             If cannot determine category, use "Inne".
 
             ## MERCHANT_CONFIDENCE
 
             Score 0.0 to 1.0:
-            - 0.95+ = exact business name found (email domain, known brand like Netflix, Allegro)
+            - 0.95+ = exact business name found (email domain, known brand like Netflix, Allegro, ZUS)
             - 0.8-0.95 = clear company/person name extracted (ŻABKA from "ŻABKA POLSKA 4521")
             - 0.5-0.8 = inferred from context, less certain
             - <0.5 = uncertain, used fallback to cleaned name
@@ -172,11 +242,11 @@ public class EnrichmentPromptBuilder {
                 {
                   "rowIndex": 0,
                   "classification": "MERCHANT",
-                  "merchant": "ŻABKA",
+                  "merchant": "ZUS",
                   "merchantConfidence": 0.95,
-                  "bankCategory": "Zakupy spożywcze",
+                  "bankCategory": "Podatki i składki",
                   "bankCategorySource": "AI_INFERRED",
-                  "classificationReason": "Card payment at grocery store chain",
+                  "classificationReason": "Payment to ZUS - government social security entity",
                   "location": null
                 },
                 {
@@ -191,16 +261,26 @@ public class EnrichmentPromptBuilder {
                 },
                 {
                   "rowIndex": 2,
-                  "classification": "CASH_WITHDRAWAL",
+                  "classification": "SELF_TRANSFER",
                   "merchant": null,
                   "merchantConfidence": null,
-                  "bankCategory": "Wypłata z bankomatu",
+                  "bankCategory": "Przelew wewnętrzny",
                   "bankCategorySource": "ORIGINAL",
-                  "classificationReason": "ATM terminal code pattern detected (00146 2703W250H)",
-                  "location": "WARSZAWA"
+                  "classificationReason": "Bank-categorized as internal transfer (Przelew wewnętrzny)",
+                  "location": null
+                },
+                {
+                  "rowIndex": 3,
+                  "classification": "MERCHANT",
+                  "merchant": "BADOO",
+                  "merchantConfidence": 0.95,
+                  "bankCategory": "Rozrywka",
+                  "bankCategorySource": "AI_INFERRED",
+                  "classificationReason": "Subscription service - extracted from email domain in description",
+                  "location": "DUBLIN"
                 }
               ],
-              "processingNotes": "Processed 3 transactions: 1 merchant, 1 bank fee, 1 ATM withdrawal"
+              "processingNotes": "Processed 4 transactions: 2 merchants, 1 bank fee, 1 self-transfer"
             }
 
             ## ERROR HANDLING

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResult.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/EnrichmentResult.java
@@ -1,11 +1,14 @@
 package com.multi.vidulum.bank_data_adapter.app.enrichment;
 
+import com.multi.vidulum.bank_data_adapter.domain.TransactionClassification;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Final result of enrichment process for all transactions.
@@ -87,6 +90,85 @@ public class EnrichmentResult {
      * Processing notes from AI (aggregated from all batches).
      */
     private String processingNotes;
+
+    // ========== CLASSIFICATION BREAKDOWN ==========
+
+    /**
+     * Number of transactions classified as MERCHANT.
+     */
+    private int classificationMerchantCount;
+
+    /**
+     * Number of transactions classified as BANK_FEE.
+     */
+    private int classificationBankFeeCount;
+
+    /**
+     * Number of transactions classified as CASH_WITHDRAWAL.
+     */
+    private int classificationCashWithdrawalCount;
+
+    /**
+     * Number of transactions classified as CASH_DEPOSIT.
+     */
+    private int classificationCashDepositCount;
+
+    /**
+     * Number of transactions classified as SELF_TRANSFER.
+     */
+    private int classificationSelfTransferCount;
+
+    /**
+     * Number of transactions classified as INTEREST.
+     */
+    private int classificationInterestCount;
+
+    /**
+     * Number of transactions classified as UNKNOWN.
+     */
+    private int classificationUnknownCount;
+
+    // ========== CONFIDENCE BREAKDOWN ==========
+
+    /**
+     * Number of transactions with high confidence (>= 0.8).
+     */
+    private int highConfidenceCount;
+
+    /**
+     * Number of transactions with medium confidence (0.5 - 0.8).
+     */
+    private int mediumConfidenceCount;
+
+    /**
+     * Number of transactions with low confidence (< 0.5).
+     */
+    private int lowConfidenceCount;
+
+    /**
+     * Returns classification breakdown as a map.
+     */
+    public Map<TransactionClassification, Integer> getClassificationBreakdown() {
+        Map<TransactionClassification, Integer> breakdown = new EnumMap<>(TransactionClassification.class);
+        breakdown.put(TransactionClassification.MERCHANT, classificationMerchantCount);
+        breakdown.put(TransactionClassification.BANK_FEE, classificationBankFeeCount);
+        breakdown.put(TransactionClassification.CASH_WITHDRAWAL, classificationCashWithdrawalCount);
+        breakdown.put(TransactionClassification.CASH_DEPOSIT, classificationCashDepositCount);
+        breakdown.put(TransactionClassification.SELF_TRANSFER, classificationSelfTransferCount);
+        breakdown.put(TransactionClassification.INTEREST, classificationInterestCount);
+        breakdown.put(TransactionClassification.UNKNOWN, classificationUnknownCount);
+        return breakdown;
+    }
+
+    /**
+     * Returns total of all classification counts (should equal totalTransactions).
+     */
+    public int getTotalClassificationCount() {
+        return classificationMerchantCount + classificationBankFeeCount +
+               classificationCashWithdrawalCount + classificationCashDepositCount +
+               classificationSelfTransferCount + classificationInterestCount +
+               classificationUnknownCount;
+    }
 
     /**
      * Creates a "no enrichment needed" result.

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/app/enrichment/TransactionEnrichmentService.java
@@ -153,9 +153,50 @@ public class TransactionEnrichmentService {
 
         long processingTimeMs = System.currentTimeMillis() - startTime;
 
+        // Calculate classification breakdown
+        Map<com.multi.vidulum.bank_data_adapter.domain.TransactionClassification, Long> classificationCounts =
+                allEnriched.stream()
+                        .collect(Collectors.groupingBy(
+                                EnrichedTransaction::effectiveClassification,
+                                Collectors.counting()
+                        ));
+
+        int classificationMerchantCount = classificationCounts
+                .getOrDefault(com.multi.vidulum.bank_data_adapter.domain.TransactionClassification.MERCHANT, 0L).intValue();
+        int classificationBankFeeCount = classificationCounts
+                .getOrDefault(com.multi.vidulum.bank_data_adapter.domain.TransactionClassification.BANK_FEE, 0L).intValue();
+        int classificationCashWithdrawalCount = classificationCounts
+                .getOrDefault(com.multi.vidulum.bank_data_adapter.domain.TransactionClassification.CASH_WITHDRAWAL, 0L).intValue();
+        int classificationCashDepositCount = classificationCounts
+                .getOrDefault(com.multi.vidulum.bank_data_adapter.domain.TransactionClassification.CASH_DEPOSIT, 0L).intValue();
+        int classificationSelfTransferCount = classificationCounts
+                .getOrDefault(com.multi.vidulum.bank_data_adapter.domain.TransactionClassification.SELF_TRANSFER, 0L).intValue();
+        int classificationInterestCount = classificationCounts
+                .getOrDefault(com.multi.vidulum.bank_data_adapter.domain.TransactionClassification.INTEREST, 0L).intValue();
+        int classificationUnknownCount = classificationCounts
+                .getOrDefault(com.multi.vidulum.bank_data_adapter.domain.TransactionClassification.UNKNOWN, 0L).intValue();
+
+        // Calculate confidence breakdown (only for transactions with merchantConfidence)
+        int highConfidenceCount = (int) allEnriched.stream()
+                .filter(e -> e.getMerchantConfidence() != null && e.getMerchantConfidence() >= 0.8)
+                .count();
+        int mediumConfidenceCount = (int) allEnriched.stream()
+                .filter(e -> e.getMerchantConfidence() != null &&
+                             e.getMerchantConfidence() >= 0.5 &&
+                             e.getMerchantConfidence() < 0.8)
+                .count();
+        int lowConfidenceCount = (int) allEnriched.stream()
+                .filter(e -> e.getMerchantConfidence() != null && e.getMerchantConfidence() < 0.5)
+                .count();
+
         log.info("Enrichment completed: {} transactions, {} groups, {} merchants, {} inferred, {} kept, {} fallbacks, {}ms",
                 transactions.size(), groups.size(), merchantsExtracted, bankCategoriesInferred,
                 bankCategoriesKept, fallbackCount, processingTimeMs);
+        log.info("Classification breakdown: MERCHANT={}, BANK_FEE={}, CASH_WITHDRAWAL={}, SELF_TRANSFER={}, UNKNOWN={}",
+                classificationMerchantCount, classificationBankFeeCount, classificationCashWithdrawalCount,
+                classificationSelfTransferCount, classificationUnknownCount);
+        log.info("Confidence breakdown: high={}, medium={}, low={}",
+                highConfidenceCount, mediumConfidenceCount, lowConfidenceCount);
 
         return EnrichmentResult.builder()
                 .enrichmentApplied(true)
@@ -172,6 +213,18 @@ public class TransactionEnrichmentService {
                 .totalInputTokens(totalInputTokens)
                 .totalOutputTokens(totalOutputTokens)
                 .processingNotes(processingNotes.toString().trim())
+                // Classification breakdown
+                .classificationMerchantCount(classificationMerchantCount)
+                .classificationBankFeeCount(classificationBankFeeCount)
+                .classificationCashWithdrawalCount(classificationCashWithdrawalCount)
+                .classificationCashDepositCount(classificationCashDepositCount)
+                .classificationSelfTransferCount(classificationSelfTransferCount)
+                .classificationInterestCount(classificationInterestCount)
+                .classificationUnknownCount(classificationUnknownCount)
+                // Confidence breakdown
+                .highConfidenceCount(highConfidenceCount)
+                .mediumConfidenceCount(mediumConfidenceCount)
+                .lowConfidenceCount(lowConfidenceCount)
                 .build();
     }
 

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/domain/AiCsvTransformationDocument.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/domain/AiCsvTransformationDocument.java
@@ -113,6 +113,20 @@ public class AiCsvTransformationDocument {
     private int enrichmentFallbackCount;            // Number of transactions using fallback
     private String enrichmentNotes;                 // Processing notes from enrichment
 
+    // ========== CLASSIFICATION BREAKDOWN ==========
+    private Integer classificationMerchantCount;        // Number of MERCHANT transactions
+    private Integer classificationBankFeeCount;         // Number of BANK_FEE transactions
+    private Integer classificationCashWithdrawalCount;  // Number of CASH_WITHDRAWAL transactions
+    private Integer classificationCashDepositCount;     // Number of CASH_DEPOSIT transactions
+    private Integer classificationSelfTransferCount;    // Number of SELF_TRANSFER transactions
+    private Integer classificationInterestCount;        // Number of INTEREST transactions
+    private Integer classificationUnknownCount;         // Number of UNKNOWN transactions
+
+    // ========== CONFIDENCE BREAKDOWN ==========
+    private Integer highConfidenceCount;            // >= 0.8
+    private Integer mediumConfidenceCount;          // 0.5 - 0.8
+    private Integer lowConfidenceCount;             // < 0.5
+
     // ========== HELPER METHODS FOR ZONEDDATETIME CONVERSION ==========
 
     public ZonedDateTime getCreatedAtZoned() {

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/rest/AiBankCsvController.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/rest/AiBankCsvController.java
@@ -212,7 +212,17 @@ public class AiBankCsvController {
         int bankCategoriesInferred,     // Number of bankCategories inferred by AI (for banks without categories)
         int bankCategoriesKept,         // Number of original bankCategories kept
         long enrichmentTimeMs,          // Time spent on enrichment in milliseconds
-        int enrichmentAiCalls           // Number of AI calls made for enrichment
+        int enrichmentAiCalls,          // Number of AI calls made for enrichment
+        // Classification breakdown (Phase 2.1)
+        Integer classificationMerchantCount,      // MERCHANT transactions
+        Integer classificationBankFeeCount,       // BANK_FEE transactions
+        Integer classificationCashWithdrawalCount,// CASH_WITHDRAWAL transactions
+        Integer classificationSelfTransferCount,  // SELF_TRANSFER transactions
+        Integer classificationUnknownCount,       // UNKNOWN transactions
+        // Confidence breakdown
+        Integer highConfidenceCount,    // merchantConfidence >= 0.8
+        Integer mediumConfidenceCount,  // 0.5 <= merchantConfidence < 0.8
+        Integer lowConfidenceCount      // merchantConfidence < 0.5
     ) {}
 
     public record PreviewResponse(
@@ -273,7 +283,17 @@ public class AiBankCsvController {
             doc.getBankCategoriesInferred(),
             doc.getBankCategoriesKept(),
             doc.getEnrichmentTimeMs(),
-            doc.getEnrichmentAiCalls()
+            doc.getEnrichmentAiCalls(),
+            // Classification breakdown
+            doc.getClassificationMerchantCount(),
+            doc.getClassificationBankFeeCount(),
+            doc.getClassificationCashWithdrawalCount(),
+            doc.getClassificationSelfTransferCount(),
+            doc.getClassificationUnknownCount(),
+            // Confidence breakdown
+            doc.getHighConfidenceCount(),
+            doc.getMediumConfidenceCount(),
+            doc.getLowConfidenceCount()
         );
     }
 


### PR DESCRIPTION
 ## Summary

  - Add classification breakdown metrics to track transaction types (MERCHANT, BANK_FEE, CASH_WITHDRAWAL, SELF_TRANSFER, UNKNOWN)
  - Add confidence breakdown metrics (high >= 0.8, medium 0.5-0.8, low < 0.5)
  - Improve enrichment prompt for better classification accuracy
  - Persist metrics to MongoDB and expose in REST API response

  ## Key Changes

  **EnrichmentResult.java**
  - Add 7 classification count fields (MERCHANT, BANK_FEE, CASH_WITHDRAWAL, CASH_DEPOSIT, SELF_TRANSFER, INTEREST, UNKNOWN)
  - Add 3 confidence count fields (high, medium, low)
  - Add helper method `getClassificationBreakdown()` returning Map<TransactionClassification, Integer>
