### PR TITLE
VID-157: Fix currency detection and header row filtering in AI CSV transformation 

### DIFF
--- a/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/AiPromptBuilder.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/AiPromptBuilder.java
@@ -30,7 +30,7 @@ public class AiPromptBuilder {
         - description: transaction purpose/title - WHY/WHAT the payment is for (CRITICAL - see POLISH BANK MAPPING below)
         - bankCategory: original category from bank (e.g., "Przelewy wychodzące")
         - amount: ALWAYS POSITIVE decimal number (use absolute value)
-        - currency: PLN, EUR, USD (3-letter code)
+        - currency: valid ISO 4217 code (e.g., PLN, EUR, USD, GBP, CHF, CZK). Determine currency ONCE from file context (metadata rows, currency column, or bank country). Apply the SAME code to ALL rows. NEVER extract currency by taking a substring of a column header name.
         - type: INFLOW (positive/credit) or OUTFLOW (negative/debit)
         - operationDate: YYYY-MM-DD format (REQUIRED)
         - bookingDate: YYYY-MM-DD format (same as operationDate if not available)
@@ -107,8 +107,12 @@ public class AiPromptBuilder {
         - IBAN lengths per country: PL=28, DE=22, GB=22, FR=27, ES=24, IT=27, NL=18
 
         ## TRANSFORMATION RULES:
-        1. SKIP metadata header lines (account info, date ranges, totals, summaries)
-        2. Find actual column headers row (contains "Data", "Kwota", etc.)
+        1. SKIP all non-data rows: metadata AND column headers.
+           - METADATA rows contain account info, date ranges, totals, summaries.
+           - COLUMN HEADER rows contain field names (in any language) — they are NOT transactions.
+           - A DATA ROW has: a parseable date, a numeric amount, and a text name/description.
+           - NEVER output metadata or column header rows as transactions.
+        2. Detect the actual column header row to understand column mapping, then SKIP it from output.
         3. Convert dates: DD-MM-YYYY or DD.MM.YYYY → YYYY-MM-DD
         4. Replace "|" characters with spaces (used as line breaks in Polish banks)
         5. Negative amount = OUTFLOW, positive = INFLOW

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/AiResponseProcessor.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/AiResponseProcessor.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -25,6 +26,12 @@ public class AiResponseProcessor {
 
     private static final Pattern ERROR_CODE_PATTERN = Pattern.compile("ERROR: (\\w+)");
     private static final Pattern ERROR_MESSAGE_PATTERN = Pattern.compile("MESSAGE: (.+)");
+
+    private static final Set<String> VALID_ISO_CURRENCIES = Set.of(
+            "PLN", "EUR", "USD", "GBP", "CHF", "CZK", "SEK", "NOK", "DKK", "HUF",
+            "RON", "BGN", "HRK", "RUB", "UAH", "TRY", "JPY", "CNY", "AUD", "CAD",
+            "NZD", "ZAR", "BRL", "MXN", "INR", "KRW", "SGD", "HKD", "THB", "ILS"
+    );
 
     public AiTransformResult process(String aiResponse) {
         if (aiResponse == null || aiResponse.isBlank()) {
@@ -63,6 +70,10 @@ public class AiResponseProcessor {
             log.warn("Header mismatch. Expected: {}, Got: {}", EXPECTED_HEADER, header);
             // Allow it but log warning - AI might have slightly different spacing
         }
+
+        // Sanitize CSV: remove header rows parsed as data, fix invalid currencies
+        csvContent = sanitizeCsvContent(csvContent);
+        lines = csvContent.split("\n");
 
         // Count data rows (excluding header)
         int rowCount = lines.length - 1;
@@ -127,5 +138,132 @@ public class AiResponseProcessor {
             return matcher.group(1).trim();
         }
         return defaultValue;
+    }
+
+    /**
+     * Sanitizes AI-generated CSV content:
+     * - Removes header rows that AI mistakenly included as data
+     * - Validates and fixes currency column
+     */
+    private String sanitizeCsvContent(String csvContent) {
+        String[] lines = csvContent.split("\n");
+        if (lines.length < 2) return csvContent;
+
+        StringBuilder result = new StringBuilder(lines[0]).append("\n"); // keep CSV header
+        int removed = 0;
+        int currencyFixed = 0;
+        String detectedCurrency = detectDominantCurrency(lines);
+
+        for (int i = 1; i < lines.length; i++) {
+            String line = lines[i].trim();
+            if (line.isEmpty()) continue;
+
+            String[] fields = parseCsvRow(line);
+
+            // Skip rows that look like original CSV column headers (not data)
+            if (isLikelyHeaderRow(fields)) {
+                log.info("Sanitizer: skipping likely header row at line {}: {}", i, line.substring(0, Math.min(80, line.length())));
+                removed++;
+                continue;
+            }
+
+            // Fix invalid currency (column index 5)
+            if (fields.length > 5) {
+                String currency = fields[5].trim();
+                if (!currency.isEmpty() && !VALID_ISO_CURRENCIES.contains(currency.toUpperCase())) {
+                    log.warn("Sanitizer: invalid currency '{}' at line {}, replacing with '{}'", currency, i, detectedCurrency);
+                    fields[5] = detectedCurrency;
+                    currencyFixed++;
+                    line = toCsvLine(fields);
+                }
+            }
+
+            result.append(line).append("\n");
+        }
+
+        if (removed > 0 || currencyFixed > 0) {
+            log.info("Sanitizer: removed {} header rows, fixed {} invalid currencies (dominant: {})",
+                    removed, currencyFixed, detectedCurrency);
+        }
+
+        return result.toString().trim();
+    }
+
+    /**
+     * Detects the most common valid currency in the CSV data.
+     */
+    private String detectDominantCurrency(String[] lines) {
+        java.util.Map<String, Integer> counts = new java.util.HashMap<>();
+        for (int i = 1; i < lines.length; i++) {
+            String[] fields = parseCsvRow(lines[i]);
+            if (fields.length > 5) {
+                String c = fields[5].trim().toUpperCase();
+                if (VALID_ISO_CURRENCIES.contains(c)) {
+                    counts.merge(c, 1, Integer::sum);
+                }
+            }
+        }
+        return counts.entrySet().stream()
+                .max(java.util.Map.Entry.comparingByValue())
+                .map(java.util.Map.Entry::getKey)
+                .orElse("PLN");
+    }
+
+    /**
+     * Checks if a row is likely a column header that was mistakenly processed as data.
+     * A data row must have a parseable date and a numeric amount.
+     */
+    private boolean isLikelyHeaderRow(String[] fields) {
+        if (fields.length < 8) return false;
+
+        String amountField = fields.length > 4 ? fields[4].trim() : "";
+        String dateField = fields.length > 7 ? fields[7].trim() : "";
+
+        // A data row has a numeric amount and a YYYY-MM-DD date
+        boolean hasNumericAmount = !amountField.isEmpty() && amountField.matches("[\\d.,]+");
+        boolean hasParseableDate = !dateField.isEmpty() && dateField.matches("\\d{4}-\\d{2}-\\d{2}");
+
+        // If NEITHER amount is numeric NOR date is parseable → likely header
+        return !hasNumericAmount && !hasParseableDate;
+    }
+
+    /**
+     * Parses a CSV row respecting quoted fields.
+     */
+    private String[] parseCsvRow(String line) {
+        List<String> values = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (c == '"') {
+                inQuotes = !inQuotes;
+            } else if (c == ',' && !inQuotes) {
+                values.add(current.toString());
+                current = new StringBuilder();
+            } else {
+                current.append(c);
+            }
+        }
+        values.add(current.toString());
+        return values.toArray(new String[0]);
+    }
+
+    /**
+     * Converts fields back to a CSV line, quoting fields that contain commas.
+     */
+    private String toCsvLine(String[] fields) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < fields.length; i++) {
+            if (i > 0) sb.append(',');
+            String field = fields[i];
+            if (field.contains(",") || field.contains("\"")) {
+                sb.append('"').append(field.replace("\"", "\"\"")).append('"');
+            } else {
+                sb.append(field);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/LocalCsvTransformer.java
+++ b/src/main/java/com/multi/vidulum/bank_data_adapter/infrastructure/LocalCsvTransformer.java
@@ -365,15 +365,25 @@ public class LocalCsvTransformer {
         return "OUTFLOW"; // Default to outflow for safety (most bank transactions are expenses)
     }
 
+    private static final Set<String> VALID_ISO_CURRENCIES = Set.of(
+            "PLN", "EUR", "USD", "GBP", "CHF", "CZK", "SEK", "NOK", "DKK", "HUF",
+            "RON", "BGN", "HRK", "RUB", "UAH", "TRY", "JPY", "CNY", "AUD", "CAD",
+            "NZD", "ZAR", "BRL", "MXN", "INR", "KRW", "SGD", "HKD", "THB", "ILS"
+    );
+
     private String extractCurrency(String value, Map<String, String> params) {
         if (value == null || value.isBlank()) {
             return params != null ? params.getOrDefault("default", "PLN") : "PLN";
         }
 
-        // Extract currency code from value
+        // Extract 3-letter code and validate against ISO 4217
         Matcher matcher = Pattern.compile("([A-Z]{3})").matcher(value.toUpperCase());
         if (matcher.find()) {
-            return matcher.group(1);
+            String candidate = matcher.group(1);
+            if (VALID_ISO_CURRENCIES.contains(candidate)) {
+                return candidate;
+            }
+            log.warn("Rejected invalid currency code '{}' extracted from '{}', using default", candidate, value);
         }
 
         return params != null ? params.getOrDefault("default", "PLN") : "PLN";

--- a/src/test/java/com/multi/vidulum/bank_data_adapter/infrastructure/LocalCsvTransformerTest.java
+++ b/src/test/java/com/multi/vidulum/bank_data_adapter/infrastructure/LocalCsvTransformerTest.java
@@ -1283,4 +1283,80 @@ class LocalCsvTransformerTest {
             assertThat(lines[7]).endsWith(",OTHER");          // "Unknown Payment Type" → OTHER
         }
     }
+
+    @Nested
+    @DisplayName("Currency ISO 4217 Validation")
+    class CurrencyIsoValidation {
+
+        @Test
+        @DisplayName("Should reject invalid currency code extracted from header name (e.g., WAL from Waluta)")
+        void shouldRejectInvalidCurrencyCode() {
+            // given - CSV where currency column contains "WAL" (substring of "Waluta" header)
+            MappingRules rules = MappingRules.builder()
+                    .bankName("Test Bank").bankCountry("PL")
+                    .dateFormat("yyyy-MM-dd").delimiter(",").headerRowIndex(0)
+                    .columnMappings(List.of(
+                            ColumnMapping.builder().sourceColumn("Date").sourceIndex(0)
+                                    .targetField("operationDate").transformationType(TransformationType.DATE_PARSE)
+                                    .transformationParams(Map.of("format", "yyyy-MM-dd")).build(),
+                            ColumnMapping.builder().sourceColumn("Amount").sourceIndex(1)
+                                    .targetField("amount").transformationType(TransformationType.AMOUNT_PARSE).build(),
+                            ColumnMapping.builder().sourceColumn("Amount").sourceIndex(1)
+                                    .targetField("type").transformationType(TransformationType.TYPE_DETECT)
+                                    .transformationParams(Map.of("amountColumn", "1")).build(),
+                            ColumnMapping.builder().sourceColumn("Currency").sourceIndex(2)
+                                    .targetField("currency").transformationType(TransformationType.CURRENCY_EXTRACT).build(),
+                            ColumnMapping.builder().sourceColumn("Name").sourceIndex(3)
+                                    .targetField("name").transformationType(TransformationType.DIRECT).build()
+                    )).build();
+
+            String csv = """
+                    Date,Amount,Currency,Name
+                    2025-01-15,-100,WAL,Test Transaction""";
+
+            // when
+            LocalCsvTransformer.TransformResult result = transformer.transform(csv, rules);
+
+            // then
+            assertThat(result.success()).isTrue();
+            String[] lines = result.csvContent().split("\n");
+            // WAL is not a valid ISO 4217 code → should fallback to PLN
+            assertThat(lines[1]).contains(",PLN,");
+        }
+
+        @Test
+        @DisplayName("Should accept valid ISO 4217 currency codes")
+        void shouldAcceptValidIsoCurrencyCodes() {
+            // given
+            MappingRules rules = MappingRules.builder()
+                    .bankName("Test Bank").bankCountry("DE")
+                    .dateFormat("yyyy-MM-dd").delimiter(",").headerRowIndex(0)
+                    .columnMappings(List.of(
+                            ColumnMapping.builder().sourceColumn("Date").sourceIndex(0)
+                                    .targetField("operationDate").transformationType(TransformationType.DATE_PARSE)
+                                    .transformationParams(Map.of("format", "yyyy-MM-dd")).build(),
+                            ColumnMapping.builder().sourceColumn("Amount").sourceIndex(1)
+                                    .targetField("amount").transformationType(TransformationType.AMOUNT_PARSE).build(),
+                            ColumnMapping.builder().sourceColumn("Amount").sourceIndex(1)
+                                    .targetField("type").transformationType(TransformationType.TYPE_DETECT)
+                                    .transformationParams(Map.of("amountColumn", "1")).build(),
+                            ColumnMapping.builder().sourceColumn("Currency").sourceIndex(2)
+                                    .targetField("currency").transformationType(TransformationType.CURRENCY_EXTRACT).build(),
+                            ColumnMapping.builder().sourceColumn("Name").sourceIndex(3)
+                                    .targetField("name").transformationType(TransformationType.DIRECT).build()
+                    )).build();
+
+            String csv = """
+                    Date,Amount,Currency,Name
+                    2025-01-15,-100,EUR,Test Transaction""";
+
+            // when
+            LocalCsvTransformer.TransformResult result = transformer.transform(csv, rules);
+
+            // then
+            assertThat(result.success()).isTrue();
+            String[] lines = result.csvContent().split("\n");
+            assertThat(lines[1]).contains(",EUR,");
+        }
+    }
 }


### PR DESCRIPTION
  Summary                                                                                                                                                                                                
                                                                                                                                                                                                         
  - Updates AI transformation prompt with language-agnostic rules for header/metadata detection — replaces hardcoded Polish column names ("Data", "Kwota") with semantic rules: "a DATA ROW has a        
  parseable date, a numeric amount, and a text description"                                                                                                                                              
  - Updates currency instruction: AI must determine currency once from file context (metadata, currency column, or bank country) and apply the same code to all rows. Explicitly forbids extracting    
  currency by substring from column header names (prevents "Waluta" → "WAL")                                                                                                                             
  - Adds post-AI CSV sanitizer in AiResponseProcessor that removes header rows mistakenly included as data and fixes invalid currency codes by detecting the dominant valid currency
  - Adds ISO 4217 validation in LocalCsvTransformer.extractCurrency() — rejects non-ISO codes (like "WAL") and falls back to country-based default                                                       
    